### PR TITLE
Update device selectors to use hooks instead of local state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Demo] Default to nearest available region
 - [Docs] Upgrade storybook to v6
+- Update Device selector to use hooks instead of local state
 
 ### Removed
 

--- a/src/components/sdk/DeviceSelection/CameraSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/CameraSelection/index.tsx
@@ -19,7 +19,7 @@ export const CameraSelection: React.FC<Props> = ({
   label = 'Camera source'
 }) => {
   const meetingManager = useMeetingManager();
-  const { devices } = useVideoInputs();
+  const { devices, selectedDevice } = useVideoInputs();
 
   async function selectVideoInput(deviceId: string) {
     meetingManager.selectVideoInputDevice(deviceId);
@@ -30,6 +30,7 @@ export const CameraSelection: React.FC<Props> = ({
       label={label}
       onChange={selectVideoInput}
       devices={devices}
+      selectedDeviceId={selectedDevice}
       notFoundMsg={notFoundMsg}
     />
   );

--- a/src/components/sdk/DeviceSelection/DeviceInput.tsx
+++ b/src/components/sdk/DeviceSelection/DeviceInput.tsx
@@ -1,16 +1,17 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useState, useEffect, ChangeEvent } from 'react';
+import React, { ChangeEvent } from 'react';
 
 import { FormField } from '../../ui/FormField';
 import { Select } from '../../ui/Select';
-import { DeviceType } from '../../../types';
+import { DeviceType, SelectedDeviceId } from '../../../types';
 
 interface Props {
   label: string;
   notFoundMsg: string;
   devices: DeviceType[];
+  selectedDeviceId: SelectedDeviceId;
   onChange: (deviceId: string) => void;
 }
 
@@ -18,9 +19,9 @@ const DeviceInput: React.FC<Props> = ({
   onChange,
   label,
   devices,
+  selectedDeviceId,
   notFoundMsg
 }) => {
-  const [selectedDevice, setSelectedDevice] = useState('');
 
   const outputOptions = devices.map(device => ({
     value: device.deviceId,
@@ -36,22 +37,12 @@ const DeviceInput: React.FC<Props> = ({
         }
       ];
 
-  useEffect(() => {
-    if (!devices.length || selectedDevice) {
-      return;
-    }
-
-    setSelectedDevice(devices[0].deviceId);
-  }, [devices, selectedDevice]);
-
   async function selectDevice(e: ChangeEvent<HTMLSelectElement>) {
     const deviceId = e.target.value;
 
     if (deviceId === 'not-available') {
       return;
     }
-
-    setSelectedDevice(deviceId);
     onChange(deviceId);
   }
 
@@ -60,7 +51,7 @@ const DeviceInput: React.FC<Props> = ({
       field={Select}
       options={options}
       onChange={selectDevice}
-      value={selectedDevice}
+      value={selectedDeviceId || ''}
       label={label}
     />
   );

--- a/src/components/sdk/DeviceSelection/MicSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/MicSelection/index.tsx
@@ -19,7 +19,7 @@ export const MicSelection: React.FC<Props> = ({
   label = 'Microphone source'
 }) => {
   const meetingManager = useMeetingManager();
-  const { devices } = useAudioInputs();
+  const { devices, selectedDevice } = useAudioInputs();
 
   async function selectAudioInput(deviceId: string) {
     meetingManager.selectAudioInputDevice(deviceId);
@@ -30,6 +30,7 @@ export const MicSelection: React.FC<Props> = ({
       label={label}
       onChange={selectAudioInput}
       devices={devices}
+      selectedDeviceId={selectedDevice}
       notFoundMsg={notFoundMsg}
     />
   );

--- a/src/components/sdk/DeviceSelection/SpeakerSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/SpeakerSelection/index.tsx
@@ -1,7 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 
 import { useMeetingManager } from '../../../../providers/MeetingProvider';
 import { useAudioOutputs } from '../../../../providers/DevicesProvider';
@@ -22,19 +22,9 @@ export const SpeakerSelection: React.FC<Props> = ({
   onChange
 }) => {
   const meetingManager = useMeetingManager();
-  const { devices } = useAudioOutputs();
-  const [selectedOutput, setSelectedOutput] = useState('');
-
-  useEffect(() => {
-    if (!devices.length || selectedOutput) {
-      return;
-    }
-
-    setSelectedOutput(devices[0].deviceId);
-  }, [selectedOutput, devices]);
+  const { devices, selectedDevice } = useAudioOutputs();
 
   async function selectAudioOutput(deviceId: string) {
-    setSelectedOutput(deviceId);
     meetingManager.selectAudioOutputDevice(deviceId);
     onChange && onChange(deviceId);
   }
@@ -44,6 +34,7 @@ export const SpeakerSelection: React.FC<Props> = ({
       label={label}
       devices={devices}
       onChange={selectAudioOutput}
+      selectedDeviceId={selectedDevice}
       notFoundMsg={notFoundMsg}
     />
   );

--- a/src/components/sdk/DeviceSelection/docs/CameraSelection.stories.mdx
+++ b/src/components/sdk/DeviceSelection/docs/CameraSelection.stories.mdx
@@ -5,7 +5,7 @@ import CameraSelection from '../CameraSelection';
 
 # CameraSelection
 
-The `CameraSelection` component renders a `Select FormField` component with video input source options provided by the `useVideoInputs` hook.
+The `CameraSelection` component renders a `Select FormField` component with video input source options and the selected video input provided by the `useVideoInputs` hook.
 
 By default, the first device will be selected from the device list returned by the `useVideoInputs` hook, otherwise a single option with _not found_ message will be shown.
 

--- a/src/components/sdk/DeviceSelection/docs/MicSelection.stories.mdx
+++ b/src/components/sdk/DeviceSelection/docs/MicSelection.stories.mdx
@@ -5,7 +5,7 @@ import MicSelection from '../MicSelection';
 
 # MicSelection
 
-The `MicSelection` component renders a `Select FormField` component with audio input source options provided by the `useAudioInputs` hook.
+The `MicSelection` component renders a `Select FormField` component with audio input source options and the selected audio input provided by the `useAudioInputs` hook.
 
 By default, the first device will be selected from the device list returned by the `useAudioInputs` hook, otherwise a single option with _not found_ message will be shown.
 

--- a/src/components/sdk/DeviceSelection/docs/SpeakerSelection.stories.mdx
+++ b/src/components/sdk/DeviceSelection/docs/SpeakerSelection.stories.mdx
@@ -5,7 +5,7 @@ import SpeakerSelection from '../SpeakerSelection';
 
 # SpeakerSelection
 
-The `SpeakerSelection` component renders a `Select FormField` with audio input source options provided by the `useAudioOutputs` hook.
+The `SpeakerSelection` component renders a `Select FormField` with audio output source options and the selected audio output device provided by the `useAudioOutputs` hook.
 
 By default, the first device will be selected from the device list returned by the `useAudioOutputs` hook, otherwise a single option with _not found_ message will be shown.
 

--- a/src/providers/DevicesProvider/AudioOutputProvider.tsx
+++ b/src/providers/DevicesProvider/AudioOutputProvider.tsx
@@ -40,9 +40,9 @@ const AudioOutputProvider: React.FC = ({ children }) => {
     let isMounted = true;
 
     const observer: DeviceChangeObserver = {
-      audioOutputsChanged: (newAudioOutput: MediaDeviceInfo[]) => {
+      audioOutputsChanged: (newAudioOutputs: MediaDeviceInfo[]) => {
         console.log('AudioOutputProvider - audio outputs updated');
-        setAudioOutputs(newAudioOutput);
+        setAudioOutputs(newAudioOutputs);
       },
     };
 


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Use hooks instead of a local state inside Device Input

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes?
- Selected difference devices in the /devices page (preview page) and verified that the correct selected devices showed up

3. If you made changes to the component library, have you provided corresponding documentation changes?
yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
