### PR TITLE
Add ability  meetingId from query params

### DIFF
--- a/demo/meeting/src/containers/MeetingForm/index.tsx
+++ b/demo/meeting/src/containers/MeetingForm/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState, useContext, ChangeEvent } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import {
   Input,
   Flex,
@@ -27,13 +27,10 @@ import { fetchMeeting, createGetAttendeeCallback } from '../../utils/api';
 import { useAppState } from '../../providers/AppStateProvider';
 
 const MeetingForm: React.FC = () => {
+  const query = new URLSearchParams(useLocation().search);
   const meetingManager = useMeetingManager();
-  const { 
-    setMeeting,
-    setLocalName,
-    setRegion: setAppRegion
-  } = useAppState();
-  const [meetingId, setMeetingId] = useState('');
+  const { setMeeting, setLocalName, setRegion: setAppRegion } = useAppState();
+  const [meetingId, setMeetingId] = useState(query.get('meetingId') || '');
   const [meetingErr, setMeetingErr] = useState(false);
   const [name, setName] = useState('');
   const [nameErr, setNameErr] = useState(false);


### PR DESCRIPTION

**Description of changes:**
if Demo meting URL has `meetingId` part of query params we can parse and insert in to the join meeting form.

https://0.0.0.0:9000/?meetingId=metting123

**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes?

3. If you made changes to the component library, have you provided corresponding documentation changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
