### PR TITLE
Fix build:release run on windows OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added npm run build to the github actions publishing workflow
 - Improve consistency and accuracy of docs for Hooks and Providers
+- Fix `npm run build:release` running on windows OS
 
 ### Removed
 

--- a/scripts/check-codestyle.js
+++ b/scripts/check-codestyle.js
@@ -124,14 +124,14 @@ allFiles().forEach(file => {
     return;
   }
   let yearsForFileInGitHistory = [];
-  const stdout = exec(`git log --pretty=format:'%ad' --date=short '${file}'`);
+  const stdout = exec(`git log --pretty=format:'%ad' --date=short ${file}`);
 
   const dates = [];
   for (const line of stdout
     .toString()
     .trim()
     .split('\n')) {
-    const year = line.replace(/[-].*/, '');
+    const year = line.replace(/[-].*/, '').replace(`'`, '');
     dates.push(year);
     allYears.push(year);
   }


### PR DESCRIPTION
**Description of changes:**
Fix ```npm run build:release``` script execution on Windows OS.

**Testing** 
Running build on windows 10

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
