### PR TITLE
Add bandwidth metrics to demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add PostLogger support to MeetingProvider
+- Add `useBandwidthMetrics` hook, add bandwidth stats to demo
 
 ### Changed
 
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
 - Fixed `css` prop not taking precedence over media queries
 
 ## [1.1.0] - 2020-08-14

--- a/demo/meeting/src/containers/MeetingMetrics/Styled.ts
+++ b/demo/meeting/src/containers/MeetingMetrics/Styled.ts
@@ -1,0 +1,22 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import styled from 'styled-components';
+
+export const StyledMetrics = styled.div`
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  min-width: 7.5rem;
+  z-index: 5;
+
+  .metric {
+    white-space: nowrap;
+    font-size: 0.75rem;
+    margin-bottom: 0.375rem;
+
+    &.title {
+      font-weight: bold;
+    }
+  }
+`;

--- a/demo/meeting/src/containers/MeetingMetrics/index.tsx
+++ b/demo/meeting/src/containers/MeetingMetrics/index.tsx
@@ -1,0 +1,39 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { useBandwidthMetrics } from 'amazon-chime-sdk-component-library-react';
+
+import { StyledMetrics } from './Styled';
+import { useNavigation } from '../../providers/NavigationProvider';
+
+function formatMetric(metric: number | null) {
+  return metric ? `${metric} Kbps` : null;
+}
+
+const MeetingMetrics = () => {
+  const { showMetrics } = useNavigation();
+
+  return showMetrics ? <BandwidthMetrics /> : null;
+};
+
+const BandwidthMetrics = () => {
+  const {
+    availableIncomingBandwidth,
+    availableOutgoingBandwidth
+  } = useBandwidthMetrics();
+
+  return (
+    <StyledMetrics>
+      <p className="metric title">Bandwidth</p>
+      <p className="metric">
+        Incoming: {formatMetric(availableIncomingBandwidth) || 'unavailable'}
+      </p>
+      <p className="metric">
+        Outgoing: {formatMetric(availableOutgoingBandwidth) || 'unavailable'}
+      </p>
+    </StyledMetrics>
+  );
+};
+
+export default MeetingMetrics;

