### PR TITLE
Update typescript exclude dir for lib build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve Storybook documentaions according to the guidance of technical writing
 - NOTICE includes correct copyright text
 - LICENSE includes full Apache license
+- Update typescript build tree to exclude test-helper and demo's folder from library build process
 
 ### Removed
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,12 +25,13 @@
   "exclude": [
     "node_modules",
     "build",
+    "demo",
     "scripts",
     ".storybook",
     "src/internal",
     "src/**/*.test.tsx",
     "src/**/*.stories.tsx",
-    "tst/**/*.test.tsx",
+    "tst",
     "coverage",
   ]
 }


### PR DESCRIPTION
**Description of changes:**
Updated config to not include test and/or demos files in the final lib output build.

**Testing**
![Screen Shot 2020-08-04 at 11 09 25 AM](https://user-images.githubusercontent.com/20075335/89328951-fed85f00-d642-11ea-9236-e52f0c3c2ce9.png)

1. Have you successfully run `npm run build:release` locally?
2. How did you test these changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

