### PR TITLE
Update ContentShareProvider to fix race conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,5 +143,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix mobile portrait local video being too large
 - Fix content share not resetting when leaving a meeting
 - Fix demo form, add display names back to form components
+- Fix race condition where content share would stop but grey bg would persist
 
 ## [0.1.1] - 2020-06-16

--- a/src/components/sdk/ContentShare/index.tsx
+++ b/src/components/sdk/ContentShare/index.tsx
@@ -12,20 +12,25 @@ interface Props extends BaseSdkProps {}
 
 export const ContentShare: React.FC<Props> = ({ className, ...rest }) => {
   const audioVideo = useAudioVideo();
-  const { activeContentTileId, isSomeoneSharing } = useContentShareState();
+  const { tileId } = useContentShareState();
   const videoEl = useRef<HTMLVideoElement | null>(null);
 
   useEffect(() => {
-    if (!audioVideo || !videoEl.current || !activeContentTileId) {
+    if (!audioVideo || !videoEl.current || !tileId) {
       return;
     }
 
-    audioVideo.bindVideoElement(activeContentTileId, videoEl.current);
+    audioVideo.bindVideoElement(tileId, videoEl.current);
 
-    return () => audioVideo.unbindVideoElement(activeContentTileId);
-  }, [audioVideo, activeContentTileId]);
+    return () => {
+      const tile = audioVideo.getVideoTile(tileId);
+      if (tile) {
+        audioVideo.unbindVideoElement(tileId);
+      }
+    };
+  }, [audioVideo, tileId]);
 
