### PR TITLE
Add Test coverage threshold %

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update demo app README
 - Update `Modal` to SDK Modal component and minor change to `Card` component in the demo
 - Updating demo with basic video grid
+- Add enforcement of passing test coverage thresholds.
 
 ### Removed
 - Removed active state button tests.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,20 +1,28 @@
 module.exports = {
-    testRegex: './*\\.test\\.tsx$',
-    setupFilesAfterEnv: ['./tst/setupTests.js'],
-    moduleFileExtensions: ["ts", "tsx", "js", "json", "jsx", "node",],
-    transform: {
-        "\\.tsx?$": "ts-jest",
-        "^.+\\.mdx$": "@storybook/addon-docs/jest-transform-mdx",
-    },
-    globals: {
-        "ts-jest": {
-        "tsConfig": 'tsconfig.json'
-        }
-    },
-    testPathIgnorePatterns: ['node_modules', '/tst/snapshots/'],
-    testEnvironment: 'jsdom',
-    collectCoverage: true,
-    collectCoverageFrom: ["src/**/*.tsx", "!src/**/*.stories.tsx"],
-    coverageReporters: ["text-summary", "lcov", "json", "clover"],
-    coverageDirectory: 'coverage',
+  testRegex: './*\\.test\\.tsx$',
+  setupFilesAfterEnv: ['./tst/setupTests.js'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json', 'jsx', 'node'],
+  transform: {
+    '\\.tsx?$': 'ts-jest',
+    '^.+\\.mdx$': '@storybook/addon-docs/jest-transform-mdx'
+  },
+  globals: {
+    'ts-jest': {
+      tsConfig: 'tsconfig.json'
+    }
+  },
+  testPathIgnorePatterns: ['node_modules', '/tst/snapshots/'],
+  testEnvironment: 'jsdom',
+  collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.tsx', '!src/**/*.stories.tsx'],
+  coverageReporters: ['text-summary', 'lcov', 'json', 'clover'],
+  coverageDirectory: 'coverage',
+  coverageThreshold: {
+    global: {
+      branches: 64,
+      functions: 72,
+      lines: 72,
+      statements: 71
+    }
+  }
 };


### PR DESCRIPTION

**Description of changes:**
Enforce test passing coverage based on current passing (rounded) percentages.
``` 
=============================== Coverage summary ===============================
Statements   : 71.63% ( 1184/1653 )
Branches     : 64.62% ( 411/636 )
Functions    : 72.59% ( 339/467 )
Lines        : 72.79% ( 1006/1382 )
================================================================================
Test Suites: 39 passed, 39 total
Tests:       153 passed, 153 total
Snapshots:   0 total
Time:        25.954s
Ran all test suites matching /.\/tst\/(components|utils)\/*/i.
```
**Testing**
npm run test

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
