### PR TITLE
Add versioning tag to demo app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add docs for VideoGrid and VideoTile components
 - Add  `Grid` unit test.
 - Add a story to display all icons in one place for reference
+- Add versioning tag to demo app
 
 ### Changed
 

--- a/demo/meeting/src/utils/VersionLabel.tsx
+++ b/demo/meeting/src/utils/VersionLabel.tsx
@@ -1,0 +1,23 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { Versioning } from 'amazon-chime-sdk-component-library-react';
+
+export const VersionLabel = () => {
+  const versionTag = `${Versioning.sdkName}@${Versioning.sdkVersion}`;
+
+  return (
+    <span
+      style={{
+        position: 'absolute',
+        bottom: 1,
+        right: 1,
+        color: '#989da5',
+        fontSize: '0.70rem'
+      }}
+    >
+      {versionTag}
+    </span>
+  );
+};

--- a/demo/meeting/src/views/Home/index.tsx
+++ b/demo/meeting/src/views/Home/index.tsx
@@ -4,12 +4,13 @@
 import React from 'react';
 
 import MeetingFormSelector from '../../containers/MeetingFormSelector';
-
 import { StyledLayout } from './Styled';
+import { VersionLabel } from '../../utils/VersionLabel';
 
 const Home = () => (
   <StyledLayout>
     <MeetingFormSelector />
+    <VersionLabel />
   </StyledLayout>
 );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-component-library-react",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-component-library-react",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "Amazon Chime SDK Component Library - React",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,3 +145,6 @@ export { MeetingManager } from './providers/MeetingProvider/MeetingManager';
 
 // Interface
 export { NotificationType, Action } from './providers/NotificationProvider';
+
+// Utilities
+export { Versioning } from './versioning/Versioning';

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -1,18 +1,18 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export default class Versioning {
+export class Versioning {
   /**
    * Return string representation of SDK name
    */
   static get sdkName(): string {
-    return 'amazon-chime-sdk-component-library';
+    return 'amazon-chime-sdk-component-library-react';
   }
 
   /**
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '0.1.26';
+    return '0.1.27';
   }
 }


### PR DESCRIPTION
**Description of changes:**
Added SDK version tag to demo application.

**Testing**

![Demo](https://user-images.githubusercontent.com/20075335/89210276-b3577f80-d574-11ea-9fe7-29532b927543.gif)

<img width="984" alt="Screen Shot 2020-07-31 at 11 46 51 AM" src="https://user-images.githubusercontent.com/20075335/89069463-0688c280-d328-11ea-89ce-ac7597981ce6.png">

1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
