### PR TITLE
remove 'styled-reset' module

### DIFF
--- a/.storybook/config.tsx
+++ b/.storybook/config.tsx
@@ -7,7 +7,7 @@ import { withThemesProvider } from 'themeprovider-storybook';
 
 import lightTheme from '../src/theme/light';
 import darkTheme from '../src/theme/dark';
-import { GlobalStyles } from '../src/theme/globalStyles';
+import { GlobalStyles } from '../src/theme/GlobalStyles';
 
 const themes = [lightTheme, darkTheme];
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add code style checking script
 - Add postbuild script
 - RemoteVideos, RemoteVideo components
+- CSS reset, public domain version
 
 ### Changed
 - Added delay for more consistent animation snapshotting with playwright.
@@ -48,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Removed active state button tests.
+- 'styled-reset' package due to license incompatibility
 
 ### Fixed
 - Fixed prebuild for PR and Push.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24812,12 +24812,6 @@
       "integrity": "sha512-uoyPlwdM8FLmdOE8dvA3iv2IOnlqMsygPxLAZy8WaK0pEcon67+SWJY/osAWZuBvRKtSo/VXn1fRCYVgbD0KUQ==",
       "dev": true
     },
-    "styled-reset": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.1.6.tgz",
-      "integrity": "sha512-ttktpWqPNk9MYRPgRTEwx1WLN3ALlXzAGyC1u6xbKOeNGDsN6AJ0z1O3BFYz7epkiMKlF50whlM/IT/IY+attQ==",
-      "dev": true
-    },
     "styled-system": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-5.1.5.tgz",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "storybook": "^1.0.0",
     "style-loader": "^0.23.1",
     "styled-components": "^5.1.0",
-    "styled-reset": "^4.1.6",
     "styled-system": "^5.1.5",
     "themeprovider-storybook": "^1.5.1",
     "ts-jest": "^25.4.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ export { NotificationProvider } from './providers/NotificationProvider';
 export { MeetingProvider } from './providers/MeetingProvider';
 
 // Themes
-export { lightTheme, darkTheme } from './theme';
+export { lightTheme, darkTheme, GlobalStyles, StyledReset } from './theme';
 
 // Types
 export { VideoQuality } from './hooks/sdk/useSelectVideoQuality';

--- a/src/theme/GlobalStyles.ts
+++ b/src/theme/GlobalStyles.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createGlobalStyle } from 'styled-components';
-import reset from 'styled-reset';
+import { StyledReset } from './StyledReset';
 
 export const GlobalStyles = createGlobalStyle`
-  ${reset};
+  ${StyledReset};
 
   *,
   *::before,
@@ -14,8 +14,8 @@ export const GlobalStyles = createGlobalStyle`
   }
 
   html {
-    font-size: 16px;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-size: ${props => props.theme.fontSizes.baseFontSize};
+    font-family: ${props => props.theme.fonts.body};;
     background-color: ${props => props.theme.global.bgd};
     color: ${props => props.theme.global.text};
     min-height: 100%;

--- a/src/theme/StyledReset.ts
+++ b/src/theme/StyledReset.ts
@@ -1,0 +1,56 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { css } from 'styled-components';
+
+export const StyledReset = css`
+  /* http://meyerweb.com/eric/tools/css/reset/
+    v2.0 | 20110126
+    License: none (public domain)
+  */
+
+  html, body, div, span, applet, object, iframe,
+  h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+  a, abbr, acronym, address, big, cite, code,
+  del, dfn, em, img, ins, kbd, q, s, samp,
+  small, strike, strong, sub, sup, tt, var,
+  b, u, i, center,
+  dl, dt, dd, ol, ul, li,
+  fieldset, form, label, legend,
+  table, caption, tbody, tfoot, thead, tr, th, td,
+  article, aside, canvas, details, embed,
+  figure, figcaption, footer, header, hgroup,
+  menu, nav, output, ruby, section, summary,
+  time, mark, audio, video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+  }
+  /* HTML5 display-role reset for older browsers */
+  article, aside, details, figcaption, figure,
+  footer, header, hgroup, menu, nav, section {
+    display: block;
+  }
+  body {
+    line-height: 1;
+  }
+  ol, ul {
+    list-style: none;
+  }
+  blockquote, q {
+    quotes: none;
+  }
+  blockquote:before, blockquote:after,
+  q:before, q:after {
+    content: '';
+    content: none;
+  }
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
+
+`;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -3,3 +3,6 @@
 
 export { lightTheme } from './light';
 export { darkTheme } from './dark';
+
+export { StyledReset } from './StyledReset';
+export { GlobalStyles } from './GlobalStyles';


### PR DESCRIPTION
**Issue #:** 
Chevice-472

**Description of changes:**
A review revealed that the 'styled-reset' module had a license that was incompatible with our organization. Upon review, it appeared that the package was leveraging the public domain `CSS Reset` by Eric Meyer (https://meyerweb.com/eric/tools/css/reset/). I wrapped that code into a CSS module that we can use in our `GlobalStyles`.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Ran snapshot testing and performed visual checks in storybook in case these base styles adversely affected any components.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
