### PR TITLE
Add docs and make SDK DeviceSelection components re-usable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add notification `NotificationType`, `Action` interfaces to index exports
 - Add docs for `MeetingControls`
 - Add introduction documentation
+- Add styles around `DeviceSelection` in demo
+- Add documentation around `DeviceSelection` and `useAudioInputActivityPreview` hook
 
 ### Changed
 
@@ -94,6 +96,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Provide fallback message when no devices are found
 - Rename `NotificationProvider` hooks
 - Update publish github action to deploy storybook documentation
+- Remake `AudioActivityPreview` into `useLocalAudioInputActivityPreview` hook
+- Refactor styles from SDK Component `DeviceSelection` and move them to demo
+- Moved `ActivityBar` from library to demo, since it seemed more tightly related our demo
 
 ### Removed
 

--- a/demo/meeting/src/components/ActivityBar/index.tsx
+++ b/demo/meeting/src/components/ActivityBar/index.tsx
@@ -27,4 +27,6 @@ const ActivityBar = React.forwardRef((props, ref: any) => (
   </Track>
 ));
 
+ActivityBar.displayName = 'MicrophoneActivityBar';
+
 export default ActivityBar;

--- a/demo/meeting/src/components/DeviceSelection/CameraDevices/index.tsx
+++ b/demo/meeting/src/components/DeviceSelection/CameraDevices/index.tsx
@@ -1,0 +1,35 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import {
+  Heading,
+  PreviewVideo,
+  QualitySelection,
+  CameraSelection,
+  Label
+} from 'amazon-chime-sdk-component-library-react';
+
+import { title, StyledInputGroup } from '../Styled';
+
+const CameraDevices = () => {
+  return (
+    <div>
+      <Heading tag="h2" level={6} css={title}>
+        Video
+      </Heading>
+      <StyledInputGroup>
+        <CameraSelection />
+      </StyledInputGroup>
+      <StyledInputGroup>
+        <QualitySelection />
+      </StyledInputGroup>
+      <Label style={{ display: 'block', marginBottom: '.5rem' }}>
+        Video preview
+      </Label>
+      <PreviewVideo />
+    </div>
+  );
+};
+
+export default CameraDevices;

--- a/demo/meeting/src/components/DeviceSelection/MicrophoneDevices/MicrophoneActivityPreview.tsx
+++ b/demo/meeting/src/components/DeviceSelection/MicrophoneDevices/MicrophoneActivityPreview.tsx
@@ -1,0 +1,21 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { Label } from 'amazon-chime-sdk-component-library-react';
+
+import { StyledPreviewGroup } from '../Styled';
+import MicrophoneActivityPreviewBar from './MicrophoneActivityPreviewBar';
+
+const MicrophoneActivityPreview = () => {
+  return (
+    <StyledPreviewGroup>
+      <Label style={{ display: 'block', marginBottom: '.5rem' }}>
+        Microphone activity
+      </Label>
+      <MicrophoneActivityPreviewBar />
+    </StyledPreviewGroup>
+  );
+};
+
+export default MicrophoneActivityPreview;

--- a/demo/meeting/src/components/DeviceSelection/MicrophoneDevices/MicrophoneActivityPreviewBar.tsx
+++ b/demo/meeting/src/components/DeviceSelection/MicrophoneDevices/MicrophoneActivityPreviewBar.tsx
@@ -1,0 +1,16 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useRef } from 'react';
+import { useLocalAudioInputActivityPreview } from 'amazon-chime-sdk-component-library-react';
+
+import ActivityBar from '../../ActivityBar';
+
+const MicrophoneActivityPreviewBar = () => {
+  const activityBarRef = useRef<HTMLDivElement>();
+  useLocalAudioInputActivityPreview(activityBarRef);
+
+  return <ActivityBar ref={activityBarRef} />;
+};
+
+export default MicrophoneActivityPreviewBar;

