### PR TITLE
Add npm & build badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.3] - 2020-08-04
 
 ### Added
+- Add NPM and CI Flow badge to README
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Chime SDK UI Component Library
 
+<a href="https://www.npmjs.com/package/amazon-chime-sdk-component-library-react"><img src="https://img.shields.io/npm/v/amazon-chime-sdk-component-library-react?style=flat-square"></a>
+<a href="https://github.com/aws/amazon-chime-sdk-component-library-react"><img src="https://github.com/aws/amazon-chime-sdk-component-library-react/workflows/CI%20Workflow/badge.svg"></a>
+
 This contains reusable components written with React, TypeScript and styled components to be used to create UIs with Chime SDK JS.
 
 ## To genereate dependencies


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Add npm package and CI build flow badge to package README
<a href="https://www.npmjs.com/package/amazon-chime-sdk-component-library-react"><img src="https://img.shields.io/npm/v/amazon-chime-sdk-component-library-react?style=flat-square"></a>
<a href="https://github.com/aws/amazon-chime-sdk-component-library-react"><img src="https://github.com/aws/amazon-chime-sdk-component-library-react/workflows/CI%20Workflow/badge.svg"></a>
**Testing**

 ### **PREVIEW** [HERE](https://github.com/aws/amazon-chime-sdk-component-library-react/blob/nick_add_feature/README.md)

1. Have you successfully run `npm run build:release` locally? no
2. How did you test these changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
