### PR TITLE
Fix prebuild script for push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,6 @@ Update prebuild script to trigger git actions on git push event
 ### Removed
 
 ### Fixed
-Fixed prebuild.
+Fixed prebuild for PR and Push.
 
 ## [0.1.1] - 2020-06-16

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -47,8 +47,13 @@ const base = fs
   .trim();
 // We need to setup first within GitActions env.
 if (GithubEvents.includes(gitActionsProps.eventName)) {
+  const branchName =
+    gitActionsProps.eventName === 'push'
+      ? base
+      : `origin/${gitActionsProps.refBranch}`;
+
   spawnOrFail('git', ['fetch']);
-  spawnOrFail('git', ['checkout', `origin/${gitActionsProps.refBranch}`]);
+  spawnOrFail('git', ['checkout', branchName]);
 }
 const commits = spawnOrFail('git', ['rev-list', `${base}..`])
   .toString()


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Attempt to fix prebuild script during push/merge to master.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? PR passes now after push we can test push GitActions to see if change is working.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
