### PR TITLE
Conditionally show control bar on user activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a story to display all icons in one place for reference
 - Add versioning tag to demo app
 - Add third party dependency attributes to NOTICE file
+- Add component to manage visibility of controlbar
 
 ### Changed
 

--- a/demo/meeting/src/views/Meeting/index.tsx
+++ b/demo/meeting/src/views/Meeting/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { VideoTileGrid } from 'amazon-chime-sdk-component-library-react';
+import { VideoTileGrid, UserActivityProvider, UserActivityManager } from 'amazon-chime-sdk-component-library-react';
 
 import { StyledLayout, StyledContent } from './Styled';
 import NavigationControl from '../../containers/Navigation/NavigationControl';
@@ -16,13 +16,17 @@ const MeetingView = () => {
   const { showNavbar, showRoster } = useNavigation();
 
   return (
-    <StyledLayout showNav={showNavbar} showRoster={showRoster}>
-      <StyledContent>
-        <VideoTileGrid noRemoteVideoView={<MeetingDetails />} />
-        <MeetingControlsContainer />
-      </StyledContent>
-      <NavigationControl />
-    </StyledLayout>
+    <UserActivityProvider>
+      <StyledLayout showNav={showNavbar} showRoster={showRoster}>
+        <StyledContent>
+          <VideoTileGrid noRemoteVideoView={<MeetingDetails />} />
+          <UserActivityManager>
+            <MeetingControlsContainer />
+          </UserActivityManager>
+        </StyledContent>
+        <NavigationControl />
+      </StyledLayout>
+    </UserActivityProvider>
   );
 };
 

