### PR TITLE
Fix video/audio selection bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,5 +101,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AudioActivityPreview` to show mic progress track on audio input device change
 - Fixed release execution bug
 - Fixed bug in verdaccio clean up
+- Fix demo application not allowing to select video / audio via popover
 
 ## [0.1.1] - 2020-06-16

--- a/demo/meeting/src/containers/MeetingControlsContainer.tsx
+++ b/demo/meeting/src/containers/MeetingControlsContainer.tsx
@@ -19,6 +19,7 @@ import { useNavigation } from '../providers/NavigationProvider';
 const StyledControlBar = styled(ControlBar)`
   grid-area: meetingcontrols;
   position: static;
+  z-index: 99;
 `;
 
 const MeetingControlsContainer = () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-component-library-react",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-component-library-react",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Amazon Chime SDK Component Library - React",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -13,6 +13,6 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '0.1.14';
+    return '0.1.15';
   }
 }


### PR DESCRIPTION
**Issue #:** 
SIM# Chevice-525

**Description of changes:**
added higher Z index for navigation bar since popover elements go over (video content) element,

**Testing**
after the fix issue no longer exists and allows user to select different popover elements from Controls section. 

1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
