### PR TITLE
Add storybook deployment to publishing script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
-name: Test, Publish, & Release
-# When a new Github Release is created via our npm script, publish to NPM
+name: Publish and Deploy Documentation
+# When a new Github Release is created via our npm script, publish to NPM and then deploy our storybook documentation to github pages
 on:
   release:
     types: [published]
@@ -15,8 +15,13 @@ jobs:
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
+      - name: NPM Install
+        run: npm install
       - name: Publish to NPM
-      # TODO: Remove the dryrun option when we actually release
-        run: npm publish --dry-run
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      - name: Publish Storybook Documentation
+        run: npm run deploy-storybook -- --ci 
+        env:
+          GH_TOKEN: chime-sdk-component-bot:${{ secrets.GITHUBPAGES}}

--- a/.github/workflows/send-webhook-star-notification.yml
+++ b/.github/workflows/send-webhook-star-notification.yml
@@ -1,4 +1,4 @@
-name: Chime Room Notification
+name: New Star Chime Notification
 
 on:
   watch:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 coverage
 tst/snapshots/**/__diff_output__
 verdaccio_app
+.out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Home view index file name
 - Provide fallback message when no devices are found
 - Rename `NotificationProvider` hooks
+- Update publish github action to deploy storybook documentation
 
 ### Removed
 


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Add storybook deployment to the publishing script, so that every time we have a new release, we will also deploy our documentation to github pages.

**Testing**

1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes?
verified the script works based on Ziyi's changes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