--- a/demo/meeting/src/containers/Navigation/index.tsx
+++ b/demo/meeting/src/containers/Navigation/index.tsx
@@ -8,14 +8,15 @@ import {
   NavbarHeader,
   NavbarItem,
   Attendees,
-  Eye
+  Eye,
+  Information
 } from 'amazon-chime-sdk-component-library-react';
 
 import { useNavigation } from '../../providers/NavigationProvider';
 import { useAppState } from '../../providers/AppStateProvider';
 
 const Navigation = () => {
-  const { toggleRoster, closeNavbar } = useNavigation();
+  const { toggleRoster, toggleMetrics, closeNavbar } = useNavigation();
   const { theme, toggleTheme } = useAppState();
 
   return (
@@ -30,6 +31,11 @@ const Navigation = () => {
         icon={<Eye />}
         onClick={toggleTheme}
         label={theme === 'light' ? 'Dark mode' : 'Light mode'}
+      />
+      <NavbarItem
+        icon={<Information />}
+        onClick={toggleMetrics}
+        label="Meeting metrics"
       />
     </Navbar>
   );

--- a/demo/meeting/src/providers/NavigationProvider.tsx
+++ b/demo/meeting/src/providers/NavigationProvider.tsx
@@ -12,12 +12,14 @@ import React, {
 export type NavigationContextType = {
   showNavbar: boolean;
   showRoster: boolean;
+  showMetrics: boolean;
   toggleRoster: () => void;
   toggleNavbar: () => void;
   openRoster: () => void;
   closeRoster: () => void;
   openNavbar: () => void;
   closeNavbar: () => void;
+  toggleMetrics: () => void;
 };
 
 type Props = {
@@ -33,6 +35,7 @@ const isDesktop = () => window.innerWidth > 768;
 const NavigationProvider = ({ children }: Props) => {
   const [showNavbar, setShowNavbar] = useState(() => isDesktop());
   const [showRoster, setShowRoster] = useState(() => isDesktop());
+  const [showMetrics, setShowMetrics] = useState(false);
   const isDesktopView = useRef(isDesktop());
 
   useEffect(() => {
@@ -64,6 +67,10 @@ const NavigationProvider = ({ children }: Props) => {
     setShowNavbar(!showNavbar);
   };
 
+  const toggleMetrics = () => {
+    setShowMetrics(currentState => !currentState);
+  };
+
   const openNavbar = (): void => {
     setShowNavbar(true);
   };
@@ -83,8 +90,10 @@ const NavigationProvider = ({ children }: Props) => {
   const providerValue = {
     showNavbar,
     showRoster,
+    showMetrics,
     toggleRoster,
     toggleNavbar,
+    toggleMetrics,
     openRoster,
     closeRoster,
     openNavbar,

--- a/demo/meeting/src/views/Meeting/index.tsx
+++ b/demo/meeting/src/views/Meeting/index.tsx
@@ -13,6 +13,7 @@ import { useNavigation } from '../../providers/NavigationProvider';
 import MeetingDetails from '../../containers/MeetingDetails';
 import MeetingControls from '../../containers/MeetingControls';
 import useMeetingEndRedirect from '../../hooks/useMeetingEndRedirect';
+import MeetingMetrics from '../../containers/MeetingMetrics';
 
 const MeetingView = () => {
   useMeetingEndRedirect();
@@ -22,6 +23,7 @@ const MeetingView = () => {
     <UserActivityProvider>
       <StyledLayout showNav={showNavbar} showRoster={showRoster}>
         <StyledContent>
+          <MeetingMetrics />
           <VideoTileGrid
             className="videos"
             noRemoteVideoView={<MeetingDetails />}

--- a/src/hooks/sdk/docs/useBandwidthMetrics.stories.mdx
+++ b/src/hooks/sdk/docs/useBandwidthMetrics.stories.mdx
@@ -1,0 +1,56 @@
+<Meta title="SDK Hooks/useBandwidthMetrics" />
+
+# useBandwidthMetrics
+
+The `useBandwidthMetrics` hook returns the available outgoing and incoming bandwidth for the current meeting session.
+
+This hook re-renders frequently. You should avoid using it high in your app tree, and ideally use it in your leaf components.
+
+### Return Value
+
+```javascript
+{
+  availableOutgoingBandwidth: number | null;
+  availableIncomingBandwidth: number | null;
+}
+}
+```
+
+## Importing
+
+```javascript
+import { useBandwidthMetrics } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+The hook depends on the `AudioVideoProvider` being rendered. If you are using the MeetingProvider, it is rendered by default.
+
+```jsx
+import React from 'react';
+import {
+  MeetingProvider,
+  useBandwidthMetrics
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <MeetingProvider>
+    <MyChild />
+  </MeetingProvider>
+);
+
+const MyChild = () => {
+  const metrics = useBandwidthMetrics();
+
+  return (
+    <>
+      <p>Incoming: {metrics.availableIncomingBandwidth}</p>
+      <p>Outgoing: {metrics.availableOutgoingBandwidth}</p>    
+    </>
+  )
+};
+```
+
+### Dependencies
+
+- `AudioVideoProvider`

--- a/src/hooks/sdk/useBandwidthMetrics.tsx
+++ b/src/hooks/sdk/useBandwidthMetrics.tsx
@@ -1,0 +1,68 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState, useEffect } from 'react';
+import { ClientMetricReport } from 'amazon-chime-sdk-js';
+
+import { useAudioVideo } from '../../providers/AudioVideoProvider';
+
+function isValidMetric(metric: any) {
+  return typeof metric === 'number' && !Number.isNaN(metric);
+}
+
+interface BandwidthMetrics {
+  availableOutgoingBandwidth: number | null;
+  availableIncomingBandwidth: number | null;
+}
+
+export function useBandwidthMetrics() {
+  const audioVideo = useAudioVideo();
+  const [metrics, setMetrics] = useState<BandwidthMetrics>({
+    availableOutgoingBandwidth: null,
+    availableIncomingBandwidth: null,
+  });
+
+  useEffect(() => {
+    if (!audioVideo) {
+      return;
+    }
+
+    const observer = {
+      metricsDidReceive(clientMetricReport: ClientMetricReport): void {
+        const metricReport = clientMetricReport.getObservableMetrics();
+
+        let availableOutgoingBandwidth = null;
+        let availableIncomingBandwidth = null;
+
+        if (isValidMetric(metricReport.availableSendBandwidth)) {
+          availableOutgoingBandwidth =
+            metricReport.availableSendBandwidth / 1000;
+        } else if (isValidMetric(metricReport.availableOutgoingBitrate)) {
+          availableOutgoingBandwidth =
+            metricReport.availableOutgoingBitrate / 1000;
+        }
+
+        if (isValidMetric(metricReport.availableReceiveBandwidth)) {
+          availableIncomingBandwidth =
+            metricReport.availableReceiveBandwidth / 1000;
+        } else if (isValidMetric(metricReport.availableIncomingBitrate)) {
+          availableIncomingBandwidth =
+            metricReport.availableIncomingBitrate / 1000;
+        }
+
+        setMetrics({
+          availableOutgoingBandwidth,
+          availableIncomingBandwidth,
+        });
+      },
+    };
+
+    audioVideo.addObserver(observer);
+
+    return () => audioVideo.removeObserver(observer);
+  }, [audioVideo]);
+
+  return metrics;
+}
+
+export default useBandwidthMetrics;

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,13 +53,13 @@ export {
   CameraSelection,
   MicSelection,
   SpeakerSelection,
-  QualitySelection
+  QualitySelection,
 } from './components/sdk/DeviceSelection';
 export {
   AudioInputControl,
   AudioOutputControl,
   ContentShareControl,
-  VideoInputControl
+  VideoInputControl,
 } from './components/sdk/MeetingControls';
 export { ContentShare } from './components/sdk/ContentShare';
 export { LocalVideo } from './components/sdk/LocalVideo';
@@ -77,15 +77,15 @@ export { KEY_CODES } from './constants';
 // Contexts
 export {
   ControlBarContext,
-  useControlBarContext
+  useControlBarContext,
 } from './components/ui/ControlBar/ControlBarContext';
 export {
   ModalContext,
-  useModalContext
+  useModalContext,
 } from './components/ui/Modal/ModalContext';
 export {
   useNotificationState,
-  useNotificationDispatch
+  useNotificationDispatch,
 } from './providers/NotificationProvider';
 export { AudioVideoContext } from './providers/AudioVideoProvider';
 
@@ -109,17 +109,18 @@ export { useFeaturedTileState } from './providers/FeaturedVideoTileProvider';
 export {
   useAudioInputs,
   useVideoInputs,
-  useAudioOutputs
+  useAudioOutputs,
 } from './providers/DevicesProvider';
 export { useToggleLocalMute } from './hooks/sdk/useToggleLocalMute';
 export { useLocalAudioOutput } from './providers/LocalAudioOutputProvider';
 export { useLocalVideo } from './providers/LocalVideoProvider';
 export {
   useContentShareState,
-  useContentShareControls
+  useContentShareControls,
 } from './providers/ContentShareProvider';
 export { useMeetingStatus } from './hooks/sdk/useMeetingStatus';
 export { useLocalAudioInputActivityPreview } from './hooks/sdk/useLocalAudioInputActivityPreview';
+export { useBandwidthMetrics } from './hooks/sdk/useBandwidthMetrics';
 
 // Providers
 export { NotificationProvider } from './providers/NotificationProvider';
@@ -132,7 +133,10 @@ export { RosterProvider } from './providers/RosterProvider';
 export { DevicesProvider } from './providers/DevicesProvider';
 export { RemoteVideoTileProvider } from './providers/RemoteVideoTileProvider';
 export { FeaturedVideoTileProvider } from './providers/FeaturedVideoTileProvider';
-export { UserActivityProvider, useUserActivityState } from './providers/UserActivityProvider';
+export {
+  UserActivityProvider,
+  useUserActivityState,
+} from './providers/UserActivityProvider';
 
 // Themes
 export { lightTheme, darkTheme, GlobalStyles, StyledReset } from './theme';


### PR DESCRIPTION
**Description of changes:**
Displays incoming/outgoing bandwidth usage for an active meeting session

**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes?

3. If you made changes to the component library, have you provided corresponding documentation changes?
yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
