### PR TITLE
Modify verdaccio script to use npm run start

### DIFF
--- a/scripts/verdaccio.js
+++ b/scripts/verdaccio.js
@@ -106,7 +106,7 @@ fs.writeFileSync(
 logger.log(`Installing ${COMPONENTS_APP_NAME} from local repo...`);
 spawnOrFail('npm', [`install ${COMPONENTS_APP_NAME} --registry ${endpoint}`]);
 
-const demoAppClientProcess = cp.exec('npm run start:client', {
+const demoAppClientProcess = cp.exec('npm run start', {
   detached: true
 });
 applicationProcesses.push(demoAppClientProcess);


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Update verdaccio script to use npm run start, instead of run start:client. That way, we don't have to explicitly create another tab to run the backend server

**Testing**
1. Have you successfully run `npm run build:release` locally? 
yes

2. How did you test these changes?
ran 'node scripts/verdaccio.js' locally and verified it ran the server with the demo app 

3. If you made changes to the component library, have you provided corresponding documentation changes?
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