--- a/demo/meeting/src/components/DeviceSelection/MicrophoneDevices/index.tsx
+++ b/demo/meeting/src/components/DeviceSelection/MicrophoneDevices/index.tsx
@@ -1,0 +1,25 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import {
+  Heading,
+  MicSelection
+} from 'amazon-chime-sdk-component-library-react';
+
+import { title } from '../Styled';
+import MicrophoneActivityPreview from './MicrophoneActivityPreview';
+
+const MicrophoneDevices = () => {
+  return (
+    <div>
+      <Heading tag="h2" level={6} css={title}>
+        Audio
+      </Heading>
+      <MicSelection />
+      <MicrophoneActivityPreview />
+    </div>
+  );
+};
+
+export default MicrophoneDevices;

--- a/demo/meeting/src/components/DeviceSelection/SpeakerDevices/index.tsx
+++ b/demo/meeting/src/components/DeviceSelection/SpeakerDevices/index.tsx
@@ -1,0 +1,31 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useState } from 'react';
+import {
+  SpeakerSelection,
+  SecondaryButton
+} from 'amazon-chime-sdk-component-library-react';
+
+import TestSound from '../../../utils/TestSound';
+
+const SpeakerDevices = () => {
+  const [selectedOutput, setSelectedOutput] = useState('');
+
+  const handleChange = (deviceId: string): void => {
+    setSelectedOutput(deviceId);
+  };
+
+  const handleTestSpeaker = () => {
+    new TestSound(selectedOutput);
+  };
+
+  return (
+    <div>
+      <SpeakerSelection onChange={handleChange} />
+      <SecondaryButton label="Test speakers" onClick={handleTestSpeaker} />
+    </div>
+  );
+};
+
+export default SpeakerDevices;

--- a/demo/meeting/src/components/DeviceSelection/Styled.tsx
+++ b/demo/meeting/src/components/DeviceSelection/Styled.tsx
@@ -3,6 +3,16 @@
 
 import styled from 'styled-components';
 
+export const title = `
+  text-transform: uppercase;
+  font-size: 1rem !important;
+  margin-bottom: 1.75rem;
+`;
+
+export const StyledPreviewGroup = styled.div`
+  margin-bottom: 2.5rem;
+`;
+
 export const StyledWrapper = styled.div`
   position: relative;
   display: flex;
@@ -50,25 +60,4 @@ export const StyledVideoGroup = styled.div`
 
 export const StyledInputGroup = styled.div`
   margin-bottom: 1.5rem;
-`;
-
-export const StyledVideoPreview = styled.video`
-  width: 100%;
-  height: auto;
-  border-radius: 0.1875rem;
-  background-color: #1c1c1c;
-`;
-
-export const StyledPreviewGroup = styled.div`
-  margin-bottom: 2.5rem;
-`;
-
-export const title = `
-  text-transform: uppercase;
-  font-size: 1rem !important;
-  margin-bottom: 1.75rem;
-`;
-
-export const inputGroup = `
-  margin-bottom: 1.25rem;
 `;

--- a/demo/meeting/src/components/DeviceSelection/index.tsx
+++ b/demo/meeting/src/components/DeviceSelection/index.tsx
@@ -1,0 +1,23 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+
+import { StyledWrapper, StyledAudioGroup, StyledVideoGroup } from './Styled';
+import MicrophoneDevices from './MicrophoneDevices';
+import SpeakerDevices from './SpeakerDevices';
+import CameraDevices from './CameraDevices';
+
+const DeviceSelection = () => (
+  <StyledWrapper>
+    <StyledAudioGroup>
+      <MicrophoneDevices />
+      <SpeakerDevices />
+    </StyledAudioGroup>
+    <StyledVideoGroup>
+      <CameraDevices />
+    </StyledVideoGroup>
+  </StyledWrapper>
+);
+
+export default DeviceSelection;

--- a/demo/meeting/src/containers/Navigation/index.tsx
+++ b/demo/meeting/src/containers/Navigation/index.tsx
@@ -9,6 +9,7 @@ import {
   NavbarItem,
   Attendees
 } from 'amazon-chime-sdk-component-library-react';