-  return isSomeoneSharing ? (
+  return tileId ? (
     <ContentTile
       objectFit="contain"
       className={className || ''}

--- a/src/components/sdk/FeaturedRemoteVideos/index.tsx
+++ b/src/components/sdk/FeaturedRemoteVideos/index.tsx
@@ -19,13 +19,13 @@ export const FeaturedRemoteVideos: FC<Props> = props => {
   const gridData = useGridData();
   const { roster } = useRosterState();
   const { tileId: featuredTileId } = useFeaturedTileState();
-  const { isSomeoneSharing } = useContentShareState();
+  const { tileId: contentTileId } = useContentShareState();
   const { tiles, tileIdToAttendeeId } = useRemoteVideoTileState();
 
   return (
     <>
       {tiles.map(tileId => {
-        const featured = !isSomeoneSharing && featuredTileId === tileId;
+        const featured = !contentTileId && featuredTileId === tileId;
         const styles = gridData && featured ? 'grid-area: ft;' : '';
         const classes = `${featured ? 'featured-tile' : ''} ${props.className ||
           ''}`;

--- a/src/components/sdk/MeetingControls/ContentShareControl.tsx
+++ b/src/components/sdk/MeetingControls/ContentShareControl.tsx
@@ -12,14 +12,14 @@ import { PopOverItemProps } from '../../ui/PopOver/PopOverItem';
 const ContentShareControl: React.FC = () => {
   const { isLocalUserSharing } = useContentShareState();
   const {
-    isContentSharePaused,
+    paused,
     toggleContentShare,
     togglePauseContentShare
   } = useContentShareControls();
 
   const dropdownOptions: PopOverItemProps[] = [
     {
-      children: <span>{isContentSharePaused ? 'Play' : 'Pause'}</span>,
+      children: <span>{paused ? 'Unpause' : 'Pause'}</span>,
       onClick: togglePauseContentShare
     }
   ];

--- a/src/components/sdk/VideoTileGrid/index.tsx
+++ b/src/components/sdk/VideoTileGrid/index.tsx
@@ -43,10 +43,10 @@ export const VideoTileGrid: React.FC<Props> = ({
 }) => {
   const { tileId: featureTileId } = useFeaturedTileState();
   const { tiles } = useRemoteVideoTileState();
-  const { isSomeoneSharing } = useContentShareState();
+  const { tileId: contentTileId } = useContentShareState();
   const { isVideoEnabled } = useLocalVideo();
-  const featured = !!featureTileId || isSomeoneSharing;
-  const remoteSize = tiles.length + (isSomeoneSharing ? 1 : 0);
+  const featured = !!featureTileId || !!contentTileId;
+  const remoteSize = tiles.length + (contentTileId ? 1 : 0);
   const gridSize =
     remoteSize > 1 && isVideoEnabled ? remoteSize + 1 : remoteSize;
 

--- a/src/hooks/introduction.stories.mdx
+++ b/src/hooks/introduction.stories.mdx
@@ -38,7 +38,7 @@ import {
 
 const ContentShare () => => {
   const audioVideo = useAudioVideo();
-  const { activeContentTileId } = useContentShareState();
+  const { tileId } = useContentShareState();
   const videoEl = useRef<HTMLVideoElement | null>(null);
 
   useEffect(() => {
@@ -46,10 +46,10 @@ const ContentShare () => => {
       return;
     }
 
-    audioVideo.bindVideoElement(activeContentTileId, videoEl.current);
+    audioVideo.bindVideoElement(tileId, videoEl.current);
 
-    return () => audioVideo.unbindVideoElement(activeContentTileId);
-  }, [audioVideo, activeContentTileId]);
+    return () => audioVideo.unbindVideoElement(tileId);
+  }, [audioVideo, tileId]);
 
   return ( 
     <video ref={videoEl} className="my-content-tile" />

--- a/src/providers/ContentShareProvider/docs/ContentShareProvider.stories.mdx
+++ b/src/providers/ContentShareProvider/docs/ContentShareProvider.stories.mdx
@@ -9,7 +9,7 @@ Provides state and functionality for content sharing.
 ```javascript
 {
   // The tile ID of the active content share
-  activeContentTileId: number | null;
+  tileId: number | null;
 
   // Whether or not a remote user is screen sharing
   isRemoteUserSharing: boolean;

--- a/src/providers/ContentShareProvider/docs/useContentShareState.stories.mdx
+++ b/src/providers/ContentShareProvider/docs/useContentShareState.stories.mdx
@@ -9,7 +9,7 @@ Returns state related to the meeting session's content share status.
 ```javascript
 {
   // The tile ID of the active content share
-  activeContentTileId: number | null;
+  tileId: number | null;
 
   // Whether or not a remote user is screen sharing
   isRemoteUserSharing: boolean;

--- a/src/providers/ContentShareProvider/state.tsx
+++ b/src/providers/ContentShareProvider/state.tsx
@@ -1,0 +1,161 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { VideoTileState } from 'amazon-chime-sdk-js';
+
+export enum ContentActionType {
+  STARTING,
+  DID_STOP,
+  UPDATE,
+  TOGGLE_PAUSE,
+  REMOVE,
+  DENIED,
+  RESET
+}
+
+type StartingAction = {
+  type: ContentActionType.STARTING;
+  payload?: any;
+};
+
+type DidStopAction = {
+  type: ContentActionType.DID_STOP;
+  payload?: any;
+};
+
+type UpdateAction = {
+  type: ContentActionType.UPDATE;
+  payload: UpdatePayload;
+};
+
+type UpdatePayload = {
+  isLocalUser: boolean;
+  tileState: VideoTileState;
+};
+
+type TogglePauseAction = {
+  type: ContentActionType.TOGGLE_PAUSE;
+  payload?: any;
+};
+
+type RemoveAction = {
+  type: ContentActionType.REMOVE;
+  payload: number;
+};
+
+type DeniedAction = {
+  type: ContentActionType.DENIED;
+  payload?: any;
+};
+
+type ResetAction = {
+  type: ContentActionType.RESET;
+  payload?: any;
+};
+
+export type Action =
+  | StartingAction
+  | DidStopAction
+  | UpdateAction
+  | TogglePauseAction
+  | RemoveAction
+  | DeniedAction
+  | ResetAction;
+
+export type ContentShareState = {
+  tileId: number | null;
+  paused: boolean;
+  isLocalShareLoading: boolean;
+  isLocalUserSharing: boolean;
+  sharingAttendeeId: string | null;
+};
+
+export const initialState: ContentShareState = {
+  tileId: null,
+  paused: false,
+  isLocalUserSharing: false,
+  isLocalShareLoading: false,
+  sharingAttendeeId: null
+};
+
+export function reducer(
+  state: ContentShareState,
+  { type, payload }: Action
+): ContentShareState {
+  switch (type) {
+    case ContentActionType.STARTING: {
+      return {
+        ...state,
+        isLocalShareLoading: true
+      };
+    }
+    case ContentActionType.UPDATE: {
+      const { isLocalUser, tileState } = payload as UpdatePayload;
+      const { tileId } = state;
+
+      if (
+        tileId === tileState.tileId ||
+        (tileId && tileId > tileState.tileId!)
+      ) {
+        return state;
+      }
+
+      return {
+        paused: false,
+        tileId: tileState.tileId!,
+        isLocalShareLoading: false,
+        isLocalUserSharing: isLocalUser,
+        sharingAttendeeId: tileState.boundAttendeeId
+      };
+    }
+    case ContentActionType.REMOVE: {
+      const { tileId } = state;
+
+      if (tileId !== payload) {
+        return state;
+      }
+
+      return initialState;
+    }
+    case ContentActionType.DID_STOP: {
+      const { isLocalUserSharing } = state;
+
+      if (isLocalUserSharing) {
+        return initialState;
+      }
+
+      return {
+        ...state,
+        isLocalShareLoading: false,
+        isLocalUserSharing: false,
+        paused: false
+      };
+    }
+    case ContentActionType.TOGGLE_PAUSE: {
+      if (!state.isLocalUserSharing) {
+        return state;
+      }
+
+      return {
+        ...state,
+        paused: !state.paused
+      };
+    }
+    case ContentActionType.DENIED: {
+      if (!state.isLocalShareLoading) {
+        return state;
+      }
+
+      return {
+        ...state,
+        isLocalShareLoading: false
+      };
+    }
+
+    case ContentActionType.RESET: {
+      return initialState;
+    }
+    default:
+      throw new Error('Incorrect type in VideoProvider');
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,17 +33,8 @@ export type LocalVideoContextType = {
   toggleVideo: () => Promise<void>;
 };
 
-export type ContentShareState = {
-  activeContentTileId: number | null;
-  isLocalShareLoading: boolean;
-  isRemoteUserSharing: boolean;
-  isLocalUserSharing: boolean;
-  isSomeoneSharing: boolean;
-  sharingAttendeeId: string | null;
-};
-
 export type ContentShareControlContextType = {
-  isContentSharePaused: boolean;
+  paused: boolean;
   toggleContentShare: () => Promise<void>;
   togglePauseContentShare: () => void;
 };


### PR DESCRIPTION
**Description of changes:**
- Switching to `useReducer` in ContentShareProvider because it should help fix an annoying race condition where we would remove/add an observer in response to state change, but at that time could miss the SDK events

**Testing**

1. Have you successfully run `npm run build:release` locally?
2. How did you test these changes?
manually

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
