### PR TITLE
Fix microphone poorConnection SVG warning in devtools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,5 +151,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix race condition where content share would stop but grey bg would persist
 - Fix end meeting
 - Fix video grid, input bugs on iOS
+- Fix microphone poorConnection SVG warning in devtools
 
 ## [0.1.1] - 2020-06-16

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-component-library-react",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-component-library-react",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "Amazon Chime SDK Component Library - React",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",

--- a/src/components/ui/icons/Microphone/Styled.tsx
+++ b/src/components/ui/icons/Microphone/Styled.tsx
@@ -1,12 +1,15 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import React from 'react';
 import styled from 'styled-components';
 
 import Svg from '../Svg';
 import { MicrophoneProps } from './';
 
-export const StyledSvg = styled(Svg)<MicrophoneProps>`
+const SvgWithoutMicrophoneProps = ({ poorConnection, muted, ...rest }: MicrophoneProps) => <Svg {...rest} />;
+
+export const StyledSvg = styled(SvgWithoutMicrophoneProps)<MicrophoneProps>`
   ${props =>
     props.poorConnection ? `color: ${props.theme.colors.error.light}` : ''}
 `;

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -13,6 +13,6 @@ export class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '0.1.27';
+    return '0.1.28';
   }
 }


### PR DESCRIPTION
**Issue #:** 
A warning was appearing in devtools saying SVG as a DOM element should not have `poorConnection` as prop. It should be lowercased.

**Description of changes:**
- Fix microphone poorConnection SVG warning in devtools

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Locally in Storybook

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
