### PR TITLE
Fix css prop not taking precedence over queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed reversed labels for mute/unmute control in `AudioInputControl`
 - Fixed `PreviewVideo` component when selecting new video input device
 - Fixed incorrect Storybook docs rendering
+- Fixed `css` prop not taking precedence over media queries
 
 ## [1.0.3] - 2020-08-04
 

--- a/src/components/ui/Base/index.ts
+++ b/src/components/ui/Base/index.ts
@@ -13,5 +13,6 @@ export interface BaseProps extends SpaceProps {
   className?: string;
 }
 
-export const baseStyles = ({ css }: BaseProps) => (css ? `${css};` : '');
+export const baseStyles = ({ css }: BaseProps) =>
+  css ? `@media { ${css} };` : '';
 export const baseSpacing = (props: BaseProps) => space(props);


### PR DESCRIPTION
**Issue #:** 
Styled Components adjusts the order of style declarations when it comes to media queries, so the `css` prop was not taking precedence over previously declared styles

[Ticket with more details here](https://github.com/styled-components/styled-components/issues/2095)

**Description of changes:**
- Wrap the `css` prop in a blank media query so it retains its order

**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes? manually

3. If you made changes to the component library, have you provided corresponding documentation changes? n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
