### PR TITLE
Add storybook docs for Label and Portal components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Navbar component
 - Add github actions workflow check for changes to workflows with 'push' or 'pull_request' trigger types
 - Add docs for MeetingProvider and hooks
+- Add docs or Label and Portal components
 
 ### Changed
 

--- a/src/components/ui/Label/Label.mdx
+++ b/src/components/ui/Label/Label.mdx
@@ -1,0 +1,35 @@
+import { Preview, Props } from '@storybook/addon-docs/blocks';
+import { ThemeProvider } from 'styled-components';
+
+import Label from './';
+import { lightTheme } from '../../../theme/';
+
+# Label
+
+The Label component displays a caption for an item in a user interface.
+
+## Importing
+
+```javascript
+import { Label } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Example
+
+<ThemeProvider theme={lightTheme}>
+  <Preview>
+    <Flex layout="fill-space-centered">
+      <Label>Hello World</Label>
+    </Flex>
+  </Preview>
+</ThemeProvider>
+
+```jsx
+<Flex layout="fill-space-centered">
+    <Label>Hello World</Label>
+</Flex>
+```
+
+## Props
+
+<Props of={Label} />

--- a/src/components/ui/Label/Label.stories.tsx
+++ b/src/components/ui/Label/Label.stories.tsx
@@ -4,10 +4,18 @@
 import React from 'react';
 import Flex from '../Flex';
 import { Label } from './';
+import LabelDocs from './Label.mdx';
 
 export default {
   title: 'UI Components/Label',
+  parameters: {
+    docs: {
+      page: LabelDocs.parameters.docs.page().props.children.type
+    }
+  },
+  component: Label
 };
+
 
 export const BasicLabel = () => {
   return (

--- a/src/components/ui/Portal/Portal.mdx
+++ b/src/components/ui/Portal/Portal.mdx
@@ -1,0 +1,38 @@
+import { Preview, Props } from '@storybook/addon-docs/blocks';
+import { ThemeProvider } from 'styled-components';
+
+import Portal from './';
+import { lightTheme } from '../../../theme/';
+import Flex from '../Flex';
+
+# Portal
+
+The Portal component is used to render children into any DOM node that exists outside the DOM hierarchy of the portal's container. 
+
+## Importing
+
+```javascript
+import { Portal } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Example
+
+<ThemeProvider theme={lightTheme}>
+  <Preview>
+    <Flex layout="fill-space-centered">
+      <div id='root-div'>Root Div</div>
+      <Portal rootId='root-div'><div>Portal content</div></Portal>
+    </Flex>
+  </Preview>
+</ThemeProvider>
+
+```jsx
+<Flex layout="fill-space-centered">
+  <div id='root-div'>Root Div</div>
+  <Portal rootId='root-div'><div>Portal content</div></Portal>
+</Flex>
+```
+
+## Props
+
+<Props of={Portal} />

--- a/src/components/ui/Portal/Portal.stories.tsx
+++ b/src/components/ui/Portal/Portal.stories.tsx
@@ -5,9 +5,16 @@ import React from 'react';
 
 import Portal from '.';
 import Flex from '../Flex';
+import PortalDocs from './Portal.mdx';
 
 export default {
   title: 'UI Components/Portal',
+  parameters: {
+    docs: {
+      page: PortalDocs.parameters.docs.page().props.children.type
+    }
+  },
+  component: Portal
 };
 
 // Simple story for Portal element

--- a/src/components/ui/Portal/index.tsx
+++ b/src/components/ui/Portal/index.tsx
@@ -5,6 +5,7 @@ import { FC, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 interface PortalProps {
+    /** Specifies the DOM node that the children of the portal will be render into. */
     rootId?: string;
 }
 


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Add storybook documentation for the Label and Portal components

**Testing**

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes? run locally on storybook server

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
