### PR TITLE
use Apache licence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add enforcement of passing test coverage thresholds.
 - Update codestyle script to ignore non-source files within `demo/meeting` app.
 - Moved components into /ui directory
+- Change license from ISC to Apache-2.0
 
 ### Removed
 - Removed active state button tests.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "dependencies": {
     "@popperjs/core": "^2.2.2",
     "@types/jest-image-snapshot": "^3.1.0",


### PR DESCRIPTION
**Issue #:** 
https://issues.amazon.com/issues/Chevice-471

**Description of changes:**
We currently use "ISC" license, as can be seen in package.json. This should be "Apache-2.0"

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
n/a
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
