### PR TITLE
Refactor AudioOutputControl and apply SDK components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Play, Pause and Sound disabled SVG icons
 - Add initial roster components
 - Add connected components to lib directory
+- Add types required in `AudioOutputProvider`
+- Add sound disabled to `AudioOutputControl`
+- Add `LocalAudioOutputProvider` to `MeetingView`
 
 ### Changed
 - Added delay for more consistent animation snapshotting with playwright.
 - `npm run test` script changed to only include /components and /utils
-Update prebuild script to trigger git actions on git push event
+- Update prebuild script to trigger git actions on git push event
+- Changed relative imports and `MeetingView` to accomodate imports of connected components from library
 
 ### Removed
 - Removed active state button tests.

--- a/demo/meeting/src/containers/DeviceSelection/SpeakerSelection/index.tsx
+++ b/demo/meeting/src/containers/DeviceSelection/SpeakerSelection/index.tsx
@@ -7,16 +7,16 @@ import DeviceInput from '../DeviceInput';
 
 const SpeakerSelection = () => {
   const meetingManager = useMeetingManager();
-  const audioOutputs = useAudioOutputs();
+  const { devices } = useAudioOutputs();
   const [selectedOutput, setSelectedOutput] = useState('');
 
   useEffect(() => {
-    if (!audioOutputs.length || selectedOutput) {
+    if (!devices.length || selectedOutput) {
       return;
     }
 
-    setSelectedOutput(audioOutputs[0].deviceId);
-  }, [selectedOutput, audioOutputs]);
+    setSelectedOutput(devices[0].deviceId);
+  }, [selectedOutput, devices]);
 
   const handleTestSpeaker = () => {
     new TestSound(selectedOutput);
@@ -24,14 +24,14 @@ const SpeakerSelection = () => {
 
   async function selectAudioOutput(deviceId: string) {
     setSelectedOutput(deviceId);
-    meetingManager.selectAudioInputDevice(deviceId);
+    meetingManager.selectAudioOutputDevice(deviceId);
   }
 
   return (
     <div>
       <DeviceInput
         label="Speaker source"
-        devices={audioOutputs}
+        devices={devices}
         onChange={selectAudioOutput}
       />
       <SecondaryButton label="Test speakers" onClick={handleTestSpeaker} />

--- a/demo/meeting/src/containers/MeetingView.tsx
+++ b/demo/meeting/src/containers/MeetingView.tsx
@@ -7,17 +7,20 @@ import ContentShare from './ContentShare';
 import MeetingControlsContainer from './MeetingControlsContainer';
 import MeetingRoster from './MeetingRoster';
 import RemoteVideoGrid from './RemoteVideoGrid';
+import { LocalAudioOutputProvider } from '../providers/LocalAudioOutputProvider';
 
 const MeetingView = () => (
   <MeetingStatusProvider>
-    <LocalVideoToggleProvider>
-      <ContentShareProvider>
-        <MeetingControlsContainer />
-        <ContentShare />
-        <MeetingRoster />
-        <RemoteVideoGrid />
-      </ContentShareProvider>
-    </LocalVideoToggleProvider>
+    <LocalAudioOutputProvider>
+      <LocalVideoToggleProvider>
+        <ContentShareProvider>
+          <MeetingControlsContainer />
+          <ContentShare />
+          <MeetingRoster />
+          <RemoteVideoGrid />
+        </ContentShareProvider>
+      </LocalVideoToggleProvider>
+    </LocalAudioOutputProvider>
   </MeetingStatusProvider>
 );
 

--- a/demo/meeting/src/providers/LocalAudioOutputProvider.tsx
+++ b/demo/meeting/src/providers/LocalAudioOutputProvider.tsx
@@ -1,0 +1,68 @@
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  createContext,
+  useMemo,
+  useCallback,
+  useContext,
+} from 'react';
+import { LocalAudioOutputContextType } from '../types';
+import { useAudioVideo } from '../../../../src';
+
+const Context = createContext<LocalAudioOutputContextType | null>(null);
+
+const LocalAudioOutputProvider: React.FC = ({ children }) => {
+  const audioVideo = useAudioVideo();
+  const [isAudioOn, setIsAudioOn] = useState(true);
+  const audioRef = useRef<HTMLAudioElement>(null);
+
+  useEffect(() => {
+    if (!audioVideo) {
+      return;
+    }
+
+    if (audioRef.current) {
+      audioVideo?.bindAudioElement(audioRef.current);
+    }
+    return (): void => {
+      audioVideo?.unbindAudioElement();
+    };
+  }, [audioVideo]);
+
+  const toggleAudio = useCallback((): void => {
+    if (!audioRef.current) {
+      return;
+    }
+    setIsAudioOn(!isAudioOn);
+    if (isAudioOn) {
+      audioVideo?.unbindAudioElement();
+    } else {
+      audioVideo?.bindAudioElement(audioRef.current);
+    }
+  }, [audioRef, audioVideo, isAudioOn]);
+
+  const value = useMemo(() => ({ isAudioOn, toggleAudio }), [
+    isAudioOn,
+    toggleAudio,
+  ]);
+
+  return (
+    <Context.Provider value={value}>
+      {children}
+      <audio ref={audioRef} style={{ display: 'none' }} />
+    </Context.Provider>
+  );
+};
+
+const useLocalAudioOutput = (): LocalAudioOutputContextType => {
+  const context = useContext(Context);
+  if (!context) {
+    throw new Error(
+      'useLocalAudioOutput must be used within LocalAudioOutputProvider'
+    );
+  }
+  return context;
+};
+
+export { LocalAudioOutputProvider, useLocalAudioOutput };

--- a/demo/meeting/src/providers/LocalVideoToggleProvider.tsx
+++ b/demo/meeting/src/providers/LocalVideoToggleProvider.tsx
@@ -4,7 +4,7 @@ import React, {
   useEffect,
   useContext,
   useCallback,
-  useMemo
+  useMemo,
 } from 'react';
 import { useMeetingManager, useAudioVideo } from '../../../../src';
 

--- a/demo/meeting/src/types/index.ts
+++ b/demo/meeting/src/types/index.ts
@@ -29,3 +29,8 @@ export type LocalVideoToggleContextType = {
 export type DeviceConfig = {
   additionalDevices?: boolean;
 };
+
+export type LocalAudioOutputContextType = {
+  isAudioOn: boolean;
+  toggleAudio: () => void;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,15 @@
 export type Direction = 'up' | 'right' | 'down' | 'left';
+
+export type FormattedDeviceType = {
+  deviceId: string;
+  label: string;
+};
+
+export type DeviceType = MediaDeviceInfo | FormattedDeviceType;
+
+export type SelectedDeviceType = string | null;
+
+export type DeviceTypeContext = {
+  devices: DeviceType[];
+  selectedDevice: SelectedDeviceType;
+};


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
* Added `LocalAudioOutputProvider` for local audio management like toggling binding/unbinding the audio element with the HTML audio tag.
* Added `useLocalAudioOutput` to provide context from above provider.
* Changed and updated the `AudioOutputControl` to control the audio output options selections and selection is delegated to above provider.
* Updated `MeetingProvider` and `AudioOutputProvider` to observe `selectedAudioOutputDevice`

Have added TODO wherever changes are needed.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Failed, but it should succeed once the prebuild script is fixed, rest all tests and snapshots passed.

2. How did you test these changes?
Tested in chrome and firefox, compared to browser demo from JS SDK. Found one bug where the audio output options are not shown in firefox, the same behavior is present in the browser demo from JS SDk. Will check with JS SDK team later.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
