### PR TITLE
Fix AudioActivityPreview to show mic progress track on audio input dev…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,5 +54,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed prebuild for PR and Push.
 - Fix react state update errors for `MeetingStatusProvider`, `MeetingRoster` and `MeetingJoinDetails`
 - Fix roster showing stale attendees
+- `AudioActivityPreview` to show mic progress track on audio input device change
 
 ## [0.1.1] - 2020-06-16

--- a/src/components/sdk/DeviceSelection/MicSelection/AudioActivityPreview.tsx
+++ b/src/components/sdk/DeviceSelection/MicSelection/AudioActivityPreview.tsx
@@ -8,10 +8,12 @@ import { useAudioVideo } from '../../../../providers/AudioVideoProvider';
 import ActivityBar from '../../../ui/ActivityBar';
 
 import { StyledPreviewGroup } from '../Styled';
+import { useAudioInputs } from '../../../../providers/DevicesProvider';
 
 const AudioActivityPreview = () => {
   const audioVideo = useAudioVideo();
   const activityBarRef = useRef<HTMLDivElement>();
+  const { selectedDevice } = useAudioInputs();
 
   useEffect(() => {
     const analyserNode = audioVideo?.createAnalyserNodeForAudioInput();
@@ -54,7 +56,7 @@ const AudioActivityPreview = () => {
     return () => {
       isMounted = false;
     };
-  }, []);
+  }, [selectedDevice]);
 
   return (
     <StyledPreviewGroup>

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -294,7 +294,7 @@ class MeetingManager implements DeviceChangeObserver {
         await this.audioVideo?.chooseAudioInputDevice(null);
         this.selectedAudioInputDevice = null;
       } else {
-        await this.audioVideo?.chooseAudioInputDevice(deviceId);
+        await this.audioVideo?.chooseAudioInputDevice(receivedDevice);
         this.selectedAudioInputDevice = deviceId;
       }
       this.publishSelectedAudioInputDeviceChange();


### PR DESCRIPTION
…ice change

**Issue #:** 

**Description of changes:**
- `AudioActivityPreview` was not showing track progress when the audio input device got changed in the `MicSelection` on `DeviceSelection` screen. This fixes it.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Locally in FF and Chrome

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
