### PR TITLE
Fix stale roster attendees and react state update errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed active state button tests.
 
 ### Fixed
-Fixed prebuild for PR and Push.
+- Fixed prebuild for PR and Push.
+- Fix react state update errors for `MeetingStatusProvider`, `MeetingRoster` and `MeetingJoinDetails`
+- Fix roster showing stale attendees
 
 ## [0.1.1] - 2020-06-16

--- a/demo/meeting/src/containers/MeetingJoinDetails.tsx
+++ b/demo/meeting/src/containers/MeetingJoinDetails.tsx
@@ -30,12 +30,12 @@ const MeetingJoinDetails = () => {
 
     try {
       await meetingManager.join();
+      setIsLoading(false);
       history.push(`${routes.MEETING}/${meetingId}`);
     } catch (error) {
+      setIsLoading(false);
       setError(error.message);
     }
-
-    setIsLoading(false);
   };
 
   return (

--- a/demo/meeting/src/providers/MeetingStatusProvider.tsx
+++ b/demo/meeting/src/providers/MeetingStatusProvider.tsx
@@ -75,13 +75,11 @@ export default function MeetingStatusProvider(props: Props) {
           - When closing a browser window or page, Chime SDK attempts to leave the session.
         */
         console.log('You left the session');
-        setMeetingStatus(MeetingStatus.Ended);
       } else if (
         sessionStatusCode === MeetingSessionStatusCode.AudioCallEnded
       ) {
         console.log('The session has ended');
         history.push(`${routes.HOME}`);
-        setMeetingStatus(MeetingStatus.Ended);
       } else {
         console.log(
           'Observer audioVideoDidStop, Stopped with a session status code: ',

--- a/src/providers/RosterProvider/index.tsx
+++ b/src/providers/RosterProvider/index.tsx
@@ -69,8 +69,11 @@ const RosterProvider: React.FC = ({ children }) => {
 
     audioVideo.realtimeSubscribeToAttendeeIdPresence(rosterUpdateCallback);
 
-    return () =>
+    return () => {
+      setRoster({});
       audioVideo.realtimeUnsubscribeToAttendeeIdPresence(rosterUpdateCallback);
+    };
+
   }, [audioVideo]);
 
   return (


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
- Fix react state update errors for `MeetingStatusProvider`, `MeetingRoster` and `MeetingJoinDetails`
- Fix roster showing stale attendees

**Testing**

1. Have you successfully run `npm run build:release` locally? 
It failed for code style checks but for the `dist` and `node_modules` folders in demo meeting app. Rest should work fine.

2. How did you test these changes?
In FF and Chrome dev tools

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
