### PR TITLE
Update CHANGELOG verification

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -38,3 +38,5 @@ jobs:
     - run: npm ci
     - run: npm run build:release --if-present
     - run: npm run test:snapshots
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed disabled microphone icon prop to muted
 - Changed modal size properties to theme object
 - Update grid to support active speaker
+- Updated prebuild script to ignore CHANGELOG verification for BOT submitted PR's
 
 ### Removed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-component-library-react",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-component-library-react",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Amazon Chime SDK Component Library - React",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -13,6 +13,6 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '0.1.6';
+    return '0.1.7';
   }
 }


### PR DESCRIPTION
**Description of changes:**
This change will allow GitAction's ```dependabot``` to skip CHANGELOG.md verification.

**Testing** locally

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
