### PR TITLE
Fix issue when reselecting device in demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,5 +128,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug in verdaccio clean up
 - Fix demo application not allowing to select video / audio via popover
 - Fixed some demo layout issues
+- Fixed issue in demo when reselecting a device in the control bar
 
 ## [0.1.1] - 2020-06-16

--- a/src/providers/DevicesProvider/AudioInputProvider.tsx
+++ b/src/providers/DevicesProvider/AudioInputProvider.tsx
@@ -30,13 +30,12 @@ const AudioInputProvider: React.FC = ({ children }) => {
     const callback = (updatedAudioInputDevice: string | null): void => {
       setSelectedAudioInputDevice(updatedAudioInputDevice);
     };
-
     meetingManager.subscribeToSelectedAudioInputDeviceChange(callback);
 
     return (): void => {
       meetingManager.unsubscribeFromSelectedAudioInputDeviceChange(callback);
     };
-  }, [meetingManager]);
+  }, []);
 
   useEffect(() => {
     let isMounted = true;

--- a/src/providers/DevicesProvider/AudioOutputProvider.tsx
+++ b/src/providers/DevicesProvider/AudioOutputProvider.tsx
@@ -34,7 +34,7 @@ const AudioOutputProvider: React.FC = ({ children }) => {
     return (): void => {
       meetingManager.unsubscribeFromSelectedAudioOutputDeviceChange(callback);
     };
-  }, [meetingManager]);
+  }, []);
 
   useEffect(() => {
     let isMounted = true;

--- a/src/providers/DevicesProvider/VideoInputProvider.tsx
+++ b/src/providers/DevicesProvider/VideoInputProvider.tsx
@@ -36,7 +36,7 @@ const VideoInputProvider: React.FC = ({ children }) => {
     return (): void => {
       meetingManager.unsubscribeFromSelectedVideoInputDeviceChange(callback);
     };
-  }, [meetingManager]);
+  }, []);
 
   useEffect(() => {
     let isMounted = true;

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -90,11 +90,8 @@ export class MeetingManager {
     this.configuration = null;
     this.meetingId = null;
     this.selectedAudioOutputDevice = null;
-    this.selectedAudioOutputDeviceObservers = [];
     this.selectedAudioInputDevice = null;
-    this.selectedAudioInputDeviceObservers = [];
     this.selectedVideoInputDevice = null;
-    this.selectedVideoInputDeviceObservers = [];
     this.audioInputDevices = [];
     this.audioOutputDevices = [];
     this.videoInputDevices = [];


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Fix issue where you cannot reselect a device in a meeting in the control bar.

**Testing**

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes? manually

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
