### PR TITLE
Add CODEOWNERS file to master branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+// To make changes to who gets added as a reviewer, refer to the documentation: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+// This will add everyone on this list as a reviewer for every PR that is submitted against master branch
+// To be even more specific, refer to the documentation above
+
+* ziyiz@amazon.com  michhhyun@amazon.com landave@amazon.com pfoucht@amazon.com bradman@amazon.com xixia@amazon.com nikk@amazon.com devalevd@amazon.com hanaharr@amazon.com
+ 
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This will make it so that after a PR is published with the master branch as the base branch, all members in this CODEOWNERS file will be automatically added as a reviewer and notified.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
