### PR TITLE
Fix roster, portrait video bug on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,5 +131,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix demo application not allowing to select video / audio via popover
 - Fixed some demo layout issues
 - Fixed issue in demo when reselecting a device in the control bar
+- Fix roster not including attendees when rejoining meeting
+- Fix mobile portrait local video being too large
+- Fix content share not resetting when leaving a meeting
 
 ## [0.1.1] - 2020-06-16

--- a/demo/meeting/src/components/DeviceSelection/SpeakerDevices/index.tsx
+++ b/demo/meeting/src/components/DeviceSelection/SpeakerDevices/index.tsx
@@ -4,13 +4,15 @@
 import React, { useState } from 'react';
 import {
   SpeakerSelection,
-  SecondaryButton
+  SecondaryButton,
+  useAudioOutputs
 } from 'amazon-chime-sdk-component-library-react';
 
 import TestSound from '../../../utils/TestSound';
 
 const SpeakerDevices = () => {
-  const [selectedOutput, setSelectedOutput] = useState('');
+  const { selectedDevice } = useAudioOutputs();
+  const [selectedOutput, setSelectedOutput] = useState(selectedDevice);
 
   const handleChange = (deviceId: string): void => {
     setSelectedOutput(deviceId);

--- a/src/components/sdk/VideoTileGrid/index.tsx
+++ b/src/components/sdk/VideoTileGrid/index.tsx
@@ -23,8 +23,8 @@ const staticStyles = `
   position: absolute;
   bottom: 1rem;
   right: 1rem;
-  width: 18vw;
-  min-width: 200px;
+  width: 20vw;
+  max-height: 30vh;
   height: auto;
 
   video {

--- a/src/providers/ContentShareProvider/index.tsx
+++ b/src/providers/ContentShareProvider/index.tsx
@@ -133,9 +133,10 @@ const ContentShareProvider: React.FC = ({ children }) => {
 
     if (isLocalUserSharing || isLocalShareLoading) {
       audioVideo.stopContentShare();
+      setIsContentSharePaused(false);
       setContentShareState(localState => ({
         ...localState,
-        isLocalShareLoading: true,
+        isLocalShareLoading: false,
         isLocalUserSharing: false
       }));
     } else {
@@ -146,6 +147,17 @@ const ContentShareProvider: React.FC = ({ children }) => {
       }));
     }
   }, [audioVideo, isLocalUserSharing, isLocalShareLoading]);
+
+  useEffect(() => {
+    if (!audioVideo) {
+      return;
+    }
+
+    return () => {
+      setIsContentSharePaused(false);
+      setContentShareState(initialState);
+    };
+  }, [audioVideo]);
 
   const togglePauseContentShare = useCallback((): void => {
     if (!audioVideo || !isLocalUserSharing) {

--- a/src/providers/RosterProvider/index.tsx
+++ b/src/providers/RosterProvider/index.tsx
@@ -82,6 +82,7 @@ const RosterProvider: React.FC = ({ children }) => {
 
     return () => {
       setRoster({});
+      rosterRef.current = {};
       audioVideo.realtimeUnsubscribeToAttendeeIdPresence(rosterUpdateCallback);
     };
   }, [audioVideo]);


### PR DESCRIPTION
**Description of changes:**
- Fixes bug where roster wouldn't display attendees when re-joining a meeting
- Prevent mobile video from taking the full screen
- Fix bug where content share state hung over when joining different meetings

**Testing**

1. Have you successfully run `npm run build:release` locally?
2. How did you test these changes?
manually

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
