### PR TITLE
Fix imports in SIP Meeting and useDevicePermissionStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change license from ISC to Apache-2.0
 - Move provider, hooks and connected components from demo to library
 - Add clear button to input component
+- SIP Meeting implementation and related imports
+- Update import in `useDevicePermissionStatus` hook
 
 ### Removed
 

--- a/demo/meeting/src/containers/SIPMeeting/index.tsx
+++ b/demo/meeting/src/containers/SIPMeeting/index.tsx
@@ -13,8 +13,7 @@ import SIPURI from '../SIPURI';
 import SIPMeetingForm from '../../components/SIPMeetingForm';
 import { getErrorContext } from '../../providers/ErrorProvider';
 import {
-  SIPMeetingContext,
-  SIPMeetingManager,
+  useSIPMeetingManager
 } from '../../providers/SIPMeetingProvider';
 
 const SIPMeeting: React.FC = () => {
@@ -22,9 +21,7 @@ const SIPMeeting: React.FC = () => {
   const [meetingId, setMeetingId] = useState('');
   const [voiceConnectorId, setVoiceConnectorId] = useState('');
   const { errorMessage, updateErrorMessage } = useContext(getErrorContext());
-  const sipMeetingManager: SIPMeetingManager | null = useContext(
-    SIPMeetingContext
-  );
+  const sipMeetingManager = useSIPMeetingManager();
 
   const handleSIPMeetingFormSubmit = async (e: FormEvent): Promise<void> => {
     e.preventDefault();

--- a/demo/meeting/src/hooks/useDevicePermissionStatus.tsx
+++ b/demo/meeting/src/hooks/useDevicePermissionStatus.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, useState } from 'react';
-import { useMeetingManager } from '../../../../src';
+import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
 
 import { DevicePermissionStatus } from '../enums';
 
@@ -19,7 +19,7 @@ export default function useDevicePermissionStatus() {
     return () => {
       meetingManager.unSubscribeFromDevicePermissionUpdate(callback);
     };
-  }, []);
+  }, [meetingManager]);
 
   return permission;
 }

--- a/demo/meeting/src/providers/SIPMeetingProvider/SIPMeetingManager.ts
+++ b/demo/meeting/src/providers/SIPMeetingProvider/SIPMeetingManager.ts
@@ -1,11 +1,9 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { ReactNode } from 'react';
-import { useMeetingManager } from '../../../../src';
-import MeetingManager from '../../../../src/providers/MeetingProvider/MeetingManager';
+import { MeetingManager } from 'amazon-chime-sdk-component-library-react';
 
-import { AMAZON_CHIME_VOICE_CONNECTOR_PHONE_NUMDER } from '../constants';
+import { AMAZON_CHIME_VOICE_CONNECTOR_PHONE_NUMDER } from '../../constants';
 
 export class SIPMeetingManager {
   private meetingManager: MeetingManager | null;
@@ -33,23 +31,4 @@ export class SIPMeetingManager {
       throw new Error(error);
     }
   };
-}
-
-export const SIPMeetingContext = React.createContext<SIPMeetingManager | null>(
-  null
-);
-
-type Props = {
-  children: ReactNode;
-};
-
-export default function SIPMeetingProvider({ children }: Props) {
-  const meetingManager = useMeetingManager();
-  const sipMeeting = new SIPMeetingManager(meetingManager);
-
-  return (
-    <SIPMeetingContext.Provider value={sipMeeting}>
-      {children}
-    </SIPMeetingContext.Provider>
-  );
 }

--- a/demo/meeting/src/providers/SIPMeetingProvider/index.tsx
+++ b/demo/meeting/src/providers/SIPMeetingProvider/index.tsx
@@ -1,0 +1,36 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactNode, useContext } from 'react';
+import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+
+import { SIPMeetingManager } from './SIPMeetingManager';
+
+const SIPMeetingContext = React.createContext<SIPMeetingManager | null>(
+  null
+);
+
+type Props = {
+  children: ReactNode;
+};
+
+export default function SIPMeetingProvider({ children }: Props) {
+  const meetingManager = useMeetingManager();
+  const sipMeeting = new SIPMeetingManager(meetingManager);
+
+  return (
+    <SIPMeetingContext.Provider value={sipMeeting}>
+      {children}
+    </SIPMeetingContext.Provider>
+  );
+}
+
+export const useSIPMeetingManager = (): SIPMeetingManager => {
+  const sipMeetingManager = useContext(SIPMeetingContext);
+
+  if (!sipMeetingManager) {
+    throw new Error('useSIPMeetingManager must be used within SIPMeetingProvider');
+  }
+
+  return sipMeetingManager;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-component-library-react",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-component-library-react",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Amazon Chime SDK Component Library - React",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,3 +116,6 @@ export { VideoQuality } from './hooks/sdk/useSelectVideoQuality';
 
 // enums
 export { MeetingStatus } from './providers/MeetingStatusProvider';
+
+// Class
+export { MeetingManager } from './providers/MeetingProvider/MeetingManager';

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -39,7 +39,7 @@ type FullDeviceInfoType = {
   videoInputDevices: MediaDeviceInfo[] | null;
 };
 
-class MeetingManager implements DeviceChangeObserver {
+export class MeetingManager implements DeviceChangeObserver {
   private static readonly LOGGER_BATCH_SIZE: number = 85;
 
   private static readonly LOGGER_INTERVAL_MS: number = 1150;

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -13,6 +13,6 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '0.1.2';
+    return '0.1.3';
   }
 }


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
- Changed SIP Meeting implementation and related imports
- Update import in `useDevicePermissionStatus` hook

**Testing**

1. Have you successfully run `npm run build:release` locally? 
Yes
2. How did you test these changes?
Locally FF and Chrome
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
