### PR TITLE
Demo meeting dev server improvements

### DIFF
--- a/demo/meeting/README.MD
+++ b/demo/meeting/README.MD
@@ -12,11 +12,9 @@ This is the SDK react meeting demo app. It shows how to use the Amazon Chime SDK
 
 4. Install dependencies: `npm install`
 
-5. Start the webpack server: `npm run start:client`
+5. Start the webpack server and node server concurrently: `npm run start`
 
-6. Open a second terminal. Within the same directory, start the server: `npm run start:backend`
-
-7. Open https://0.0.0.0:9000/ in your browser
+6. Open https://0.0.0.0:9000/ in your browser
 
 ### Troubleshooting
 

--- a/demo/meeting/package-lock.json
+++ b/demo/meeting/package-lock.json
@@ -2773,6 +2773,61 @@
         }
       }
     },
+    "concurrently": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-5.2.0.tgz",
+      "integrity": "sha512-XxcDbQ4/43d6CxR7+iV8IZXhur4KbmEJk1CetVMUqCy34z9l0DkszbY+/9wvmSnToTej0SYomc2WSRH+L0zVJw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "date-fns": "^2.0.1",
+        "lodash": "^4.17.15",
+        "read-pkg": "^4.0.1",
+        "rxjs": "^6.5.2",
+        "spawn-command": "^0.0.2-1",
+        "supports-color": "^6.1.0",
+        "tree-kill": "^1.2.2",
+        "yargs": "^13.3.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
+          "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
+          "dev": true,
+          "requires": {
+            "normalize-package-data": "^2.3.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "confusing-browser-globals": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
@@ -3069,6 +3124,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz",
       "integrity": "sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==",
+      "dev": true
+    },
+    "date-fns": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.15.0.tgz",
+      "integrity": "sha512-ZCPzAMJZn3rNUvvQIMlXhDr4A+Ar07eLeGsGREoWU19a3Pqf5oYa+ccd+B3F6XVtQY6HANMFdOQ8A+ipFnvJdQ==",
       "dev": true
     },
     "debug": {
@@ -8117,6 +8178,12 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
+    "spawn-command": {
+      "version": "0.0.2-1",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
+      "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
+      "dev": true
+    },
     "spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -8730,6 +8797,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
       "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
+      "dev": true
+    },
+    "tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
     },
     "ts-loader": {

--- a/demo/meeting/package.json
+++ b/demo/meeting/package.json
@@ -21,7 +21,8 @@
     "build": "npm install && npm run build:prod",
     "build:prod": "webpack --config ./webpack.config.js --mode=production --devtool=false",
     "start:client": "npm install && webpack-dev-server",
-    "start:backend": "node server.js"
+    "start:backend": "node server.js",
+    "start": "concurrently \"npm run start:client\" \"npm run start:backend\""
   },
   "devDependencies": {
     "@types/styled-system": "^5.1.9",
@@ -38,6 +39,7 @@
     "@types/throttle-debounce": "^2.1.0",
     "babel-eslint": "^9.0.0",
     "babel-loader": "^8.0.4",
+    "concurrently": "5.2.0",
     "css-loader": "^3.5.3",
     "eslint": "^5.16.0",
     "eslint-config-airbnb": "^17.1.1",


### PR DESCRIPTION
**Issue #: NA** 

**Description of changes:**
Improvements to demo meeting dev server
1. Run both webpack server and node server on the same terminal
    * Developers have to open two terminals and run two different commands in order to test the demo site
    * Modified configuration which now requires only running one command `npm run start` to run the demo site.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Yes. Follow there steps to test:
    1. Clone repo
    2. run `cd demo/meeting`
    3. run `npm i`
    4. run `npm run start`
    5. In browser open `localhost:9000`
    6. You should be able to connect to a meeting. (AWS credentials setup required)

3. If you made changes to the component library, have you provided corresponding documentation changes?
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
