### PR TITLE
Add travis config for building and testing CI workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `Modal`, `ModalButtonGroup` to library `src/index`
 - Add code style checking script
 - Add postbuild script
-- RemoteVideos, RemoteVideo components
+- RemoteVideos, RemoteVideo 
+- Added travis CI workflow to build and test on pull requests
 
 ### Changed
 - Added delay for more consistent animation snapshotting with playwright.

--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,16 @@
+language: node_js
+node_js:
+- 12
+git:
+  depth: false
+jobs:
+  include:
+    #Build and unit tests
+    - stage: Build, unit test, and snapshot test
+      if: (type = pull_request) OR (type = push AND branch != master)
+      name: "Build and run Unit Tests"
+      script: npm run build:release
+      name: "Run Snaptshot testing"
+      script: npm run test:snapshots
+      addons: skip
+    


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
This is the basic CI workflow that is identical to our current CO workflow with GHA. I submitted a TT to get approval to use Travis for our Repo, but the approval will be done on Monday, so until then, this script will do nothing. I won't merge this in until the travis integration with our repo is done. 

**Testing**

1. Have you successfully run `npm run build:release` locally?
- yes
2. How did you test these changes?
- n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
