### PR TITLE
Add documentation for UserActivityProvider and RosterProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add documentation for UserActivityProvider and RosterProvider
+
+### Changed
+
+### Removed
+
+### Fixed
+
+## [Unreleased]
+
+### Added
 
 - Add PostLogger support to MeetingProvider
 - Add `useBandwidthMetrics` hook, add bandwidth stats to demo

--- a/src/providers/RosterProvider/docs/RosterProvider.stories.mdx
+++ b/src/providers/RosterProvider/docs/RosterProvider.stories.mdx
@@ -1,0 +1,61 @@
+<Meta title="SDK Providers/RosterProvider" />
+
+# RosterProvider
+
+The `RosterProvider` provides the state of the roster.
+
+### State
+
+```javascript
+{
+ [AttendeeId: string]: {
+   chimeAttendeeId: string;
+   externalUserId?: string;
+   name?: string;
+ }
+}
+```
+You can access the state by using the [useRosterState](/?path=/docs/sdk-hooks-userosterstate--page) hook.
+
+## Usage
+
+If you are using `MeetingProvider`, the `RosterProvider` is rendered by default.
+
+```jsx
+import React from 'react';
+import {
+  MeetingProvider,
+  useRosterState,
+  Roster,
+  RosterGroup,
+  RosterAttendee
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <MeetingProvider>
+    <MyChild />
+  </MeetingProvider>
+);
+
+const MyChild = () => {
+  const { roster } = useRosterState();
+  const rosterArray = Object.values(roster);
+
+  const attendeeItems = attendees.map(attendee => {
+    const { chimeAttendeeId, name } = attendee;
+    return (
+      <RosterAttendee key={chimeAttendeeId} attendeeId={chimeAttendeeId} />
+    );
+  });
+
+  return (
+    <Roster>
+      <RosterGroup>{attendeeItems}</RosterGroup>
+    </Roster>
+  );
+};
+```
+
+### Dependencies
+
+- `MeetingProvider`

--- a/src/providers/UserActivityProvider/docs/UserActivityProvider.stories.mdx
+++ b/src/providers/UserActivityProvider/docs/UserActivityProvider.stories.mdx
@@ -1,0 +1,44 @@
+<Meta title="SDK Providers/UserActivityProvider" />
+
+# UserActivityProvider
+
+The `UserActivityProvider` provides the state of user activity by tracking mouse movements and focus events. The user activity state can be used to conditionally show/hide elements like the [ControlBar](?path=/story/ui-components-controlbar--control-bar) component.
+
+### State
+
+```javascript
+{
+    // Whether or not the the user is active
+    isUserActive: boolean | null;
+}
+```
+
+## Importing
+
+```javascript
+import { UserActivityProvider } from 'amazon-chime-sdk-component-library-react';
+```
+
+You can access the state by using the [useUserActivityState](/?path=/docs/sdk-hooks-useuseractivitystate--page) hook.
+
+## Usage
+
+```jsx
+import React from 'react';
+import {
+  UserActivityProvider,
+  useUserActivityState,
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <UserActivityProvider>
+    <MyChild />
+  </UserActivityProvider>
+);
+
+const MyChild = () => {
+  const { isUserActive } = useUserActivityState();
+
+  return isUserActive ? <div>Active</div> : <div>Not active</div>;
+};
+```

--- a/src/providers/UserActivityProvider/docs/useUserActivityState.stories.mdx
+++ b/src/providers/UserActivityProvider/docs/useUserActivityState.stories.mdx
@@ -1,0 +1,48 @@
+<Meta title="SDK Hooks/useUserActivityState" />
+
+# useUserActivityState
+
+The `useUserActivityState` hook returns the state of the user activity.
+
+### Return Value
+
+```javascript
+{
+    // Whether or not the the user is active
+    isUserActive: boolean | null;
+}
+```
+
+## Importing
+
+```javascript
+import { useUserActivityState } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+The hook depends on the `UserActivityProvider`.
+
+```jsx
+import React from 'react';
+import {
+  UserActivityProvider,
+  useUserActivityState,
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <UserActivityProvider>
+    <MyChild />
+  </UserActivityProvider>
+);
+
+const MyChild = () => {
+  const { isUserActive } = useUserActivityState();
+
+  return isUserActive ? <div>Active</div> : <div>Not active</div>;
+};
+```
+
+### Dependencies
+
+- `UserActivityProvider`


### PR DESCRIPTION
**Issue #:** 
https://github.com/aws/amazon-chime-sdk-component-library-react/issues/172
**Description of changes:**
Add documentation for UserActivityProvider and RosterProvider

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? n/a

3. If you made changes to the component library, have you provided corresponding documentation changes?
yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
