### PR TITLE
Fix useAttendeeStatus local user bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed `css` prop not taking precedence over media queries
 - Fixed incorrect device permission status
+- Fixed `useAttendeeStatus` returning incorrect video state for local user when mounting
 
 ## [1.1.0] - 2020-08-14
 

--- a/src/hooks/sdk/useAttendeeStatus.tsx
+++ b/src/hooks/sdk/useAttendeeStatus.tsx
@@ -23,10 +23,18 @@ export function useAttendeeStatus(attendeeId: string): RosterAttendeeStatus {
       return null;
     }
 
+    const localAttendeeId = (audioVideo as any).audioVideoController
+      ?.realtimeController?.state?.localAttendeeId;
+    const isLocalUser = attendeeId === localAttendeeId;
     const tiles = audioVideo.getAllVideoTiles();
-    const videoTile = tiles.find(tile => {
+    const videoTile = tiles.find((tile) => {
       const state = tile.state();
-      return !state.isContent && state.boundAttendeeId === attendeeId;
+
+      if (state.isContent || (isLocalUser && !state.active)) {
+        return false;
+      }
+
+      return state.boundAttendeeId === attendeeId;
     });
 
     return videoTile ? videoTile.state().tileId : null;
@@ -38,7 +46,7 @@ export function useAttendeeStatus(attendeeId: string): RosterAttendeeStatus {
     }
 
     const tiles = audioVideo.getAllVideoTiles();
-    const videoTile = tiles.find(tile => {
+    const videoTile = tiles.find((tile) => {
       const state = tile.state();
       if (!state.boundAttendeeId || !state.isContent) {
         return false;
@@ -56,7 +64,7 @@ export function useAttendeeStatus(attendeeId: string): RosterAttendeeStatus {
     }
 
     const observer: AudioVideoObserver = {
-      videoTileDidUpdate: state => {
+      videoTileDidUpdate: (state) => {
         if (state.boundAttendeeId !== attendeeId) {
           return;
         }
@@ -76,7 +84,7 @@ export function useAttendeeStatus(attendeeId: string): RosterAttendeeStatus {
         if (tileId === videoTileId) {
           setVideoTileId(null);
         }
-      }
+      },
     };
 
     audioVideo.addObserver(observer);
@@ -90,7 +98,7 @@ export function useAttendeeStatus(attendeeId: string): RosterAttendeeStatus {
     }
 
     const observer: AudioVideoObserver = {
-      videoTileDidUpdate: state => {
+      videoTileDidUpdate: (state) => {
         if (!state.isContent || !state.boundAttendeeId || contentTileId) {
           return;
         }
@@ -107,7 +115,7 @@ export function useAttendeeStatus(attendeeId: string): RosterAttendeeStatus {
         if (tileId === contentTileId) {
           setContentTileId(null);
         }
-      }
+      },
     };
 
     audioVideo.addObserver(observer);
@@ -122,7 +130,7 @@ export function useAttendeeStatus(attendeeId: string): RosterAttendeeStatus {
   return {
     ...audioState,
     videoEnabled,
-    sharingContent
+    sharingContent,
   };
 }
 


### PR DESCRIPTION
**Issue #:** 
When disabling your local video, there is still a video tile present in the session. This was causing incorrect state for the local user when using `useAttendeeStatus` on mount.

**Description of changes:**
Fixes above bug by checking if the tile is active

**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes?
yes

3. If you made changes to the component library, have you provided corresponding documentation changes?
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