+
 import { useNavigation } from '../../providers/NavigationProvider';
 
 const Navigation = () => {

--- a/demo/meeting/src/containers/SIPMeeting/index.tsx
+++ b/demo/meeting/src/containers/SIPMeeting/index.tsx
@@ -12,9 +12,7 @@ import Card from '../../components/Card';
 import SIPURI from '../SIPURI';
 import SIPMeetingForm from '../../components/SIPMeetingForm';
 import { getErrorContext } from '../../providers/ErrorProvider';
-import {
-  useSIPMeetingManager
-} from '../../providers/SIPMeetingProvider';
+import { useSIPMeetingManager } from '../../providers/SIPMeetingProvider';
 
 const SIPMeeting: React.FC = () => {
   const [sipURI, setSipURI] = useState('');

--- a/demo/meeting/src/views/DeviceSetup/index.tsx
+++ b/demo/meeting/src/views/DeviceSetup/index.tsx
@@ -2,14 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import {
-  Heading,
-  DeviceSelection,
-} from 'amazon-chime-sdk-component-library-react';
+import { Heading } from 'amazon-chime-sdk-component-library-react';
 
 import JoinMeetingDetails from '../../containers/MeetingJoinDetails';
-
 import { StyledLayout } from './Styled';
+import DeviceSelection from '../../components/DeviceSelection';
 
 const DeviceSetup: React.FC = () => (
   <StyledLayout>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-component-library-react",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-component-library-react",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Amazon Chime SDK Component Library - React",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",

--- a/src/components/sdk/DeviceSelection/CameraSelection/QualitySelection.tsx
+++ b/src/components/sdk/DeviceSelection/CameraSelection/QualitySelection.tsx
@@ -6,10 +6,7 @@ import React, { useState, ChangeEvent } from 'react';
 import { FormField } from '../../../ui/FormField';
 import { Select } from '../../../ui/Select';
 import { useSelectVideoQuality, VideoQuality } from '../../../../hooks/sdk/useSelectVideoQuality';
-
 import { VIDEO_INPUT_QUALITY } from '../../../../constants';
-
-import { StyledInputGroup } from '../Styled';
 
 const qualityOptions = [
   {
@@ -30,7 +27,7 @@ const qualityOptions = [
   }
 ];
 
-const QualitySelection = () => {
+export const QualitySelection = () => {
   const selectVideoQuality = useSelectVideoQuality();
   const [videoQuality, setVideoQuality] = useState('unselected');
 
@@ -41,15 +38,13 @@ const QualitySelection = () => {
   }
 
   return (
-    <StyledInputGroup>
-      <FormField
-        field={Select}
-        options={qualityOptions}
-        onChange={selectQuality}
-        value={videoQuality}
-        label="Video quality"
-      />
-    </StyledInputGroup>
+    <FormField
+      field={Select}
+      options={qualityOptions}
+      onChange={selectQuality}
+      value={videoQuality}
+      label="Video quality"
+    />
   );
 };
 

--- a/src/components/sdk/DeviceSelection/CameraSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/CameraSelection/index.tsx
@@ -3,22 +3,16 @@
 
 import React from 'react';
 
-import { Heading } from '../../../ui/Heading';
-import { Label } from '../../../ui/Label';
 import { useMeetingManager } from '../../../../providers/MeetingProvider';
 import { useVideoInputs } from '../../../../providers/DevicesProvider';
-import PreviewVideo from '../../PreviewVideo';
-
-import QualitySelection from './QualitySelection';
 import DeviceInput from '../DeviceInput';
 
-import { title } from '../Styled';
-
 interface Props {
+  /** Message shown when no camera devices are found */
   notFoundMsg?: string;
 }
 
-const CameraSelection: React.FC<Props> = ({
+export const CameraSelection: React.FC<Props> = ({
   notFoundMsg = 'No camera devices found'
 }) => {
   const meetingManager = useMeetingManager();
@@ -29,22 +23,12 @@ const CameraSelection: React.FC<Props> = ({
   }
 
   return (
-    <div>
-      <Heading tag="h2" level={6} css={title}>
-        Video
-      </Heading>
-      <DeviceInput
-        label="Camera source"
-        onChange={selectVideoInput}
-        devices={devices}
-        notFoundMsg={notFoundMsg}
-      />
-      <QualitySelection />
-      <Label style={{ display: 'block', marginBottom: '.5rem' }}>
-        Video preview
-      </Label>
-      <PreviewVideo />
-    </div>
+    <DeviceInput
+      label="Camera source"
+      onChange={selectVideoInput}
+      devices={devices}
+      notFoundMsg={notFoundMsg}
+    />
   );
 };
 

--- a/src/components/sdk/DeviceSelection/DeviceInput.tsx
+++ b/src/components/sdk/DeviceSelection/DeviceInput.tsx
@@ -5,7 +5,6 @@ import React, { useState, useEffect, ChangeEvent } from 'react';
 
 import { FormField } from '../../ui/FormField';
 import { Select } from '../../ui/Select';
-import { StyledInputGroup } from './Styled';
 import { DeviceType } from '../../../types';
 
 interface Props {
@@ -57,15 +56,13 @@ const DeviceInput: React.FC<Props> = ({
   }
 
   return (
-    <StyledInputGroup>
-      <FormField
-        field={Select}
-        options={options}
-        onChange={selectDevice}
-        value={selectedDevice}
-        label={label}
-      />
-    </StyledInputGroup>
+    <FormField
+      field={Select}
+      options={options}
+      onChange={selectDevice}
+      value={selectedDevice}
+      label={label}
+    />
   );
 };
 

--- a/src/components/sdk/DeviceSelection/MicSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/MicSelection/index.tsx
@@ -3,19 +3,16 @@
 
 import React from 'react';
 
-import { Heading } from '../../../ui/Heading';
 import { useMeetingManager } from '../../../../providers/MeetingProvider';
 import { useAudioInputs } from '../../../../providers/DevicesProvider';
 import DeviceInput from '../DeviceInput';
-import AudioActivityPreview from './AudioActivityPreview';
-
-import { title } from '../Styled';
 
 interface Props {
+  /** Message shown when no microphone devices are found */
   notFoundMsg?: string;
 }
 
-const MicSelection: React.FC<Props> = ({
+export const MicSelection: React.FC<Props> = ({
   notFoundMsg = 'No microphone devices found'
 }) => {
   const meetingManager = useMeetingManager();
@@ -26,18 +23,12 @@ const MicSelection: React.FC<Props> = ({
   }
 
   return (
-    <div>
-      <Heading tag="h2" level={6} css={title}>
-        Audio
-      </Heading>
-      <DeviceInput
-        label="Microphone source"
-        onChange={selectAudioInput}
-        devices={devices}
-        notFoundMsg={notFoundMsg}
-      />
-      <AudioActivityPreview />
-    </div>
+    <DeviceInput
+      label="Microphone source"
+      onChange={selectAudioInput}
+      devices={devices}
+      notFoundMsg={notFoundMsg}
+    />
   );
 };
 

--- a/src/components/sdk/DeviceSelection/SpeakerSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/SpeakerSelection/index.tsx
@@ -3,18 +3,20 @@
 
 import React, { useState, useEffect } from 'react';
 
-import { SecondaryButton } from '../../../ui/Button/SecondaryButton';
 import { useMeetingManager } from '../../../../providers/MeetingProvider';
 import { useAudioOutputs } from '../../../../providers/DevicesProvider';
-import TestSound from '../../../../../demo/meeting/src/utils/TestSound';
 import DeviceInput from '../DeviceInput';
 
 interface Props {
+  /** Message shown when no audio output speaker devices are found */
   notFoundMsg?: string;
+  /** Callback fired on selection change, needed if you want to add testing functionality around speaker selection  */
+  onChange?: (selectedAudioOutputDeviceId: string) => void;
 }
 
-const SpeakerSelection: React.FC<Props> = ({
-  notFoundMsg = 'No speaker devices found'
+export const SpeakerSelection: React.FC<Props> = ({
+  notFoundMsg = 'No speaker devices found',
+  onChange
 }) => {
   const meetingManager = useMeetingManager();
   const { devices } = useAudioOutputs();
@@ -28,25 +30,19 @@ const SpeakerSelection: React.FC<Props> = ({
     setSelectedOutput(devices[0].deviceId);
   }, [selectedOutput, devices]);
 
-  const handleTestSpeaker = () => {
-    new TestSound(selectedOutput);
-  };
-
   async function selectAudioOutput(deviceId: string) {
     setSelectedOutput(deviceId);
     meetingManager.selectAudioOutputDevice(deviceId);
+    onChange && onChange(deviceId);
   }
 
   return (
-    <div>
-      <DeviceInput
-        label="Speaker source"
-        devices={devices}
-        onChange={selectAudioOutput}
-        notFoundMsg={notFoundMsg}
-      />
-      <SecondaryButton label="Test speakers" onClick={handleTestSpeaker} />
-    </div>
+    <DeviceInput
+      label="Speaker source"
+      devices={devices}
+      onChange={selectAudioOutput}
+      notFoundMsg={notFoundMsg}
+    />
   );
 };
 

--- a/src/components/sdk/DeviceSelection/docs/CameraSelection.stories.mdx
+++ b/src/components/sdk/DeviceSelection/docs/CameraSelection.stories.mdx
@@ -1,0 +1,44 @@
+import { Props } from '@storybook/addon-docs/blocks';
+import CameraSelection from '../CameraSelection';
+
+<Meta title="SDK Components/DeviceSelection/Camera/CameraSelection" />
+
+# CameraSelection
+Renders a `Select FormField` component with video input source options provided by the `useVideoInputs` hook.
+
+By default, the first device is selected from the devices returned by `useVideoInputs` hook, otherwise a single option with not found message is shown.
+
+The component depends on the `DevicesProvider`. If you are using `MeetingProvider`, `DevicesProvider` is rendered by default.
+
+## Importing
+```javascript
+import { CameraSelection } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+```jsx
+import React from 'react';
+import { 
+  MeetingProvider,
+  CameraSelection
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => {
+  return (
+    <MeetingProvider>
+      <CameraSelection />
+    </MeetingProvider>
+  );
+}
+```
+
+## Props
+<Props of={CameraSelection} />
+
+### Dependencies
+
+- `MeetingProvider`
+- `DevicesProvider`, If you are using `MeetingProvider`, `DevicesProvider` is rendered by default
+- `useVideoInputs`
+

--- a/src/components/sdk/DeviceSelection/docs/MicSelection.stories.mdx
+++ b/src/components/sdk/DeviceSelection/docs/MicSelection.stories.mdx
@@ -1,0 +1,43 @@
+import { Props } from '@storybook/addon-docs/blocks';
+import MicSelection from '../MicSelection';
+
+<Meta title="SDK Components/DeviceSelection/MicSelection" />
+
+# MicSelection
+Renders a `Select FormField` component with audio input source options provided by the `useAudioInputs` hook.
+
+By default, the first device is selected from the devices returned by `useAudioInputs` hook, otherwise a single option with not found message is shown.
+
+The component depends on the `DevicesProvider`. If you are using `MeetingProvider`, `DevicesProvider` is rendered by default.
+
+## Importing
+```javascript
+import { MicSelection } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+```jsx
+import React from 'react';
+import { 
+  MeetingProvider,
+  MicSelection
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => {
+  return (
+    <MeetingProvider>
+      <MicSelection />
+    </MeetingProvider>
+  );
+}
+```
+
+## Props
+<Props of={MicSelection} />
+
+### Dependencies
+
+- `MeetingProvider`
+- `DevicesProvider`, If you are using `MeetingProvider`, `DevicesProvider` is rendered by default
+- `useAudioInputs`

--- a/src/components/sdk/DeviceSelection/docs/QualitySelection.stories.mdx
+++ b/src/components/sdk/DeviceSelection/docs/QualitySelection.stories.mdx
@@ -1,0 +1,36 @@
+<Meta title="SDK Components/DeviceSelection/Camera/QualitySelection" />
+
+# QualitySelection
+Renders a `Select FormField` to select video input quality from '720p', '540p' and '360p'.
+
+The component depends on the `DevicesProvider`. If you are using `MeetingProvider`, `DevicesProvider` is rendered by default.
+
+## Importing
+```javascript
+import { QualitySelection } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+```jsx
+import React from 'react';
+import { 
+  MeetingProvider,
+  QualitySelection
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => {
+  return (
+    <MeetingProvider>
+      <QualitySelection />
+    </MeetingProvider>
+  );
+}
+```
+
+### Dependencies
+
+- `MeetingProvider`
+- `DevicesProvider`, If you are using `MeetingProvider`, `DevicesProvider` is rendered by default
+- `useSelectVideoQuality` - Uses `selectVideoQuality` to select the current video input quality
+

--- a/src/components/sdk/DeviceSelection/docs/SpeakerSelection.stories.mdx
+++ b/src/components/sdk/DeviceSelection/docs/SpeakerSelection.stories.mdx
@@ -1,0 +1,44 @@
+import { Props } from '@storybook/addon-docs/blocks';
+import SpeakerSelection from '../SpeakerSelection';
+
+<Meta title="SDK Components/DeviceSelection/SpeakerSelection" />
+
+# SpeakerSelection
+Renders a `Select FormField` with audio output source options provided by the `useAudioOutputs` hook.
+
+By default, the first device is selected from the devices returned by `useAudioOutputs` hook, otherwise a single option with not found message is shown.
+
+The component depends on the `DevicesProvider`. If you are using `MeetingProvider`, `DevicesProvider` is rendered by default.
+
+## Importing
+```javascript
+import { SpeakerSelection } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+```jsx
+import React from 'react';
+import { 
+  MeetingProvider,
+  SpeakerSelection
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => {
+  return (
+    <MeetingProvider>
+      <SpeakerSelection />
+    </MeetingProvider>
+  );
+}
+```
+
+## Props
+<Props of={SpeakerSelection} />
+
+### Dependencies
+
+- `MeetingProvider`
+- `DevicesProvider`, If you are using `MeetingProvider`, `DevicesProvider` is rendered by default
+- `useAudioOutputs`
+

--- a/src/components/sdk/DeviceSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/index.tsx
@@ -1,24 +1,14 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
-
 import SpeakerSelection from './SpeakerSelection';
 import MicSelection from './MicSelection';
 import CameraSelection from './CameraSelection';
+import QualitySelection from './CameraSelection/QualitySelection';
 
-import { StyledWrapper, StyledAudioGroup, StyledVideoGroup } from './Styled';
-
-export const DeviceSelection = () => (
-  <StyledWrapper>
-    <StyledAudioGroup>
-      <MicSelection />
-      <SpeakerSelection />
-    </StyledAudioGroup>
-    <StyledVideoGroup>
-      <CameraSelection />
-    </StyledVideoGroup>
-  </StyledWrapper>
-);
-
-export default DeviceSelection;
+export {
+  SpeakerSelection,
+  MicSelection,
+  CameraSelection,
+  QualitySelection
+}

--- a/src/hooks/sdk/docs/useLocalAudioInputAcitivityPreview.stories.mdx
+++ b/src/hooks/sdk/docs/useLocalAudioInputAcitivityPreview.stories.mdx
@@ -1,0 +1,51 @@
+<Meta title="SDK Hooks/useLocalAudioInputActivityPreview" />
+
+# useLocalAudioInputActivityPreview
+
+Applies scale transformation to the HTML element passed by reference showing the microphone activity from the currently selected audio input.
+You can use it to develop a microphone activity preview component.
+
+## Parameters
+
+Accepts two parameters:
+- `elementRef` (Reference to HTML element)
+- `scaleDirection` defined by `TransformScaleDirection` type, by default it is 'horizontal'
+
+`TransformScaleDirection` type
+```javascript
+type TransformScaleDirection = 'horizontal' | 'vertical';
+```
+
+## Importing
+
+```javascript
+import { useLocalAudioInputActivityPreview } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+The hook depends on the `AudioVideoProvider`. If you are using `MeetingProvider`, it is rendered by default.
+
+```jsx
+import React, { useRef } from 'react';
+import { MeetingProvider, useLocalAudioInputActivityPreview } from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <MeetingProvider>
+    <MicrophoneActivityPreview />
+  </MeetingProvider>
+);
+
+const MicrophoneActivityPreview = () => {
+  const elementRef = useRef<HTMLDivElement>();
+  useLocalAudioInputActivityPreview(elementRef);
+
+  return <div ref={activityBarRef}></div>;
+}
+```
+
+### Dependencies
+
+- `MeetingProvider`
+- `AudioVideoProvider`, If you are using `MeetingProvider`, `AudioVideoProvider` is rendered by default
+- `useAudioInputs`

--- a/src/hooks/sdk/useLocalAudioInputActivityPreview.tsx
+++ b/src/hooks/sdk/useLocalAudioInputActivityPreview.tsx
@@ -1,22 +1,20 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
-import { Label } from '../../../ui/Label';
-import { useAudioVideo } from '../../../../providers/AudioVideoProvider';
-import ActivityBar from '../../../ui/ActivityBar';
+import { useAudioVideo } from '../../providers/AudioVideoProvider';
+import { useAudioInputs } from '../../providers/DevicesProvider';
 
-import { StyledPreviewGroup } from '../Styled';
-import { useAudioInputs } from '../../../../providers/DevicesProvider';
+type TransformScaleDirection = 'horizontal' | 'vertical';
 
-const AudioActivityPreview = () => {
+export const useLocalAudioInputActivityPreview = (elementRef: any, scaleDirection: TransformScaleDirection = 'horizontal') => {
   const audioVideo = useAudioVideo();
-  const activityBarRef = useRef<HTMLDivElement>();
   const { selectedDevice } = useAudioInputs();
 
   useEffect(() => {
     const analyserNode = audioVideo?.createAnalyserNodeForAudioInput();
+    console.log('useLocalAudioInputActivityPreview', analyserNode)
 
     if (!analyserNode?.getByteTimeDomainData) {
       return;
@@ -40,8 +38,10 @@ const AudioActivityPreview = () => {
         }
         const decimal = (Math.log(lowest) - Math.log(max)) / Math.log(lowest);
 
-        if (activityBarRef.current && decimal >= 0) {
-          activityBarRef.current.style.transform = `scaleX(${decimal})`;
+        if (elementRef.current && decimal >= 0) {
+          elementRef.current.style.transform = scaleDirection === 'horizontal' 
+            ? `scaleX(${decimal})`
+            : `scaleY(${decimal})`;
         }
       }
       frameIndex = (frameIndex + 1) % 2;
@@ -57,15 +57,6 @@ const AudioActivityPreview = () => {
       isMounted = false;
     };
   }, [selectedDevice]);
-
-  return (
-    <StyledPreviewGroup>
-      <Label style={{ display: 'block', marginBottom: '.5rem' }}>
-        Microphone activity
-      </Label>
-      <ActivityBar ref={activityBarRef} />
-    </StyledPreviewGroup>
-  );
 };
 
-export default AudioActivityPreview;
+export default useLocalAudioInputActivityPreview;

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,12 @@ export { RosterGroup } from './components/ui/Roster/RosterGroup';
 export { RosterCell } from './components/ui/Roster/RosterCell';
 
 // SDK components
-export { DeviceSelection } from './components/sdk/DeviceSelection';
+export { 
+  CameraSelection,
+  MicSelection,
+  SpeakerSelection,
+  QualitySelection
+} from './components/sdk/DeviceSelection';
 export {
   AudioInputControl,
   AudioOutputControl,
@@ -57,6 +62,7 @@ export {
 } from './components/sdk/MeetingControls';
 export { ContentShare } from './components/sdk/ContentShare';
 export { LocalVideo } from './components/sdk/LocalVideo';
+export { PreviewVideo } from './components/sdk/PreviewVideo';
 export { RemoteVideo } from './components/sdk/RemoteVideo';
 export { RemoteVideos } from './components/sdk/RemoteVideos';
 export { FeaturedRemoteVideos } from './components/sdk/FeaturedRemoteVideos';
@@ -108,6 +114,7 @@ export {
   useContentShareControls
 } from './providers/ContentShareProvider';
 export { useMeetingStatus } from './providers/MeetingStatusProvider';
+export { useLocalAudioInputActivityPreview } from './hooks/sdk/useLocalAudioInputActivityPreview';
 
 // Providers
 export { NotificationProvider } from './providers/NotificationProvider';

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -13,6 +13,6 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '0.1.17';
+    return '0.1.18';
   }
 }


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
- Refactor styles from SDK Component `DeviceSelection` and move them to demo
- Remake `AudioActivityPreview` into `useAudioInputActivityPreview` hook
- Add documentation around `DeviceSelection` and `useAudioInputActivityPreview` hook
- Moved `ActivityBar` from library to demo, since it seemed more tightly related our demo.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? In Storybook locally for components and docs, demo in FF and Chrome

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
