### PR TITLE
Use route HOME constant as BASE_URL to replace runtime BASE_URL gener…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add redirection to home on page refresh in demo
 - Changed `NotificationGroup` minor styles
 - Updated VideoTileGrid to take in prop for fallback view. Updated demo meeting view with meeting info
+- Use route HOME constant as BASE_URL to replace runtime BASE_URL generation
 
 ### Removed
 

--- a/demo/meeting/src/constants/routes.ts
+++ b/demo/meeting/src/constants/routes.ts
@@ -1,13 +1,15 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-const awsPath: string = '/Prod';
-const rootPath: string = window.location.href.includes(awsPath) ? `${awsPath}/` : '/';
+const awsPath = '/Prod';
+export const rootPath: string = window.location.href.includes(awsPath)
+  ? `${awsPath}/`
+  : '/';
 
 const routes = {
   HOME: `${rootPath}`,
   DEVICE: `${rootPath}devices`,
   MEETING: `${rootPath}meeting`,
-}
+};
 
 export default routes;

--- a/demo/meeting/src/utils/api.ts
+++ b/demo/meeting/src/utils/api.ts
@@ -1,12 +1,9 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export const BASE_URL: string = [
-  location.protocol,
-  '//',
-  location.host,
-  location.pathname.replace(/.*/, '/')
-].join('');
+import routes from '../constants/routes';
+
+export const BASE_URL = routes.HOME;
 
 interface MeetingResponse {
   JoinInfo: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-component-library-react",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-component-library-react",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Amazon Chime SDK Component Library - React",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -13,6 +13,6 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '0.1.20';
+    return '0.1.21';
   }
 }


### PR DESCRIPTION
…ation

**Issue #:** 
After deploying found that the BASE_URL was not correctly getting set and throwing 403s when joining a meeting.
This is a temporary fix to handle the BASE_URL set from the routes constant rather than dynamic generation. We may in future fix this to handle the dynamic generation of BASE_URL.

**Description of changes:**
- Use route HOME constant as BASE_URL to replace runtime BASE_URL generation

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Manually locally as well as after deployment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
