### PR TITLE
Refactor AudioControlInput and apply SDK components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add sound disabled to `AudioOutputControl`
 - Add `LocalAudioOutputProvider` to `MeetingView`
 - Add `ContentShareControlProvider` for content share control methods
+- Add `device-utils` needed in audio, video providers in library connected components
+- Add audio, video device types to types in library
+- Add `useToggleLocalMute` to demo
 
 ### Changed
 - Added delay for more consistent animation snapshotting with playwright.
@@ -24,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed relative imports and `MeetingView` to accomodate imports of connected components from library
 - Updated the `ContentShareControl` with SDK components
 - Changed `ScreenShare` to `ContentShare` in library and demo
+- Update `AudioInputControl` to use hooks and SDK components
 
 ### Removed
 - Removed active state button tests.

--- a/demo/meeting/src/containers/DeviceSelection/MicSelection/index.tsx
+++ b/demo/meeting/src/containers/DeviceSelection/MicSelection/index.tsx
@@ -9,7 +9,7 @@ import { title } from '../Styled';
 
 const MicSelection = () => {
   const meetingManager = useMeetingManager();
-  const audioInputs = useAudioInputs();
+  const { devices } = useAudioInputs();
 
   async function selectAudioInput(deviceId: string) {
     meetingManager.selectAudioInputDevice(deviceId);
@@ -23,7 +23,7 @@ const MicSelection = () => {
       <DeviceInput
         label="Microphone source"
         onChange={selectAudioInput}
-        devices={audioInputs}
+        devices={devices}
       />
       <AudioActivityPreview />
     </div>

--- a/demo/meeting/src/hooks/useToggleLocalMute.tsx
+++ b/demo/meeting/src/hooks/useToggleLocalMute.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState, useCallback } from 'react';
+
+import { useAudioVideo } from '../../../../src';
+
+export default function useToggleLocalMute() {
+  const audioVideo = useAudioVideo();
+  const [muted, setMuted] = useState<boolean>(
+    () => audioVideo?.realtimeIsLocalAudioMuted() || false
+  );
+
+  useEffect(() => {
+    const muteUnmutecallback = (localMuted: boolean): void => {
+      setMuted(localMuted);
+    };
+
+    audioVideo?.realtimeSubscribeToMuteAndUnmuteLocalAudio(muteUnmutecallback);
+
+    return (): void => {
+      audioVideo?.realtimeUnsubscribeToMuteAndUnmuteLocalAudio(muteUnmutecallback);
+    };
+  }, [audioVideo]);
+
+  const toggleMute = useCallback(() => {
+    if (muted) {
+      audioVideo?.realtimeUnmuteLocalAudio();
+    } else {
+      audioVideo?.realtimeMuteLocalAudio();
+    }
+  }, [muted]);
+
+  return { muted, toggleMute };
+}

--- a/demo/meeting/src/utils/DeviceUtils.ts
+++ b/demo/meeting/src/utils/DeviceUtils.ts
@@ -95,6 +95,16 @@ export const videoInputSelectionToDevice = (deviceId: string): Device => {
   return deviceId;
 };
 
+export const audioInputSelectionToDevice = (deviceId: string): Device => {
+  if (deviceId === '440') {
+    return DefaultDeviceController.synthesizeAudioDevice(440);
+  }
+  if (deviceId === 'none') {
+    return null;
+  }
+  return deviceId;
+};
+
 export const isOptionActive = (
   meetingManagerDeviceId: string | null,
   currentDeviceId: string

--- a/src/constants/additional-audio-video-devices.ts
+++ b/src/constants/additional-audio-video-devices.ts
@@ -1,0 +1,10 @@
+export const VIDEO_INPUT = {
+  NONE: 'None',
+  BLUE: 'Blue',
+  SMPTE: 'SMPTE Color Bars',
+};
+
+export const AUDIO_INPUT = {
+  NONE: 'None',
+  440: '440 Hz',
+};

--- a/src/providers/DevicesProvider/VideoInputProvider.tsx
+++ b/src/providers/DevicesProvider/VideoInputProvider.tsx
@@ -9,45 +9,15 @@ import { DeviceChangeObserver } from 'amazon-chime-sdk-js';
 
 import { useAudioVideo } from '../AudioVideoProvider';
 import { useMeetingManager } from '../MeetingProvider';
-
-export const getFormattedDropdownDeviceOptions = (
-  jsonObject: any
-): FormattedDeviceType[] => {
-  const formattedJSONObject = Object.entries(jsonObject).map(entry => ({
-    deviceId: entry[0].toLowerCase(),
-    label: entry[1] as string
-  }));
-  return formattedJSONObject;
-};
-
-export const VIDEO_INPUT = {
-  NONE: 'None',
-  BLUE: 'Blue',
-  SMPTE: 'SMPTE Color Bars'
-};
-
-export type FormattedDeviceType = {
-  deviceId: string;
-  label: string;
-};
-
-export type DeviceType = MediaDeviceInfo | FormattedDeviceType;
-
-export type SelectedDeviceType = string | null;
-
-export type DeviceTypeContext = {
-  devices: DeviceType[];
-  selectedDevice: SelectedDeviceType;
-};
+import { DeviceTypeContext, DeviceConfig } from '../../types';
+import { VIDEO_INPUT } from '../../constants/additional-audio-video-devices';
+import { getFormattedDropdownDeviceOptions } from '../../utils/device-utils';
 
 export type LocalVideoToggleContextType = {
   isVideoEnabled: boolean;
   toggleVideo: () => Promise<void>;
 };
 
-export type DeviceConfig = {
-  additionalDevices?: boolean;
-};
 
 const Context = createContext<DeviceTypeContext | null>(null);
 
@@ -126,11 +96,11 @@ const useVideoInputs = (props?: DeviceConfig): DeviceTypeContext => {
   const { selectedDevice } = context;
 
   if (needAdditionalIO) {
-    const additionalAudioInputs = getFormattedDropdownDeviceOptions(
+    const additionalVideoInputs = getFormattedDropdownDeviceOptions(
       additionalIOJSON
     );
-    if (additionalAudioInputs !== null) {
-      devices = [...devices, ...additionalAudioInputs];
+    if (additionalVideoInputs !== null) {
+      devices = [...devices, ...additionalVideoInputs];
     }
   }
   return { devices, selectedDevice };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,3 +13,7 @@ export type DeviceTypeContext = {
   devices: DeviceType[];
   selectedDevice: SelectedDeviceType;
 };
+
+export type DeviceConfig = {
+  additionalDevices?: boolean;
+};

--- a/src/utils/device-utils.ts
+++ b/src/utils/device-utils.ts
@@ -1,0 +1,33 @@
+import { FormattedDeviceType } from "../types";
+import { Device, DefaultDeviceController } from "amazon-chime-sdk-js";
+
+export const getFormattedDropdownDeviceOptions = (jsonObject: any): FormattedDeviceType[] => {
+  const formattedJSONObject = Object.entries(jsonObject).map(entry => ({
+    deviceId: entry[0].toLowerCase(),
+    label: entry[1] as string,
+  }));
+  return formattedJSONObject;
+};
+
+export const videoInputSelectionToDevice = (deviceId: string): Device => {
+  if (deviceId === 'blue') {
+    return DefaultDeviceController.synthesizeVideoDevice('blue');
+  }
+  if (deviceId === 'smpte') {
+    return DefaultDeviceController.synthesizeVideoDevice('smpte');
+  }
+  if (deviceId === 'none') {
+    return null;
+  }
+  return deviceId;
+};
+
+export const audioInputSelectionToDevice = (deviceId: string): Device => {
+  if (deviceId === '440') {
+    return DefaultDeviceController.synthesizeAudioDevice(440);
+  }
+  if (deviceId === 'none') {
+    return null;
+  }
+  return deviceId;
+};


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added:
* `useToggleLocalMute` -> For local mute/unmute handling 
* Add `device-utils` needed in audio, video providers in library connected components
* Add audio, video device types to types in library

Changed:
* `AudioInputControl` -> Now it handles only the creation of pop over items required for microphone options rest needs like mute/unmute, handling of current audio input device is delegated to re-usable hooks/provider mentioned above.
* `AudioInputProvider` -> GIves current audio input device stored with the `MeetingManager` and audio input devices 

I have placed TODO where we still have dependency elsewhere and need to fix it, but eventually will be replaced.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
