### PR TITLE
Remove hardcoded endpoints, make getAttendee/join extendable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add docs for Flex component
 - Add Navbar component
 - Add github actions workflow check for changes to workflows with 'push' or 'pull_request' trigger types
+- Add docs for MeetingProvider and hooks
 
 ### Changed
 
@@ -82,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed `prebuild:publish' to run npm install prior to running scripts to make sure all dependencies are available
 - Update roster with mobile design
 - [Deskptop only] Integrate navbar, roster toggle in demo
+- Take callback for fetching attendees. Take in meeting/attendee info for joining meeting
 
 ### Removed
 
@@ -96,6 +98,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix roster showing stale attendees
 - `AudioActivityPreview` to show mic progress track on audio input device change
 - Fixed release execution bug
-- Fixed bug in verdaccio clean up 
+- Fixed bug in verdaccio clean up
 
 ## [0.1.1] - 2020-06-16

--- a/demo/meeting/src/app.tsx
+++ b/demo/meeting/src/app.tsx
@@ -9,6 +9,7 @@ import {
   MeetingProvider
 } from 'amazon-chime-sdk-component-library-react';
 
+import { AppStateProvider } from './providers/AppStateProvider';
 import ErrorProvider from './providers/ErrorProvider';
 import routes from './constants/routes';
 import { Meeting, Home, DeviceSetup } from './views';
@@ -18,11 +19,13 @@ const App: FC = () => (
     <ThemeProvider theme={lightTheme}>
       <ErrorProvider>
         <MeetingProvider>
-          <Switch>
-            <Route exact path={routes.HOME} component={Home} />
-            <Route path={routes.DEVICE} component={DeviceSetup} />
-            <Route path={routes.MEETING} component={Meeting} />
-          </Switch>
+          <AppStateProvider>
+            <Switch>
+              <Route exact path={routes.HOME} component={Home} />
+              <Route path={routes.DEVICE} component={DeviceSetup} />
+              <Route path={routes.MEETING} component={Meeting} />
+            </Switch>
+          </AppStateProvider>
         </MeetingProvider>
       </ErrorProvider>
     </ThemeProvider>

--- a/demo/meeting/src/containers/EndMeetingControl/index.tsx
+++ b/demo/meeting/src/containers/EndMeetingControl/index.tsx
@@ -16,8 +16,10 @@ import {
   MeetingStatus
 } from 'amazon-chime-sdk-component-library-react';
 
+import { endMeeting } from '../../utils/api';
 import routes from '../../constants/routes';
 import { StyledP } from './Styled';
+import { useAppState } from '../../providers/AppStateProvider';
 
 const EndMeetingControl: React.FC = () => {
   const meetingManager = useMeetingManager();
@@ -25,15 +27,24 @@ const EndMeetingControl: React.FC = () => {
   const [showModal, setShowModal] = useState(false);
   const toggleModal = (): void => setShowModal(!showModal);
   const { updateMeetingStatus } = useMeetingStatus();
+  const { meetingId } = useAppState();
 
-  const endMeeting = async (): Promise<void> => {
-    await meetingManager?.endMeeting();
+  const endMeetingForAll = async (): Promise<void> => {
+    try {
+      await meetingManager.leave();
+      if (meetingId) {
+        await endMeeting(meetingId);
+      }
+    } catch (e) {
+      console.log('Could not end meeting');
+    }
+
     updateMeetingStatus(MeetingStatus.Ended);
     history.push(routes.HOME);
   };
 
   const leaveMeeting = async (): Promise<void> => {
-    await meetingManager?.leaveMeeting();
+    await meetingManager.leave();
     history.push(routes.HOME);
   };
 
@@ -52,7 +63,7 @@ const EndMeetingControl: React.FC = () => {
           <ModalButtonGroup
             primaryButtons={[
               <ModalButton
-                onClick={endMeeting}
+                onClick={endMeetingForAll}
                 variant="primary"
                 label="End meeting for all"
                 closesModal

--- a/demo/meeting/src/containers/MeetingJoinDetails.tsx
+++ b/demo/meeting/src/containers/MeetingJoinDetails.tsx
@@ -10,26 +10,25 @@ import {
   useMeetingManager,
   Modal,
   ModalBody,
-  ModalHeader,
+  ModalHeader
 } from 'amazon-chime-sdk-component-library-react';
 
 import routes from '../constants/routes';
 import Card from '../components/Card';
+import { useAppState } from '../providers/AppStateProvider';
 
 const MeetingJoinDetails = () => {
   const meetingManager = useMeetingManager();
   const history = useHistory();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
-
-  const meetingId = meetingManager?.meetingId || '';
-  const attendeeName = meetingManager?.attendeeName;
+  const { meetingId, localUserName } = useAppState();
 
   const handleJoinMeeting = async () => {
     setIsLoading(true);
 
     try {
-      await meetingManager.join();
+      await meetingManager.start();
       setIsLoading(false);
       history.push(`${routes.MEETING}/${meetingId}`);
     } catch (error) {
@@ -46,7 +45,7 @@ const MeetingJoinDetails = () => {
           onClick={handleJoinMeeting}
         />
         <Label style={{ margin: '.75rem 0 0 0' }}>
-          Joining meeting <b>{meetingId}</b> as <b>{attendeeName}</b>
+          Joining meeting <b>{meetingId}</b> as <b>{localUserName}</b>
         </Label>
       </Flex>
       {error && (

--- a/demo/meeting/src/containers/MeetingRoster.tsx
+++ b/demo/meeting/src/containers/MeetingRoster.tsx
@@ -31,8 +31,14 @@ const MeetingRoster = () => {
   };
 
   const attendeeItems = attendees.map((attendee: any) => {
-    const { id, name } = attendee || {};
-    return <RosterAttendee key={id} attendeeId={id} name={name} />;
+    const { chimeAttendeeId, name } = attendee || {};
+    return (
+      <RosterAttendee
+        key={chimeAttendeeId}
+        attendeeId={chimeAttendeeId}
+        name={name}
+      />
+    );
   });
 
   return (

--- a/demo/meeting/src/providers/AppStateProvider.tsx
+++ b/demo/meeting/src/providers/AppStateProvider.tsx
@@ -1,0 +1,53 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useContext, useState, ReactNode } from 'react';
+
+type Props = {
+  children: ReactNode;
+};
+
+interface AppStateValue {
+  meetingId: string;
+  localUserName: string;
+  setMeeting: (meetingId: string) => void;
+  setLocalName: (name: string) => void;
+}
+
+const AppStateContext = React.createContext<AppStateValue | null>(null);
+
+export function useAppState(): AppStateValue {
+  const state = useContext(AppStateContext);
+
+  if (!state) {
+    throw new Error('useAppState must be used within AppStateProvider');
+  }
+
+  return state;
+}
+
+export function AppStateProvider({ children }: Props) {
+  const [meetingId, setMeetingId] = useState('');
+  const [localUserName, setLocalUserName] = useState('');
+
+  const setMeeting = (meetingId: string): void => {
+    setMeetingId(meetingId);
+  };
+
+  const setLocalName = (name: string): void => {
+    setLocalUserName(name);
+  };
+
+  const providerValue = {
+    meetingId,
+    localUserName,
+    setLocalName,
+    setMeeting
+  };
+
+  return (
+    <AppStateContext.Provider value={providerValue}>
+      {children}
+    </AppStateContext.Provider>
+  );
+}

--- a/demo/meeting/src/providers/SIPMeetingProvider/SIPMeetingManager.ts
+++ b/demo/meeting/src/providers/SIPMeetingProvider/SIPMeetingManager.ts
@@ -1,18 +1,16 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { MeetingManager } from 'amazon-chime-sdk-component-library-react';
-
+import { fetchMeeting } from '../../utils/api';
 import { AMAZON_CHIME_VOICE_CONNECTOR_PHONE_NUMDER } from '../../constants';
 
 export class SIPMeetingManager {
-  private meetingManager: MeetingManager | null;
-
   private region: string;
 
-  constructor(theMeetingManager: MeetingManager | null) {
-    this.meetingManager = theMeetingManager;
-    this.region = this.meetingManager?.region || 'us-east-1';
+  private meetingData: any = null;
+
+  constructor(region = 'us-east-1') {
+    this.region = region;
   }
 
   getSIPURI = async (
@@ -20,12 +18,12 @@ export class SIPMeetingManager {
     voiceConnectorId: string
   ): Promise<string> => {
     try {
-      const json = await this.meetingManager?.joinMeeting(
+      this.meetingData = await fetchMeeting(
         meetingId,
         AMAZON_CHIME_VOICE_CONNECTOR_PHONE_NUMDER,
         this.region
       );
-      const joinToken = json.JoinInfo.Attendee.JoinToken;
+      const joinToken = this.meetingData.JoinInfo.Attendee.JoinToken;
       return `sip:${AMAZON_CHIME_VOICE_CONNECTOR_PHONE_NUMDER}@${voiceConnectorId};transport=tls;X-joinToken=${joinToken}`;
     } catch (error) {
       throw new Error(error);

--- a/demo/meeting/src/providers/SIPMeetingProvider/index.tsx
+++ b/demo/meeting/src/providers/SIPMeetingProvider/index.tsx
@@ -1,22 +1,18 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { ReactNode, useContext } from 'react';
-import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+import React, { ReactNode, useContext, useState } from 'react';
 
 import { SIPMeetingManager } from './SIPMeetingManager';
 
-const SIPMeetingContext = React.createContext<SIPMeetingManager | null>(
-  null
-);
+const SIPMeetingContext = React.createContext<SIPMeetingManager | null>(null);
 
 type Props = {
   children: ReactNode;
 };
 
 export default function SIPMeetingProvider({ children }: Props) {
-  const meetingManager = useMeetingManager();
-  const sipMeeting = new SIPMeetingManager(meetingManager);
+  const [sipMeeting] = useState(new SIPMeetingManager());
 
   return (
     <SIPMeetingContext.Provider value={sipMeeting}>
@@ -29,8 +25,10 @@ export const useSIPMeetingManager = (): SIPMeetingManager => {
   const sipMeetingManager = useContext(SIPMeetingContext);
 
   if (!sipMeetingManager) {
-    throw new Error('useSIPMeetingManager must be used within SIPMeetingProvider');
+    throw new Error(
+      'useSIPMeetingManager must be used within SIPMeetingProvider'
+    );
   }
 
   return sipMeetingManager;
-}
+};

--- a/demo/meeting/src/types/index.ts
+++ b/demo/meeting/src/types/index.ts
@@ -1,15 +1,6 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export type RosterAttendeeType = {
-  id: string;
-  name: string;
-};
-
-export type RosterType = {
-  [attendeeId: string]: RosterAttendeeType;
-};
-
 export type FormattedDeviceType = {
   deviceId: string;
   label: string;

--- a/demo/meeting/src/utils/api.ts
+++ b/demo/meeting/src/utils/api.ts
@@ -1,0 +1,72 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export const BASE_URL: string = [
+  location.protocol,
+  '//',
+  location.host,
+  location.pathname.replace(/\/*$/, '/')
+].join('');
+
+interface MeetingResponse {
+  JoinInfo: {
+    Attendee: any;
+    Meeting: any;
+  };
+}
+
+export async function fetchMeeting(
+  meetingId: string,
+  name: string,
+  region: string
+): Promise<MeetingResponse> {
+  const response = await fetch(
+    `${BASE_URL}join?title=${encodeURIComponent(
+      meetingId
+    )}&name=${encodeURIComponent(name)}&region=${encodeURIComponent(region)}`,
+    {
+      method: 'POST'
+    }
+  );
+  const data = await response.json();
+
+  if (data.error) {
+    throw new Error(`Server error: ${data.error}`);
+  }
+
+  return data;
+}
+
+export function createGetAttendeeCallback(meetingId: string) {
+  return async (chimeAttendeeId: string, externalUserId?: string) => {
+    const attendeeUrl = `${BASE_URL}attendee?title=${encodeURIComponent(
+      meetingId
+    )}&attendee=${encodeURIComponent(chimeAttendeeId)}`;
+    const res = await fetch(attendeeUrl, {
+      method: 'GET'
+    });
+
+    if (!res.ok) {
+      throw new Error('Invalid server response');
+    }
+
+    const data = await res.json();
+
+    return {
+      name: data.AttendeeInfo.Name
+    };
+  };
+}
+
+export async function endMeeting(meetingId: string) {
+  const res = await fetch(
+    `${BASE_URL}end?title=${encodeURIComponent(meetingId)}`,
+    {
+      method: 'POST'
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error('Server error ending meeting');
+  }
+}

--- a/src/hooks/sdk/docs/useAttendeeAudioStatus.stories.mdx
+++ b/src/hooks/sdk/docs/useAttendeeAudioStatus.stories.mdx
@@ -1,0 +1,53 @@
+<Meta title="SDK Hooks/useAttendeeAudioStatus" />
+
+# useAttendeeAudioStatus
+
+Returns the mute and signal strength state for a given chime attendee ID.
+
+### Return value
+
+```javascript
+{
+  muted: boolean;
+
+  // Either 0 (no signal), 50 (weak signal), or 100 (good signal)
+  signalStrength: number;
+}
+```
+
+## Importing
+
+```javascript
+import { useAttendeeAudioStatus } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+The hook depends on the `AudioVideoProvider`. If you are using `MeetingProvider`, it is rendered by default.
+
+```jsx
+import React from 'react';
+import { MeetingProvider, useAttendeeAudioStatus } from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <MeetingProvider>
+      <MyChild />
+  </MeetingProvider>
+);
+
+
+const MyChild = () => {
+  const { muted, signalStrength } = useAttendeeAudioStatus('chime-attendee-id-1234');
+
+  return (
+    <> 
+      <p> chime-attendee-id-1234 is {muted ? 'muted' : 'unmuted'} </p>
+      <p> signal strength: {signalStrength} </p>
+    </>
+  )
+}
+```
+
+### Dependencies
+
+- `AudioVideoProvider`

