### PR TITLE
Re-enable github action publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,27 +1,29 @@
-# name: Publish and Deploy Documentation
-# # When a new Github Release is created via our npm script, publish to NPM and then deploy our storybook documentation to github pages
-# on:
-#   release:
-#     types: [published]
+name: Publish and Deploy Documentation
+# When a new Github Release is created via our npm script, publish to NPM and then deploy our storybook documentation to github pages
+on:
+  release:
+    types: [published]
 
-# jobs:  
-#   publish-npm:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Checkout Package
-#         uses: actions/checkout@master
-#       - name: Setup Node environment
-#         uses: actions/setup-node@v1
-#         with:
-#           node-version: 12
-#           registry-url: https://registry.npmjs.org/
-#       - name: NPM Install
-#         run: npm install
-#       - name: Publish to NPM
-#         run: npm publish --access public
-#         env:
-#           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-#       - name: Publish Storybook Documentation
-#         run: npm run deploy-storybook -- --ci 
-#         env:
-#           GH_TOKEN: chime-sdk-component-bot:${{ secrets.GITHUBPAGES}}
+jobs:  
+  publish-and-deploy-documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Package
+        uses: actions/checkout@master
+      - name: Setup Node environment
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - name: NPM Install
+        run: npm install
+      - name: NPM run build
+        run: npm run build
+      - name: Publish to NPM
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      - name: Publish Storybook Documentation
+        run: npm run deploy-storybook -- --ci 
+        env:
+          GH_TOKEN: chime-sdk-component-bot:${{ secrets.GITHUBPAGES}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated the github actions publishing workflow
+- Added npm run build to the github actions publishing workflow
 
 ### Removed
 


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
- Re-enables the publishing workflow, making sure to build the component library before publishing it

**Testing**

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes? n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
