### PR TITLE
Create automated publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Test, Publish, & Release
+# When a new Github Release is created via our npm script, publish to NPM
+on:
+  release:
+    types: [published]
+
+jobs:  
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Package
+        uses: actions/checkout@master
+      - name: Setup Node environment
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - name: Publish to NPM
+      # TODO: Remove the dryrun option when we actually release
+        run: npm publish --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add publish script.
 - ActiveSpeaker, ActiveTile providers and hooks
 - Add docs for PopOver component
+- Add github action workflow that automates publishing to npm
 
 ### Changed
 


### PR DESCRIPTION
**Issue #:** 
n/a

**Description of changes:**
This workflow should handle the publishing of our package to NPM. 
All of the pre-publishing workflows should be handled by Nik's PR. 



**Testing**

1. Have you successfully run `npm run build:release` locally?
- No code change
2. How did you test these changes?
- tested on a test public repository

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