--- a/src/hooks/sdk/docs/useAttendeeStatus.stories.mdx
+++ b/src/hooks/sdk/docs/useAttendeeStatus.stories.mdx
@@ -1,0 +1,67 @@
+<Meta title="SDK Hooks/useAttendeeStatus" />
+
+# useAttendeeStatus
+
+Returns the mute, video enabled, content sharing and signal strength state for a given attendee ID. You can use this state to then build out a roster to reflect each attendee's meeting state.
+
+### Return value
+
+```javascript
+{
+  // Whether or not the user is sharing their local video
+  videoEnabled: boolean;
+
+  // Whether or not the user is content sharing
+  sharingContent: boolean;
+
+  // Whether or not the user is muted
+  muted: boolean;
+
+  // Either 0 (no signal), 50 (weak signal), or 100 (good signal)
+  signalStrength: number;
+}
+```
+
+## Importing
+
+```javascript
+import { useAttendeeStatus } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+The hook depends on the `AudioVideoProvider`. If you are using `MeetingProvider`, it is rendered by default.
+
+```jsx
+import React from 'react';
+import { MeetingProvider, useAttendeeStatus } from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <MeetingProvider>
+      <MyChild />
+  </MeetingProvider>
+);
+
+
+const MyChild = () => {
+  const { 
+    muted, 
+    videoEnabled, 
+    sharingContent, 
+    signalStrength 
+  } = useAttendeeStatus('chime-attendee-id-1234');
+
+  return (
+    <> 
+      <p> chime-attendee-id-1234 is {muted ? 'muted' : 'unmuted'} </p>
+      <p> {videoEnabled ? 'Sharing local video' : 'Not sharing local video'} </p>
+      <p> {sharingContent ? 'Sharing content' : 'Not sharing content'} </p>
+      <p> signal strength: {signalStrength} </p>
+    </>
+  )
+}
+```
+
+### Dependencies
+
+- `AudioVideoProvider`

--- a/src/hooks/sdk/docs/useSelectVideoQuality.stories.mdx
+++ b/src/hooks/sdk/docs/useSelectVideoQuality.stories.mdx
@@ -1,0 +1,49 @@
+<Meta title="SDK Hooks/useSelectVideoQuality" />
+
+# useSelectVideoQuality
+
+Returns a function that can be used to select the user's video input quality.
+
+### Return value
+
+```javascript
+(VideoQuality) => void;
+
+type VideoQuality = '360p' | '540p' | '720p';
+```
+
+## Importing
+
+```javascript
+import { useSelectVideoQuality } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+The hook depends on the `AudioVideoProvider`. If you are using `MeetingProvider`, it is rendered by default.
+
+```jsx
+import React from 'react';
+import { MeetingProvider, useSelectVideoQuality } from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <MeetingProvider>
+      <MyChild />
+  </MeetingProvider>
+);
+
+
+const MyChild = () => {
+  const selectVideoQuality = useSelectVideoQuality();
+
+  return (
+    <button onClick={() => selectVideoQuality('360p')}> 360p video input quality </button>
+    <button onClick={() => selectVideoQuality('540p')}> 540p video input quality </button>
+    <button onClick={() => selectVideoQuality('720p')}> 720p video input quality </button>
+  )
+}
+```
+
+### Dependencies
+
+- `AudioVideoProvider`

