### PR TITLE
Add docs for Navbar, Roster and Notification components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add github actions workflow check for changes to workflows with 'push' or 'pull_request' trigger types
 - Add docs for MeetingProvider and hooks
 - Add docs or Label and Portal components
+- Add docs for Navbar, Roster and Notification components
+- Add notification `Severity`, `ActionType` enums to index exports
+- Add notification `NotificationType`, `Action` interfaces to index exports
 
 ### Changed
 
@@ -87,6 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Take callback for fetching attendees. Take in meeting/attendee info for joining meeting
 - Update Home view index file name
 - Provide fallback message when no devices are found
+- Rename `NotificationProvider` hooks
 
 ### Removed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-component-library-react",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-component-library-react",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Amazon Chime SDK Component Library - React",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",

--- a/src/components/ui/Navbar/Navbar.mdx
+++ b/src/components/ui/Navbar/Navbar.mdx
@@ -1,0 +1,124 @@
+import { Preview, Props } from '@storybook/addon-docs/blocks';
+import { ThemeProvider } from 'styled-components';
+import { lightTheme } from '../../../theme/';
+import Navbar from '.';
+import NavbarHeader from './NavbarHeader';
+import NavbarItem from './NavbarItem';
+import { Attendees, LeaveMeeting, Information } from '../icons';
+import Flex from '../Flex';
+
+# Navbar
+
+The Navbar component displays a vertical menu with navigation icon buttons and labels. Navbar is constructed using the NavbarHeader and NavbarItem components.
+
+## Importing
+
+```javascript
+import {
+  Navbar,
+  NavbarHeader,
+  NavbarItem
+} from 'amazon-chime-sdk-component-library-react';
+```
+
+## Example
+
+### Navbar Component
+<ThemeProvider theme={lightTheme}>
+  <Navbar flexDirection="column" container>
+    <NavbarHeader onClose={() => {}}/>
+    <Flex>
+      <NavbarItem
+        icon={<Information />}
+        onClick={() => {}}
+        label="Bridge Information"
+      />
+      <NavbarItem
+        icon={<Attendees />}
+        onClick={() => {}}
+        label="Attendees"
+      />
+    </Flex>
+    <Flex marginTop='auto'>
+      <NavbarItem
+        icon={<LeaveMeeting />}
+        onClick={() => {}}
+        label="Leave Meeting"
+      />
+    </Flex>
+  </Navbar>
+</ThemeProvider>
+
+```jsx
+<Navbar flexDirection="column" container height='10%'>
+  <NavbarHeader onClose={() => {}}/>
+  <Flex>
+    <NavbarItem
+      icon={<Information />}
+      onClick={() => {}}
+      label="Bridge Information"
+    />
+    <NavbarItem
+      icon={<Attendees />}
+      onClick={() => {}}
+      label="Attendees"
+    />
+  </Flex>
+  <Flex marginTop='auto'>
+    <NavbarItem
+      icon={<LeaveMeeting />}
+      onClick={() => {}}
+      label="Leave Meeting"
+    />
+  </Flex>
+</Navbar>
+```
+
+## Props
+
+### Navbar Props
+<Props of={Navbar} />
+
+# NavbarHeader
+
+NavbarHeader component is displayed only in the mobile view with screen size less than `theme.mediaQueries.min.md` value defined in your theme (defaults to 768px).
+
+It gives a title to Navbar and also a close icon button to close the Navbar in mobile view.
+
+# Example
+
+```javascript
+<NavbarHeader title="Menu" onClose={() => {}}/>
+```
+
+### NavbarHeader Props
+<Props of={NavbarHeader} />
+
+# NavbarItem
+
+The NavbarItem component displays a single row in the Navbar. It is made up of `ControlBarItem` which acts as a button and a label. 
+
+The label is displayed only on smaller screens with width defined by `theme.mediaQueries.min.md` value in your theme (defaults to 768px), else only icon button is shown.
+
+# Example
+
+### NavbarItem component
+
+<ThemeProvider theme={lightTheme}>
+  <NavbarItem
+    icon={<Information />}
+    onClick={() => {}}
+    label="Bridge Information"
+  />
+</ThemeProvider>
+
+```javascript
+<NavbarItem
+  icon={<Information />}
+  onClick={() => {}}
+  label="Bridge Information"
+/>
+```
+
+### NavbarItem Props
+<Props of={NavbarItem} />

