### PR TITLE
Correct reversed labels for mute/unmute control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fixed reversed labels for mute/unmute control in `AudioInputControl`
 
 ## [1.0.3] - 2020-08-04
 

--- a/src/components/sdk/MeetingControls/AudioInputControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioInputControl.tsx
@@ -41,7 +41,7 @@ const AudioInputControl: React.FC<Props> = ({
     <ControlBarButton
       icon={<Microphone muted={muted} />}
       onClick={toggleMute}
-      label={muted ? muteLabel : unmuteLabel}
+      label={muted ? unmuteLabel : muteLabel}
       popOver={dropdownOptions}
     />
   );


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
- Fixed reversed labels for mute/unmute control in `AudioInputControl`

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Locally running the demo app

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