--- a/src/hooks/sdk/docs/useToggleLocalMute.stories.mdx
+++ b/src/hooks/sdk/docs/useToggleLocalMute.stories.mdx
@@ -1,0 +1,55 @@
+import useToggleLocalMute from '../useToggleLocalMute'
+
+<Meta title="SDK Hooks/useToggleLocalMute" />
+
+# useToggleLocalMute
+
+Returns the state of whether the local user is muted or not, and a function to toggle their mute state.
+
+### Return value
+
+```javascript
+{
+  // Whether or not the local user is muted
+  muted: boolean;
+
+  // A function to toggle the local user's mute state
+ toggleMute: () => void;
+}
+```
+
+## Importing
+
+```javascript
+import { useToggleLocalMute } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+The hook depends on the `AudioVideoProvider`. If you are using `MeetingProvider`, it is rendered by default.
+
+```jsx
+import React from 'react';
+import { MeetingProvider, useToggleLocalMute } from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <MeetingProvider>
+      <MyChild />
+  </MeetingProvider>
+);
+
+
+const MyChild = () => {
+  const {muted, toggleMute} = useToggleLocalMute();
+
+  return (
+    <button onClick={toggleMute}>
+      { muted ? 'Umute myself' : 'Mute}
+    </button>
+  )
+}
+```
+
+### Dependencies
+
+- `AudioVideoProvider`

--- a/src/providers/FeaturedVideoTileProvider/docs/useFeaturedTileState.stories.mdx
+++ b/src/providers/FeaturedVideoTileProvider/docs/useFeaturedTileState.stories.mdx
@@ -4,7 +4,7 @@
 
 Provides the tile ID of the **most** active speaker, if they are sharing video. If there are no active speakers, or the active speaker is not sharing video, there will be no tile ID.
 
-### State
+### Return value
 
 ```javascript
 {

--- a/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
+++ b/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
@@ -1,0 +1,81 @@
+<Meta title="Providers/MeetingManager" />
+
+# MeetingManager
+
+The `MeetingManager` is a class that helps integrates with the SDK. It is tied to the `MeetingProvider` and is primarily responsible for joining, starting, and leaving your meeting. 
+
+You can access the `MeetingManager` instance with the `useMeetingManager` hook.
+
+## Usage
+
+`MeetingProvider` must be rendered somewhere higher in the tree.
+
+```jsx
+import React from 'react';
+import { MeetingProvider, useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <MeetingProvider>
+    <MyApp />
+  </MeetingProvider>
+);
+
+const MyApp = () => {
+  const meetingManager = useMeetingManager();
+
+  ...
+}
+```
+
+## Interface
+
+### `meetingManager.join`
+
+Creates a meeting session using the meeting and attendee data passed. It will attempt to select default devices for the user.
+
+```javascript
+(data: MeetingJoinData) => Promise<void>
+
+interface MeetingJoinData {
+  // The response from calling chime:CreateMeeting from your server
+  meetingInfo: any;
+
+  // The response from calling chime:CreateAttendee from your server
+  attendeeInfo: any;
+}
+```
+
+### `meetingManager.start`
+
+Starts the meeting session so that attendee's can receive audio and video from the meeting. This must be called after calling `join`.
+
+```javascript
+() => Promise<void>
+```
+
+### `meetingManager.leave`
+
+Stops the meeting session and performs cleanup. This should be called anytime a user needs to leave a meeting.
+
+```javascript
+() => Promise<void>
+```
+
+### `meetingManager.getAttendee`
+
+This method is expected to be supplied by the developer. It is called with the Chime user ID and external user ID anytime an attendee joins the meeting, and expects to be resolved with an object that has a `name` property that will be used for video nameplates and roster state.
+
+For example - you may want to fetch the attendee from the database, or get the name from some local application state. This is up to the developer.
+
+```javascript
+(
+  chimeAttendeeId: string,
+  externalUserId?: string
+) => Promise<AttendeeResponse>
+
+interface AttendeeResponse {
+  name?: string;
+}
+```
+
+

--- a/src/providers/MeetingProvider/docs/MeetingProvider.stories.mdx
+++ b/src/providers/MeetingProvider/docs/MeetingProvider.stories.mdx
@@ -2,17 +2,19 @@
 
 # MeetingProvider
 
-The **root provider** for building a realtime meeting application. It is responsible for rendering out a series of providers and providing a `MeetingManager` class that helps integrate with the Chime JavaScript SDK.
+The **root provider** for building a realtime meeting application. It is responsible for rendering out a series of providers and providing a `MeetingManager` class that helps integrate with the Chime JavaScript SDK. The `MeetingManager` has APIs for joining, starting, and leaving a meeting.
+
+You can access the `MeetingManager` instance with the `useMeetingManager` hook.
+
+## Importing
+
+```jsx
+import { MeetingProvider } from 'amazon-chime-sdk-component-library-react';
+```
 
 ## Usage
 
-@@ THIS IS A TODO SECTION @@
-
-MeetingProvider requires you to configure how to fetch the meeting data and attendee data. 
-
-@@ END TODO SECTION @@
-
-The MeetingProvider should be placed near or at the root of your application.
+Render the MeetingProvider near the root of your application. 
 
 ```jsx
 import React from 'react';
@@ -20,15 +22,7 @@ import { MeetingProvider } from 'amazon-chime-sdk-component-library-react';
 
 const App = () => (
   <MeetingProvider>
-    <MyApp>
-      <MyChild />
-    </MyApp>
+    <MyApp />
   </MeetingProvider>
 );
 ```
-
-Once you have placed the MeetingProvider, you can use any of our hooks or components within your application.
-
-@@ TODO - MeetingManager interface @@
-
-@@ TODO - Minimal meeting example for joining/ending @@

--- a/src/providers/MeetingProvider/docs/useMeetingManager.stories.mdx
+++ b/src/providers/MeetingProvider/docs/useMeetingManager.stories.mdx
@@ -1,0 +1,40 @@
+<Meta title="SDK Hooks/useMeetingManager" />
+
+# useMeetingManager
+
+Returns the MeetingManager instance.
+
+### Return value
+
+```javascript
+MeetingManager
+```
+
+## Importing
+
+```javascript
+import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+
+```
+
+## Usage
+
+The hook depends on the `MeetingProvider`.
+
+```jsx
+import React from 'react';
+import { MeetingProvider, useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <MeetingProvider>
+    <MyChild />
+  </MeetingProvider>
+);
+
+
+const MyChild = () => {
+  const meetingManager = useMeetingManager();
+
+  ...
+}
+```

--- a/src/providers/RosterProvider/docs/useRosterState.stories.mdx
+++ b/src/providers/RosterProvider/docs/useRosterState.stories.mdx
@@ -9,7 +9,8 @@ Returns state around the meeting's roster.
 ```javascript
 {
  [AttendeeId: string]: {
-   id: string;
+   chimeAttendeeId: string;
+   externalUserId?: string;
    name?: string;
  }
 }

--- a/src/providers/introduction.stories.mdx
+++ b/src/providers/introduction.stories.mdx
@@ -1,3 +1,101 @@
 <Meta title="Providers/Introduction" />
 
-### INTRO PROVIDERS PAGE PLACEHOLDER
+# Introduction
+
+Providers are responsible for maintaining state and functionality related to the Amazon Chime JS SDK. While this section includes documentation on individual providers, **you will likely only ever need to work with the `MeetingProvider`**. The `MeetingProvider` is the root provider, and renders all other providers so that you can quickly build out a realtime meeting application. 
+
+## Getting started with MeetingProvider
+
+To build realtime meeting applications with the `MeetingProvider`, follow these steps 
+
+1. Render the MeetingProvider near the root of your application. 
+
+```jsx
+import React from 'react';
+import { MeetingProvider } from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <MeetingProvider>
+    <MyApp />
+  </MeetingProvider>
+);
+```
+
+2. *Optional* - Configure how to fetch attendees as they join the meeting
+
+If you want nameplates on your videos or want to build a realtime roster of attendees, you will need to assign a `meetingManager.getAttendee` function. This function is passed the chime attendee ID and external user ID (if present) as attendees join the meeting. It is expected to return a promise that resolves with the attendee's name.
+
+You can access the MeetingManager class instance with the `useMeetingManager` hook.
+
+```jsx
+import React from 'react';
+import { MeetingProvider, useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <MeetingProvider>
+    <MyApp />
+  </MeetingProvider>
+);
+
+const MyApp = () => {
+  const meetingManager = useMeetingManager();
+
+  useEffect(() => {
+    meetingManager.getAttendee = async (chimeAttendeeId: string, externalUserId?: string) => {
+      const response = await fetch('/my-attendees-endpoint);
+      const user = await res.json();
+
+      return {
+        name: user.name
+      }
+    }
+  }, [])
+}
+```
+
+3. Join a meeting
+
+To join a meeting, you will need to pass the meeting and attendee data from Chime's [CreateAttendee](https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateAttendee.html) and [CreateMeeting](https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateMeeting.html) APIs. [Read this for more details](https://aws.github.io/amazon-chime-sdk-js/modules/gettingstarted.html#meeting-service).
+
+Once you have your meeting and attendee data, you can call `meetingManager.join` to join the meeting.
+
+```jsx
+import React from 'react';
+import { MeetingProvider, useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <MeetingProvider>
+    <MyApp />
+  </MeetingProvider>
+);
+
+const MyApp = () => {
+  const meetingManager = useMeetingManager();
+
+  const joinMeeting = async () => {
+    const response = await fetch('/my-meetings-endpoint')
+    const data = await response.json();
+
+    const joinData = {
+      meetingInfo: data.Meeting,
+      attendeeInfo: data.Attendee
+    }
+
+    try {
+      await meetingManager.join(joinData);
+    } catch {
+      console.error("Something went wrong");
+    }   
+  }
+
+  <button onClick={joinMeeting}>Join Meeting</button>
+}
+```
+
+4. Start the meeting session
+
+After joining a meeting, you can begin the meeting sesion by calling `meetingManager.start`. You may want to allow users to configure their selected input/output devices prior to calling `start`. 
+
+5. Done!
+
+The attendee should be in the meeting, and able to receive audio/video. Check out the `SDK components` documentation section for components that you can drop in, or the `SDK hooks` for building out your own UI. 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,3 +52,13 @@ export type MeetingContextType = {
   meetingStatus: MeetingStatus;
   updateMeetingStatus: (s: MeetingStatus) => void;
 };
+
+export type RosterAttendeeType = {
+  chimeAttendeeId: string;
+  externalUserId?: string;
+  name?: string;
+};
+
+export type RosterType = {
+  [attendeeId: string]: RosterAttendeeType;
+};


### PR DESCRIPTION
**Description of changes:**
- change meetingManager to `join`, `start`, `leave` APIs
- `join` now takes in Attendee and Meeting info and creates the meeting session configuration
- `meetingMangager.getMeeting` now expects to be assigned a callback that will return an object with a `name` in order to generate the roster
- Removed other business logic/state from meetingManager (current meeting title, region, etc) and into a small state provider (not for library)

**Testing**

1. Have you successfully run `npm run build:release` locally? failed, looking into it
2. How did you test these changes? manually

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