--- a/src/components/ui/Navbar/Navbar.stories.tsx
+++ b/src/components/ui/Navbar/Navbar.stories.tsx
@@ -8,9 +8,16 @@ import NavbarHeader from './NavbarHeader';
 import NavbarItem from './NavbarItem';
 import { Attendees, LeaveMeeting, Information } from '../icons';
 import Flex from '../Flex';
+import NavbarDocs from "./Navbar.mdx";
 
 export default {
   title: 'UI Components/Navbar',
+  parameters: {
+    docs: {
+      page: NavbarDocs.parameters.docs.page().props.children.type
+    }
+  },
+  component: Navbar
 };
 
 export const _Navbar = () => {

--- a/src/components/ui/Navbar/NavbarHeader.tsx
+++ b/src/components/ui/Navbar/NavbarHeader.tsx
@@ -9,7 +9,9 @@ import { StyledHeader } from './Styled';
 import { Remove } from '../icons';
 
 export interface NavbarHeaderProps extends BaseProps {
+  /** Title of Navbar menu */
   title: string;
+  /** Callback fired when Navbar is closed */
   onClose?: () => void;
 }
 

--- a/src/components/ui/Navbar/NavbarItem.tsx
+++ b/src/components/ui/Navbar/NavbarItem.tsx
@@ -8,9 +8,13 @@ import { PopOverItemProps } from '../PopOver/PopOverItem';
 import ControlBarButton from '../ControlBar/ControlBarItem';
 
 export interface NavbarItemProps {
+  /** Any icon from the library for button in navbar item */
   icon: JSX.Element;
+  /** Callback fired when icon is clicked */
   onClick: () => void;
+  /** Label for navbar item */
   label: string;
+  /** PopOver menu if needed in navbar item */
   popOver?: PopOverItemProps[] | null;
 }
 

--- a/src/components/ui/Navbar/index.tsx
+++ b/src/components/ui/Navbar/index.tsx
@@ -7,7 +7,9 @@ import { StyledNavbar } from './Styled';
 import { FlexProps } from '../Flex';
 
 export interface NavbarProps extends FlexProps {
+  /** Classname to apply custom CSS styles */
   className?: string;
+  /** Any react components or HTML elements */
   children?: any;
 }
 

--- a/src/components/ui/Notification/Notification.mdx
+++ b/src/components/ui/Notification/Notification.mdx
@@ -1,0 +1,56 @@
+import { Preview, Props } from '@storybook/addon-docs/blocks';
+import { ThemeProvider } from 'styled-components';
+import { lightTheme } from '../../../theme/';
+import { Notification } from '.';
+import { Severity } from '../../../providers/NotificationProvider';
+
+# Notification
+
+The Notification component displays various types of notifications based on severity.
+
+There are four types of notification severity:
+- Error
+- Success
+- Info
+- Warning
+
+## Importing
+
+```javascript
+import { Notification } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Example
+
+### Notification Component
+<ThemeProvider theme={lightTheme}>
+  <Notification
+    onClose={() => {console.log('Close notification')}}
+    severity={Severity.ERROR}
+    message='Failed to join the meeting'
+  />
+</ThemeProvider>
+
+
+```jsx
+<Notification
+  onClose={() => {console.log('Close notification')}}
+  severity={Severity.ERROR}
+  message='Failed to join the meeting'
+/>
+```
+
+#### Severity
+```jsx
+enum Severity {
+  ERROR = 'error',
+  SUCCESS = 'success',
+  INFO = 'info',
+  WARNING = 'warning',
+};
+```
+
+## Props
+
+### Notification Props
+<Props of={Notification} />

--- a/src/components/ui/Notification/Notification.stories.tsx
+++ b/src/components/ui/Notification/Notification.stories.tsx
@@ -6,9 +6,16 @@ import { select } from '@storybook/addon-knobs';
 
 import { Notification } from '.';
 import { Severity } from '../../../providers/NotificationProvider';
+import NotificationDocs from './Notification.mdx';
 
 export default {
   title: 'UI Components/Notification',
+  parameters: {
+    docs: {
+      page: NotificationDocs.parameters.docs.page().props.children.type
+    }
+  },
+  component: Notification
 };
 
 export const _Notification = () => {
@@ -24,7 +31,7 @@ export const _Notification = () => {
            },
           Severity.ERROR
         )}
-        message='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.'
+        message='This is the notification message'
       />
   );
 };

--- a/src/components/ui/Notification/Styled.tsx
+++ b/src/components/ui/Notification/Styled.tsx
@@ -38,7 +38,7 @@ export const StyledNotification = styled.div<StyledNotificationProps>`
     font-size: ${props => props.theme.fontSizes.text.fontSize};
     font-size: ${props => props.theme.fontSizes.text.lineHeight};
     letter-spacing: -0.005625rem;
-    margin: 0.375rem 3.3125rem 0.375rem 0.75rem;
+    margin: 0.5rem 3.3125rem 0.375rem 0.75rem;
   }
 
   ${StyledCloseIconButton} {

--- a/src/components/ui/Notification/index.tsx
+++ b/src/components/ui/Notification/index.tsx
@@ -5,17 +5,30 @@ import React, { useEffect, HTMLAttributes } from 'react';
 
 import { StyledNotification, StyledCloseIconButton } from './Styled';
 import { Caution, CheckRound, Information, Remove, Clock } from '../icons';
-import { Severity } from '../../../providers/NotificationProvider';
 import { BaseProps } from '../Base';
 
-export const DEFAULT_DELAY: number = 8000;
+export const DEFAULT_DELAY: number = 6000;
+
+enum Severity {
+  ERROR = 'error',
+  SUCCESS = 'success',
+  INFO = 'info',
+  WARNING = 'warning',
+};
 
 export interface NotificationProps extends Omit<HTMLAttributes<HTMLDivElement>, 'css'>, BaseProps {
+  /** Notification Severity */
   severity?: Severity;
+  /** Message to show in notification */
   message?: string;
+  /** Callback fired when notification is closed */
   onClose: () => void;
+  /** Whether or not the notification should get autoclosed */
   autoClose?: boolean;
+  /** Auto-closing delay in milliseconds, default delay is 6000 (6s) */
   autoCloseDelay?: number;
+  /** CSS classname to apply custom styles */
+  className?: string;
 }
 
 const iconMapping = {

--- a/src/components/ui/NotificationGroup/NotificationGroup.mdx
+++ b/src/components/ui/NotificationGroup/NotificationGroup.mdx
@@ -1,0 +1,29 @@
+import { Preview, Props } from '@storybook/addon-docs/blocks';
+import { ThemeProvider } from 'styled-components';
+import { lightTheme } from '../../../theme/';
+import { NotificationGroup } from '.';
+
+# NotificationGroup
+
+The NotificationGroup component renders any current notifications to the top of the screen.
+
+Check `NotificationProvider` [documentation](/?path=/docs/ui-providers-notificationprovider--page) for more information.
+
+## Importing
+
+```javascript
+import { NotificationGroup } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Example
+
+```jsx
+<NotificationProvider>
+  <NotificationGroup />
+</NotificationProvider>
+```
+
+Note: Check for working under the `Canvas` section for this component.
+
+## Dependencies
+- `NotificationProvider`

--- a/src/components/ui/NotificationGroup/NotificationGroup.stories.tsx
+++ b/src/components/ui/NotificationGroup/NotificationGroup.stories.tsx
@@ -5,18 +5,25 @@ import React from 'react';
 
 import NotificationGroup from '.';
 import {
-  useNotificationDispatchContext,
+  useNotificationDispatch,
   NotificationProvider,
   ActionType,
   Severity
 } from '../../../providers/NotificationProvider';
+import NotificationGroupDocs from './NotificationGroup.mdx';
 
 export default {
   title: 'UI Components/NotificationGroup',
+  parameters: {
+    docs: {
+      page: NotificationGroupDocs.parameters.docs.page().props.children.type
+    }
+  },
+  component: NotificationGroup
 };
 
 const StorybookTestButton = ({ label, payload }: any) => {
-  const dispatch = useNotificationDispatchContext();
+  const dispatch = useNotificationDispatch();
 
   const addNotification = (e: any) => {
     dispatch({

--- a/src/components/ui/NotificationGroup/index.tsx
+++ b/src/components/ui/NotificationGroup/index.tsx
@@ -5,12 +5,12 @@ import React from 'react';
 
 import Notification from '../Notification';
 import Portal from '../Portal';
-import { useNotificationStateContext, useNotificationDispatchContext, ActionType } from '../../../providers/NotificationProvider';
+import { useNotificationState, useNotificationDispatch, ActionType } from '../../../providers/NotificationProvider';
 import { StyledNotificationGroup } from './Styled';
 
 export const NotificationGroup: React.FC = () => {
-  const { notifications } = useNotificationStateContext();
-  const dispatch = useNotificationDispatchContext();
+  const { notifications } = useNotificationState();
+  const dispatch = useNotificationDispatch();
 
   return (
     <Portal rootId='notification-group-root'>

--- a/src/components/ui/Roster/Roster.mdx
+++ b/src/components/ui/Roster/Roster.mdx
@@ -1,0 +1,250 @@
+import { Preview, Props } from '@storybook/addon-docs/blocks';
+import { ThemeProvider } from 'styled-components';
+import { lightTheme } from '../../../theme/';
+import RosterCell from './RosterCell';
+import RosterGroup from './RosterGroup';
+import RosterHeader from './RosterHeader';
+import Roster from './';
+import Flex from '../Flex';
+
+# Roster
+
+The Roster component displays all the attendees in a meeting including their local statuses for audio, video, content share and if running late.
+It is made up of one RosterHeader component and multiple RosterGroup components.
+
+## Importing
+
+```javascript
+import { 
+  Roster,
+  RosterGroup,
+  RosterHeader,
+  RosterCell
+} from 'amazon-chime-sdk-component-library-react';
+```
+
+## Example
+
+### Roster Component
+
+<ThemeProvider theme={lightTheme}>
+  <Flex 
+    container
+    css="height: 10%; background: #f6f9fc;"
+  >
+    <Roster>
+      <RosterHeader
+        title="Present"
+        badge={2}
+        onClose={() => {}}
+        searchValue="Michael"
+        onSearch={() => {}}
+      />
+      <RosterGroup>
+        <RosterCell
+          name="Michael Scott"
+          subtitle="Regional Manager"
+          muted={false}
+          videoEnabled={true}
+        />
+        <RosterCell
+          name="Michael Scarn"
+          subtitle="FBI agent"
+          muted={true}
+          videoEnabled={false}
+        />
+      </RosterGroup>
+      <RosterGroup title="Left" badge={2}>
+        <RosterCell name="Dwight" subtitle="Assistant regional manager" />
+        <RosterCell name="Mike the Magic" subtitle="Magician" />
+      </RosterGroup>
+    </Roster>
+  </Flex>
+</ThemeProvider>
+
+```jsx
+<Roster>
+  <RosterHeader
+    title="Present"
+    badge={2}
+    onClose={() => {}}
+    searchValue="Michael"
+    onSearch={() => {}}
+  />
+  <RosterGroup>
+    <RosterCell
+      name="Michael Scott"
+      subtitle="Regional Manager"
+      muted={false}
+      videoEnabled={true}
+    />
+    <RosterCell
+      name="Michael Scarn"
+      subtitle="FBI agent"
+      muted={true}
+      videoEnabled={false}
+    />
+  </RosterGroup>
+  <RosterGroup title="Left" badge={2}>
+    <RosterCell name="Dwight" subtitle="Assistant regional manager" />
+    <RosterCell name="Mike the Magic" subtitle="Magician" />
+  </RosterGroup>
+</Roster>
+```
+
+# RosterHeader
+
+The RosterHeader component displays the title of the Roster's header and number of attendees.
+It is also equipped with the search functionality and close icon button to close the roster itself.
+
+## Example
+
+### RosterHeader Component
+
+<ThemeProvider theme={lightTheme}>
+  <RosterHeader
+    title="Present"
+    badge={2}
+    onClose={() => {}}
+    searchValue="Michael"
+    onSearch={() => {}}
+  />
+</ThemeProvider>
+
+```jsx
+<RosterHeader
+  title="Present"
+  badge={2}
+  onClose={() => {}}
+  searchValue="Michael"
+  onSearch={() => {}}
+/>
+```
+
+### RosterHeader Props
+<Props of={RosterHeader} />
+
+# RosterGroup
+
+The RosterGroup component displays multiple RosterCell components grouped by a category. The title distinguishes the RosterGroup category.
+
+## Example
+
+### RosterGroup Component
+
+<ThemeProvider theme={lightTheme}>
+  <Flex container layout="fill-space-centered" css="height: 5%;">
+    <Flex css="width: 100%; max-width: 280px;">
+      <RosterGroup title={"Left"} badge={4}>
+        <RosterCell name="Michael Scarn" subtitle="FBI agent" />
+        <RosterCell name="Prison Mike" subtitle="Inmate" />
+        <RosterCell name="Date Mike" subtitle="Bachelor" />
+        <RosterCell name="Dwight" subtitle="Assistant regional manager" />
+      </RosterGroup>
+    </Flex>
+  </Flex>
+</ThemeProvider>
+
+```jsx
+<RosterGroup title={"Left"} badge={4}>
+  <RosterCell name="Michael Scarn" subtitle="FBI agent" />
+  <RosterCell name="Prison Mike" subtitle="Inmate" />
+  <RosterCell name="Date Mike" subtitle="Bachelor" />
+  <RosterCell name="Dwight" subtitle="Assistant regional manager" />
+</RosterGroup>
+```
+### RosterGroup Props
+<Props of={RosterGroup} />
+
+# RosterCell
+
+The RosterCell component displays a single row in the Roster component providing various statuses for an attendee in a meeting. In a meeting, the RosterCell shows the current status of audio, video and presence of an attendee with the attendee name. One can also show running late messages as well as a subtitle for the attendee.
+
+## Example
+
+### RosterCell Component with late message
+
+<ThemeProvider theme={lightTheme}>
+  <Flex container layout="fill-space-centered" css="height: 5%;">
+    <Flex css="width: 100%; max-width: 280px;">
+      <RosterCell
+        name="Stanley Hudson"
+        subtitle="Manager"
+        muted={true}
+        videoEnabled={false}
+        sharingContent={false}
+        runningLate={"10 minutes"}
+      />
+    </Flex>
+  </Flex>
+</ThemeProvider>
+
+```jsx
+<RosterCell
+  name="Stanley Hudson"
+  subtitle="Manager"
+  muted={true}
+  videoEnabled={false}
+  sharingContent={false}
+  runningLate={"10 minutes"}
+/>
+```
+
+### RosterCell Component with micPosition leading
+
+<ThemeProvider theme={lightTheme}>
+  <Flex container layout="fill-space-centered" css="height: 5%;">
+    <Flex css="width: 100%; max-width: 280px;">
+      <RosterCell
+        name="Stanley Hudson"
+        subtitle="Manager"
+        muted={true}
+        videoEnabled={false}
+        sharingContent={false}
+        micPosition={"leading"}
+      />
+    </Flex>
+  </Flex>
+</ThemeProvider>
+
+```jsx
+<RosterCell
+  name="Stanley Hudson"
+  subtitle="Manager"
+  muted={true}
+  videoEnabled={true}
+  sharingContent={false}
+  micPosition={"leading"}
+/>
+```
+
+### RosterCell Component with micPosition grouped
+
+<ThemeProvider theme={lightTheme}>
+  <Flex container layout="fill-space-centered" css="height: 5%;">
+    <Flex css="width: 100%; max-width: 280px;">
+      <RosterCell
+        name="Stanley Hudson"
+        subtitle="Manager"
+        muted={true}
+        videoEnabled={false}
+        sharingContent={false}
+        micPosition={"grouped"}
+      />
+    </Flex>
+  </Flex>
+</ThemeProvider>
+
+```jsx
+<RosterCell
+  name="Stanley Hudson"
+  subtitle="Manager"
+  muted={true}
+  videoEnabled={true}
+  sharingContent={false}
+  micPosition={"grouped"}
+/>
+```
+
+### RosterCell Props
+<Props of={RosterCell} />

--- a/src/components/ui/Roster/Roster.stories.tsx
+++ b/src/components/ui/Roster/Roster.stories.tsx
@@ -9,9 +9,16 @@ import Roster from './';
 import RosterGroup from './RosterGroup';
 import RosterCell from './RosterCell';
 import RosterHeader from './RosterHeader';
+import RosterDocs from './Roster.mdx';
 
 export default {
-  title: 'UI Components/Roster'
+  title: 'UI Components/Roster',
+  parameters: {
+    docs: {
+      page: RosterDocs.parameters.docs.page().props.children.type
+    }
+  },
+  component: Roster
 };
 
 const Menu = () => (

--- a/src/components/ui/Roster/RosterCell/index.tsx
+++ b/src/components/ui/Roster/RosterCell/index.tsx
@@ -13,15 +13,25 @@ import { PopOverMenu } from '../PopOverMenu';
 type MicPosition = 'leading' | 'grouped';
 
 export interface RosterCellProps extends BaseProps {
+  /** Primary name in roster cell */
   name: string;
+  /** Subtitle for the primary name */
   subtitle?: string;
+  /** Late message */
   runningLate?: string;
+  /** Mic's position defined by type MicPosition either 'leading' or 'grouped' */
   micPosition?: MicPosition;
+  /** Whether or not the user is muted */
   muted?: boolean;
+  /** Whether or not the user has enabled the local video */
   videoEnabled?: boolean;
+  /** Whether or not the user is sharing content */
   sharingContent?: boolean;
+  /** Whether or not the user is having poor connection*/
   poorConnection?: boolean;
+  /** PopOver menu for more options */
   menu?: React.ReactNode;
+  /** Label for PopOverMenu, by default it is an empty string */
   a11yMenuLabel?: string;
 }
 

--- a/src/components/ui/Roster/RosterGroup.tsx
+++ b/src/components/ui/Roster/RosterGroup.tsx
@@ -10,7 +10,9 @@ import { BaseProps } from '../Base';
 import { StyledGroupWrapper, StyledGroup, StyledTitle } from './Styled';
 
 interface Props extends BaseProps {
+  /** Title of the Roster group */
   title?: string;
+  /** Number of attendees under one roster group*/
   badge?: number;
 }
 

--- a/src/components/ui/Roster/RosterHeader.tsx
+++ b/src/components/ui/Roster/RosterHeader.tsx
@@ -13,12 +13,19 @@ import { BaseProps } from '../Base';
 import { PopOverMenu } from './PopOverMenu';
 
 interface RosterHeaderProps extends BaseProps {
+  /** Title of the Roster header */
   title: string;
+  /** Number of attendees */
   badge?: number;
+  /** String value to search in Roster */
   searchValue?: string;
+  /** Callback fired on search value change */
   onSearch?: (e: ChangeEvent<HTMLInputElement>) => void;
+  /** Callback fired when Roster is closed */
   onClose?: () => void;
+  /** PopOver menu for more options*/
   menu?: React.ReactNode;
+  /** PopOver menu label */
   a11yMenuLabel?: string;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,8 +75,8 @@ export {
   useModalContext
 } from './components/ui/Modal/ModalContext';
 export {
-  useNotificationStateContext,
-  useNotificationDispatchContext
+  useNotificationState,
+  useNotificationDispatch
 } from './providers/NotificationProvider';
 export { AudioVideoContext } from './providers/AudioVideoProvider';
 
@@ -131,6 +131,10 @@ export { VideoQuality } from './hooks/sdk/useSelectVideoQuality';
 
 // enums
 export { MeetingStatus } from './providers/MeetingStatusProvider';
+export { Severity, ActionType } from './providers/NotificationProvider';
 
 // Class
 export { MeetingManager } from './providers/MeetingProvider/MeetingManager';
+
+// Interface
+export { NotificationType, Action } from './providers/NotificationProvider';

--- a/src/providers/NotificationProvider/docs/NotificationProvider.stories.mdx
+++ b/src/providers/NotificationProvider/docs/NotificationProvider.stories.mdx
@@ -1,0 +1,80 @@
+<Meta title="UI Providers/NotificationProvider" />
+
+# NotificationProvider
+
+Provides state and react dispatch method for building NotificationGroup like component.
+
+## Provides
+
+Internally uses `useReducer` hook from React to provide a state and a dispatch method to update this state.
+
+### State
+```javascript
+[{
+  // uuid generated while adding the notification to state array
+  id?: string;
+
+  // Notification Severity controlled by Seveirty enum
+  severity?: Severity;
+
+  // Message to show in notification
+  message?: string;
+
+  // Whether or not the notification should autoclose
+  autoClose?: boolean;
+
+  // Auto close delay in milliseconds, default delay is 6000 (6s)
+  autoCloseDelay?: number;
+
+  // Whether or not the current notification array (state) be emptied
+  replaceAll?: boolean;
+}]
+```
+
+You can access the state using `useNotificationState` hook.
+
+### Dispatch Method
+```javascript
+dispatch: React.Dispatch<Action>
+```
+You can access the dispatch method using `useNotificationDispatch` hook.
+
+## Usage
+
+```jsx
+import React from 'react';
+import { 
+  NotificationProvider, 
+  useNotificationState,
+  useNotificationDispatch,
+  Notification
+ } from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <NotificationProvider>
+    <NotificationGroup />
+  </NotificationProvider>
+);
+
+const NotificationGroup = () => {
+
+  const { notifications } = useNotificationState();
+  const dispatch = useNotificationDispatch();
+
+  const notificationItems = {notifications.map(({ id, ...rest }): any => (
+    <Notification
+      key={id}
+      {...rest}
+      onClose={() => dispatch({ type: ActionType.REMOVE, payload: id })}
+    />
+  ))};
+
+  return (
+    <>
+      {notificationItems}
+    </>
+  )
+}
+```
+
+**Note**: Check [useNotificationState](/?path=/docs/ui-hooks-notification-usenotificationstate--page) and [useNotificationDispatch](/?path=/docs/ui-hooks-notification-usenotificationdispatch--page) for more information.

--- a/src/providers/NotificationProvider/docs/useNotificationDispatch.stories.mdx
+++ b/src/providers/NotificationProvider/docs/useNotificationDispatch.stories.mdx
@@ -1,0 +1,81 @@
+<Meta title="UI Hooks/Notification/useNotificationDispatch" />
+
+# useNotificationDispatch
+
+Returns the Dispatch method from React to handle updates to `NotificationProvider` state.
+
+The action type that can be dispatched using the returned dispatch method is controlled by `Action` interface.
+
+### Action interface
+```javascript
+interface Action {
+  type: ActionType;
+  payload?: any;
+};
+
+enum ActionType {
+  ADD,
+  REMOVE,
+  REMOVE_ALL,
+};
+```
+
+
+
+### Return value
+
+```javascript
+React.Dispatch<Action>
+```
+
+## Importing
+
+```javascript
+import { useNotificationDispatch } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+The hook depends on the `NotificationProvider` being rendered.
+
+```jsx
+import React from 'react';
+import {
+  NotificationProvider,
+  useNotificationDispatch,
+  NotificationGroup
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <NotificationProvider>
+    <NotificationGroup />
+    <AddNotificationButton />
+  </NotificationProvider>
+);
+
+const AddNotificationButton = () => {
+  const dispatch = useNotificationDispatch();
+
+  const payload: any = {
+    severity: Severity.INFO,
+    message:'Information'
+  };
+
+  const addNotification = (e: any) => {
+    dispatch({
+      type: ActionType.ADD,
+      payload: payload
+    });
+  }
+
+  return (
+    <button  onClick={addNotification}>
+      {label}
+    </button>
+  );
+};
+```
+
+### Dependencies
+
+- `NotificationProvider`

--- a/src/providers/NotificationProvider/docs/useNotificationState.stories.mdx
+++ b/src/providers/NotificationProvider/docs/useNotificationState.stories.mdx
@@ -1,0 +1,67 @@
+<Meta title="UI Hooks/Notification/useNotificationState" />
+
+# useNotificationState
+
+Returns the state for developing `NotificationGroup` like component. 
+
+### Return value
+
+```javascript
+{
+ notifications: [{
+  id?: string;
+  severity?: Severity;
+  message?: string;
+  autoClose?: boolean;
+  autoCloseDelay?: number;
+  replaceAll?: boolean;
+ }]
+}
+```
+
+## Importing
+
+```javascript
+import { useNotificationState } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+The hook depends on the `NotificationProvider` being rendered.
+
+```jsx
+import React from 'react';
+import { NotificationProvider, useNotificationState, NotificationGroup } from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <NotificationProvider>
+    <MyChild />
+  </NotificationProvider>
+);
+
+const MyChild = () => {
+
+  const { notifications } = useNotificationState();
+  const dispatch = useNotificationDispatch();
+
+  const notificationItems = {notifications.map(({ id, ...rest }): any => (
+    <Notification
+      key={id}
+      {...rest}
+      onClose={() => dispatch({ type: ActionType.REMOVE, payload: id })}
+    />
+  ))};
+
+  return (
+    <NotificationGroup>
+      {notificationItems}
+    </NotificationGroup>
+  )
+}
+```
+
+Note: Check `ActionType` information in `useNotificationDispatch` [documentation](/?path=/docs/ui-hooks-notification-usenotificationdispatch--page).
+
+### Dependencies
+
+- `NotificationProvider`

--- a/src/providers/NotificationProvider/index.tsx
+++ b/src/providers/NotificationProvider/index.tsx
@@ -25,21 +25,22 @@ const NotificationProvider: React.FC = ({ children }) => {
   );
 }
 
-const useNotificationStateContext = () => {
+const useNotificationState = () => {
   const state = useContext(StateContext);
   return state;
 }
 
-const useNotificationDispatchContext = () => {
+const useNotificationDispatch = () => {
   const dispatch = useContext(DispatchContext);
   return dispatch;
 }
 
 export {
   NotificationProvider,
-  useNotificationStateContext,
-  useNotificationDispatchContext,
+  useNotificationState,
+  useNotificationDispatch,
   Severity, 
   NotificationType,
   ActionType,
+  Action
 };

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -13,6 +13,6 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '0.1.15';
+    return '0.1.16';
   }
 }

--- a/tst/components/ui/NotificationGroup/index.test.tsx
+++ b/tst/components/ui/NotificationGroup/index.test.tsx
@@ -8,10 +8,10 @@ import { render, cleanup, fireEvent, within, waitFor } from '@testing-library/re
 import { renderWithTheme } from '../../../test-helpers';
 import lightTheme from '../../../../src/theme/light';
 import NotificationGroup from '../../../../src/components/ui/NotificationGroup'
-import { NotificationProvider, Severity, useNotificationDispatchContext, ActionType } from '../../../../src/providers/NotificationProvider';
+import { NotificationProvider, Severity, useNotificationDispatch, ActionType } from '../../../../src/providers/NotificationProvider';
 
 const StorybookTestButton = ({ label, payload }: any) => {
-  const dispatch = useNotificationDispatchContext();
+  const dispatch = useNotificationDispatch();
   const addNotification = (e: any) => {
     dispatch({
       type: ActionType.ADD,


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
- Add docs for Navbar, Roster and Notification components along with NotificationProvider and corresponding hooks
- Add notification `Severity`, `ActionType` enums to index exports
- Add notification `NotificationType`, `Action` interfaces to index exports

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Locally in Storybook UI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
