### PR TITLE
Update prebuild script to trigger checks on git push event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-Fixed prebuild.
 
 ### Added
 Add Play, Pause and Sound disabled SVG icons
 
 ### Changed
+Update prebuild script to trigger git actions on git push event
 
 ### Removed
 
 ### Fixed
+Fixed prebuild.
 
 ## [0.1.1] - 2020-06-16

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -40,11 +40,13 @@ const gitActionsProps = {
   eventName: process.env.GITHUB_EVENT_NAME // pull_request or push
 };
 
+const GithubEvents = ['pull_request', 'push'];
+
 const base = fs
   .readFileSync(path.join(process.cwd(), '.base-branch'), 'utf8')
   .trim();
 // We need to setup first within GitActions env.
-if (gitActionsProps.eventName === 'pull_request') {
+if (GithubEvents.includes(gitActionsProps.eventName)) {
   spawnOrFail('git', ['fetch']);
   spawnOrFail('git', ['checkout', `origin/${gitActionsProps.refBranch}`]);
 }


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Update prebuild script to trigger checks on git push event, currently they are triggered on pull_request.

**Testing**

1. Have you successfully run `npm run build:release` locally? 
    Yes
2. How did you test these changes?
    `npm run build:release` succeeds
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
