### PR TITLE
Add display names back to form components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,5 +137,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix roster not including attendees when rejoining meeting
 - Fix mobile portrait local video being too large
 - Fix content share not resetting when leaving a meeting
+- Fix demo form, add display names back to form components
 
 ## [0.1.1] - 2020-06-16

--- a/src/components/ui/FormField/index.tsx
+++ b/src/components/ui/FormField/index.tsx
@@ -72,7 +72,7 @@ export const FormField = forwardRef(
       ...rest
     } = props;
 
-    const displayName = Field.displayName?.toLowerCase();
+    const displayName = Field.displayName?.toLowerCase() || '';
     const labelId = useUniqueId();
     const descriptionId = useUniqueId();
     let helpText = (error && errorText) || infoText;

--- a/src/components/ui/Input/index.tsx
+++ b/src/components/ui/Input/index.tsx
@@ -104,4 +104,6 @@ export const Input = forwardRef(
   }
 );
 
+Input.displayName = 'Input';
+
 export default Input;

--- a/src/components/ui/Radio/index.tsx
+++ b/src/components/ui/Radio/index.tsx
@@ -55,4 +55,6 @@ export const Radio: FC<RadioProps> = props => {
   );
 };
 
+Radio.displayName = 'Radio';
+
 export default Radio;

--- a/src/components/ui/RadioGroup/index.tsx
+++ b/src/components/ui/RadioGroup/index.tsx
@@ -40,4 +40,6 @@ export const RadioGroup: FC<RadioGroupProps> = props => {
   );
 };
 
+RadioGroup.displayName = 'RadioGroup';
+
 export default RadioGroup;

--- a/src/components/ui/Select/index.tsx
+++ b/src/components/ui/Select/index.tsx
@@ -45,4 +45,6 @@ export const Select = forwardRef(
   )
 );
 
+Select.displayName = 'Select';
+
 export default Select;

--- a/src/components/ui/Textarea/index.tsx
+++ b/src/components/ui/Textarea/index.tsx
@@ -25,4 +25,6 @@ export const Textarea: FC<TextareaProps> = ({ label, ...props }) => {
   );
 };
 
+Textarea.displayName = 'Textarea';
+
 export default Textarea;


### PR DESCRIPTION
**Description of changes:**
- Removing the display names broke some of our form layout in the demo, adding them back

**Testing**

1. Have you successfully run `npm run build:release` locally?
2. How did you test these changes?
manually

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
