### PR TITLE
Fix PreviewVideo component when selecting new video input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed reversed labels for mute/unmute control in `AudioInputControl`
+- Fixed `PreviewVideo` component when selecting new video input device
 
 ## [1.0.3] - 2020-08-04
 


### PR DESCRIPTION
**Issue #:** 
- When selecting a new video input device, the preview won't re-render, and the unmounting behavior causes us to lose the media stream

**Description of changes:**
- Re-render when a new device is selected
- Reselect video input device to make sure we have a video strema

**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes? manually

3. If you made changes to the component library, have you provided corresponding documentation changes?
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
