### PR TITLE
Add documentation for modal component again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add styles around `DeviceSelection` in demo
 - Add documentation around `DeviceSelection` and `useAudioInputActivityPreview` hook
 - Add docs for all icon components
+- Added documentation for Modal component again, after being reverted
 
 ### Changed
 

--- a/src/components/ui/Modal/Modal.mdx
+++ b/src/components/ui/Modal/Modal.mdx
@@ -1,0 +1,68 @@
+import { Preview, Story, Props } from '@storybook/addon-docs/blocks';
+import { ThemeProvider } from 'styled-components';
+import { useState } from 'react';
+
+import Modal from './';
+import ModalHeader from './ModalHeader';
+import ModalBody from './ModalBody';
+import ModalButton from './ModalButton';
+import ModalButtonGroup from './ModalButtonGroup';
+import ModalContext from './ModalContext';
+import { ModalDemo } from './Modal.stories';
+import { lightTheme } from '../../../theme/';
+import PrimaryButton from '../Button/PrimaryButton';
+
+# Modal
+
+The Modal component renders as an overlay over the rest of the application. It may be closed on an outside click. While the modal is open, it will trap the user's focus.
+
+The modal itself is composed of other components including ModalHeader, ModalBody, ModalButtonGroup, and ModalButton. Other elements can also be included in the modal.
+
+## Importing
+
+```javascript
+import {
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalButtonGroup,
+  ModalButton
+} from 'amazon-chime-sdk-component-library-react';
+```
+
+## Example
+
+### Modal
+
+<ThemeProvider theme={lightTheme}>
+  <Preview>
+      <ModalDemo/>
+  </Preview>
+</ThemeProvider>
+
+```jsx
+{isOpen && <Modal size='md' onClose={() => setIsOpen(false)} rootId='modal-root'>
+  <ModalHeader title='Modal header'/>
+  <ModalBody>
+    <p>This is information presented in a modal</p>
+    <ModalButtonGroup
+      primaryButtons={[<ModalButton onClick={() => {}} label='submit' variant='primary' />]}
+      secondaryButtons={[<ModalButton onClick={() => {}} label='More info' variant='secondary' />]}
+    />
+  </ModalBody>
+</Modal>}
+```
+
+## Props
+
+### Modal
+<Props of={Modal}/>
+
+### ModalHeader
+<Props of={ModalHeader}/>
+
+### ModalButtonGroup
+<Props of={ModalButtonGroup}/>
+
+### ModalButton
+<Props of={ModalButton}/>

--- a/src/components/ui/Modal/Modal.stories.tsx
+++ b/src/components/ui/Modal/Modal.stories.tsx
@@ -13,9 +13,17 @@ import ModalBody from './ModalBody';
 import ModalButton from './ModalButton'
 import ModalButtonGroup from './ModalButtonGroup';
 import PrimaryButton from '../Button/PrimaryButton';
+import ModalDocs from './Modal.mdx';
 
 export default {
-  title: 'UI Components/Modal'
+  title: 'UI Components/Modal',
+  parameters: {
+    docs: {
+      page: ModalDocs.parameters.docs.page().props.children.type
+    }
+  },
+  component: Modal,
+  excludeStories: ['ModalDemo']
 };
 
 const options = [
@@ -141,4 +149,23 @@ export const largeContent = () => {
 
 largeContent.story = {
   name: 'Large content example',
+};
+
+export const ModalDemo = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <>
+      <PrimaryButton label='Open Modal' onClick={() => setIsOpen(true)} />
+      {isOpen && <Modal size='md' onClose={() => setIsOpen(false)} rootId='modal-root'>
+        <ModalHeader title='Modal header' displayClose={true} />
+        <ModalBody>
+          <p>This is information presented in a modal</p>
+          <ModalButtonGroup
+            primaryButtons={[<ModalButton onClick={() => {}} label='submit' variant='primary' />]}
+            secondaryButtons={[<ModalButton onClick={() => {}} label='More info' variant='secondary' />]}
+          />
+        </ModalBody>
+      </Modal>}
+    </>
+  );
 };


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Add storybook documentation for the modal components. Hopefully avoiding the `CSSProperties` error from before. 

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
