### PR TITLE
Provide fallbacks when no devices are found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Desktop only] Integrate navbar, roster toggle in demo
 - Take callback for fetching attendees. Take in meeting/attendee info for joining meeting
 - Update Home view index file name
+- Provide fallback message when no devices are found
 
 ### Removed
 

--- a/demo/meeting/src/containers/Navigation/index.tsx
+++ b/demo/meeting/src/containers/Navigation/index.tsx
@@ -6,7 +6,6 @@ import React from 'react';
 import {
   Navbar,
   NavbarHeader,
-  Flex,
   NavbarItem,
   Attendees
 } from 'amazon-chime-sdk-component-library-react';
@@ -17,15 +16,13 @@ const Navigation = () => {
   return (
     <Navbar className="nav" flexDirection="column" container>
       <NavbarHeader title="Navigation" onClose={closeNavbar} />
-      <Flex>
-        {toggleRoster && (
-          <NavbarItem
-            icon={<Attendees />}
-            onClick={toggleRoster}
-            label="Attendees"
-          />
-        )}
-      </Flex>
+      {toggleRoster && (
+        <NavbarItem
+          icon={<Attendees />}
+          onClick={toggleRoster}
+          label="Attendees"
+        />
+      )}
     </Navbar>
   );
 };

--- a/src/components/sdk/DeviceSelection/CameraSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/CameraSelection/index.tsx
@@ -14,7 +14,13 @@ import DeviceInput from '../DeviceInput';
 
 import { title } from '../Styled';
 
-const CameraSelection = () => {
+interface Props {
+  notFoundMsg?: string;
+}
+
+const CameraSelection: React.FC<Props> = ({
+  notFoundMsg = 'No camera devices found'
+}) => {
   const meetingManager = useMeetingManager();
   const { devices } = useVideoInputs();
 
@@ -31,6 +37,7 @@ const CameraSelection = () => {
         label="Camera source"
         onChange={selectVideoInput}
         devices={devices}
+        notFoundMsg={notFoundMsg}
       />
       <QualitySelection />
       <Label style={{ display: 'block', marginBottom: '.5rem' }}>

--- a/src/components/sdk/DeviceSelection/DeviceInput.tsx
+++ b/src/components/sdk/DeviceSelection/DeviceInput.tsx
@@ -10,17 +10,32 @@ import { DeviceType } from '../../../types';
 
 interface Props {
   label: string;
+  notFoundMsg: string;
   devices: DeviceType[];
   onChange: (deviceId: string) => void;
 }
 
-const DeviceInput: React.FC<Props> = ({ onChange, label, devices }) => {
+const DeviceInput: React.FC<Props> = ({
+  onChange,
+  label,
+  devices,
+  notFoundMsg
+}) => {
   const [selectedDevice, setSelectedDevice] = useState('');
 
-  const selectOptions = devices.map(device => ({
+  const outputOptions = devices.map(device => ({
     value: device.deviceId,
     label: device.label
   }));
+
+  const options = outputOptions.length
+    ? outputOptions
+    : [
+        {
+          value: 'not-available',
+          label: notFoundMsg
+        }
+      ];
 
   useEffect(() => {
     if (!devices.length || selectedDevice) {
@@ -32,6 +47,11 @@ const DeviceInput: React.FC<Props> = ({ onChange, label, devices }) => {
 
   async function selectDevice(e: ChangeEvent<HTMLSelectElement>) {
     const deviceId = e.target.value;
+
+    if (deviceId === 'not-available') {
+      return;
+    }
+
     setSelectedDevice(deviceId);
     onChange(deviceId);
   }
@@ -40,7 +60,7 @@ const DeviceInput: React.FC<Props> = ({ onChange, label, devices }) => {
     <StyledInputGroup>
       <FormField
         field={Select}
-        options={selectOptions}
+        options={options}
         onChange={selectDevice}
         value={selectedDevice}
         label={label}

--- a/src/components/sdk/DeviceSelection/MicSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/MicSelection/index.tsx
@@ -11,7 +11,13 @@ import AudioActivityPreview from './AudioActivityPreview';
 
 import { title } from '../Styled';
 
-const MicSelection = () => {
+interface Props {
+  notFoundMsg?: string;
+}
+
+const MicSelection: React.FC<Props> = ({
+  notFoundMsg = 'No microphone devices found'
+}) => {
   const meetingManager = useMeetingManager();
   const { devices } = useAudioInputs();
 
@@ -28,6 +34,7 @@ const MicSelection = () => {
         label="Microphone source"
         onChange={selectAudioInput}
         devices={devices}
+        notFoundMsg={notFoundMsg}
       />
       <AudioActivityPreview />
     </div>

--- a/src/components/sdk/DeviceSelection/SpeakerSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/SpeakerSelection/index.tsx
@@ -9,7 +9,13 @@ import { useAudioOutputs } from '../../../../providers/DevicesProvider';
 import TestSound from '../../../../../demo/meeting/src/utils/TestSound';
 import DeviceInput from '../DeviceInput';
 
-const SpeakerSelection = () => {
+interface Props {
+  notFoundMsg?: string;
+}
+
+const SpeakerSelection: React.FC<Props> = ({
+  notFoundMsg = 'No speaker devices found'
+}) => {
   const meetingManager = useMeetingManager();
   const { devices } = useAudioOutputs();
   const [selectedOutput, setSelectedOutput] = useState('');
@@ -37,6 +43,7 @@ const SpeakerSelection = () => {
         label="Speaker source"
         devices={devices}
         onChange={selectAudioOutput}
+        notFoundMsg={notFoundMsg}
       />
       <SecondaryButton label="Test speakers" onClick={handleTestSpeaker} />
     </div>

--- a/src/components/sdk/MeetingControls/AudioOutputControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioOutputControl.tsx
@@ -32,7 +32,7 @@ const AudioOutputControl: React.FC = () => {
         icon={<Sound disabled={!isAudioOn} />}
         onClick={toggleAudio}
         label="Audio"
-        popOver={dropdownOptions}
+        popOver={dropdownOptions.length ? dropdownOptions : null}
       />
     </>
   );


### PR DESCRIPTION
**Description of changes:**
- Don't render a dropdown when we don't have any devices for the audio output selector
- Show a no devices found message in all device selection form fields instead of an empty field

**Testing**

1. Have you successfully run `npm run build:release` locally?
2. How did you test these changes?
manually

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