--- a/src/components/ui/Grid/Grid.stories.tsx
+++ b/src/components/ui/Grid/Grid.stories.tsx
@@ -62,14 +62,14 @@ export const NamedGrid = () => {
         }}
         gridTemplateAreas={{
           md: `"other main sidebar"
-               "other main sidebar"
-               "other main sidebar"`,
+              "other main sidebar"
+              "other main sidebar"`,
           lg: `"other other sidebar"
-               "main main sidebar"
-               "main main sidebar"`,
+              "main main sidebar"
+              "main main sidebar"`,
           xl: `"other main sidebar"
-               "other main sidebar"
-               "other main sidebar"`
+              "other main sidebar"
+              "other main sidebar"`
         }}
       >
         <Child>Other</Child>

--- a/src/components/ui/UserActivityManager/Styled.tsx
+++ b/src/components/ui/UserActivityManager/Styled.tsx
@@ -1,0 +1,16 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import styled from "styled-components";
+
+import { fadeAnimation } from '../../../utils/animations';
+import { Props } from './';
+
+export const StyledUserActivityManager = styled.div<Props>`
+  z-index: ${props => props.isActive ? props.theme.zIndex.controlBar : "-10"};
+  visibility: ${props => props.isActive ? "visible" : "hidden"};
+
+  &.active {
+    animation: ${fadeAnimation} 0.25s ease 0s forwards;
+  }
+`;

--- a/src/components/ui/UserActivityManager/index.tsx
+++ b/src/components/ui/UserActivityManager/index.tsx
@@ -1,0 +1,23 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { FC } from 'react';
+import { useUserActivityState } from '../../../providers/UserActivityProvider';
+import { StyledUserActivityManager } from './Styled';
+
+export interface Props {
+  isActive?: boolean | null;
+}
+
+export const UserActivityManager: FC<Props> = ({ children }) => {
+  const { isUserActive } = useUserActivityState();
+  return (
+    <StyledUserActivityManager isActive={isUserActive} className={`${isUserActive ? "active" : ""}` }>
+      {children}
+    </StyledUserActivityManager>
+  );
+};
+
+UserActivityManager.displayName = 'UserActivityManager';
+
+export default UserActivityManager;

--- a/src/hooks/useFocusIn/index.tsx
+++ b/src/hooks/useFocusIn/index.tsx
@@ -1,0 +1,40 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState, useEffect, useRef, RefObject } from 'react';
+
+export function useFocusIn(el: RefObject<any>, delay = 3000) {
+  let timeoutRef: any = useRef(null);
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!el.current) {
+      return;
+    }
+
+    const onFocusIn = () => {
+      clearTimeout(timeoutRef.current);
+      setIsFocused(true);
+    }
+
+    const onFocusOut = () => {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => {
+        setIsFocused(false);
+      }, delay);
+    };
+
+    el.current.addEventListener('focusin', onFocusIn);
+    el.current.addEventListener('focusout', onFocusOut);
+
+    return (): void => {
+      el.current.removeEventListener('focusin', onFocusIn);
+      el.current.removeEventListener('focusout', onFocusOut);
+    };
+
+  }, [el]);
+
+  return { isFocused };
+}
+
+export default useFocusIn;

--- a/src/hooks/useMouseMove/index.tsx
+++ b/src/hooks/useMouseMove/index.tsx
@@ -1,0 +1,34 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState, useEffect, useRef, RefObject } from 'react';
+
+export function useMouseMove(el: RefObject<any>, delay = 3000) {
+  let timeoutRef: any = useRef(null);
+  const [isMouseMoving, setIsMouseActive] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!el.current) {
+      return;
+    }
+
+    const onMouseMove = () => {
+      clearTimeout(timeoutRef.current);
+      setIsMouseActive(true);
+      timeoutRef.current = setTimeout(() => {
+        setIsMouseActive(false);
+      }, delay);
+    };
+
+    el.current.addEventListener('mousemove', onMouseMove);
+
+    return (): void => {
+      el.current.removeEventListener('mousemove', onMouseMove);
+    };
+
+  }, [el]);
+
+  return { isMouseMoving };
+}
+
+export default useMouseMove;

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ export { Roster } from './components/ui/Roster';
 export { RosterHeader } from './components/ui/Roster/RosterHeader';
 export { RosterGroup } from './components/ui/Roster/RosterGroup';
 export { RosterCell } from './components/ui/Roster/RosterCell';
+export { UserActivityManager } from './components/ui/UserActivityManager';
 
 // SDK components
 export {
@@ -92,6 +93,8 @@ export { AudioVideoContext } from './providers/AudioVideoProvider';
 export { useClickOutside } from './hooks/useClickOutside';
 export { useTabOutside } from './hooks/useTabOutside';
 export { useUniqueId } from './hooks/useUniqueId';
+export { useFocusIn } from './hooks/useFocusIn';
+export { useMouseMove } from './hooks/useMouseMove';
 
 export { useAttendeeStatus } from './hooks/sdk/useAttendeeStatus';
 export { useAttendeeAudioStatus } from './hooks/sdk/useAttendeeAudioStatus';
@@ -129,6 +132,7 @@ export { RosterProvider } from './providers/RosterProvider';
 export { DevicesProvider } from './providers/DevicesProvider';
 export { RemoteVideoTileProvider } from './providers/RemoteVideoTileProvider';
 export { FeaturedVideoTileProvider } from './providers/FeaturedVideoTileProvider';
+export { UserActivityProvider, useUserActivityState } from './providers/UserActivityProvider';
 
 // Themes
 export { lightTheme, darkTheme, GlobalStyles, StyledReset } from './theme';

--- a/src/providers/UserActivityProvider/index.tsx
+++ b/src/providers/UserActivityProvider/index.tsx
@@ -1,0 +1,45 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { createContext, FC, useContext, useMemo, useRef } from 'react';
+
+import useFocusIn from '../../hooks/useFocusIn';
+import useMouseMove from '../../hooks/useMouseMove';
+
+interface UserActivityState {
+  isUserActive: boolean | null;
+}
+
+export const UserActivityContext = createContext<UserActivityState | null>(null);
+
+const UserActivityProvider: FC = ({ children }) => {
+  const ref = useRef<any>(null);
+  const { isFocused } = useFocusIn(ref);
+  const { isMouseMoving } = useMouseMove(ref);
+  const isUserActive = isFocused || isMouseMoving;
+  const value = useMemo(() => ({
+    isUserActive
+  }), [isUserActive]);
+
+  return (
+    <div ref={ref}>
+      <UserActivityContext.Provider value={value}>
+        {children}
+      </UserActivityContext.Provider>
+    </div>
+  );
+};
+
+function useUserActivityState(): UserActivityState {
+  const state = useContext(UserActivityContext);
+
+  if (!state) {
+    throw new Error(
+      'useUserActivityState must be used within an UserActivityContextProvider'
+    );
+  }
+
+  return state;
+}
+
+export { UserActivityProvider, useUserActivityState };

--- a/src/theme/default.ts
+++ b/src/theme/default.ts
@@ -16,6 +16,7 @@ export const radii = {
 
 export const zIndex = {
   navigation: 10,
+  controlBar: 15,
   modal: 20,
   popOver: 30,
   notificationGroup: 40,

--- a/src/theme/styled.d.ts
+++ b/src/theme/styled.d.ts
@@ -140,6 +140,7 @@ declare module 'styled-components' {
 
     zIndex: {
       navigation: string | number;
+      controlBar: string | number;
       modal: string | number;
       popOver: string | number;
       notificationGroup: string | number;


### PR DESCRIPTION
**Description of changes:**
Currently when the `ControlBar` is in its' undocked state, it will display over the top of other content on the page, which can be problematic. This change introduces a `UserActivityProvider`, which can be used to record mouse or focus activity on a section of a page. Accompanying this is a component that listens for this activity and conditionally adjusts visibility. A few notes:

* The component does not remove its' children from  the page. I discovered some usability issues with focus when I did. Instead we make it invisible and give it a negative z-index when it there is no user activity.
* We can probably add more to the hooks, especially `useMouseMove`, as it will be useful for draggable UI etc. For time constraints, it's just recording movement.

**Testing**

1. Have you successfully run `npm run build:release` locally? YES
2. How did you test these changes? manually in a number of supported browsers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
