### PR TITLE
useToggleLocalMute: Initialize muted when audioVideo changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [Unreleased]
+
+### Fixed
+
+- Fixed `useToggleLocalMute` not working when mounted before audioVideo initialized
 
 ## [1.2.0] - 2020-09-04
 

--- a/src/hooks/sdk/useToggleLocalMute.tsx
+++ b/src/hooks/sdk/useToggleLocalMute.tsx
@@ -17,6 +17,7 @@ export function useToggleLocalMute() {
     };
 
     audioVideo?.realtimeSubscribeToMuteAndUnmuteLocalAudio(muteUnmutecallback);
+    setMuted(audioVideo?.realtimeIsLocalAudioMuted() || false);
 
     return (): void => {
       audioVideo?.realtimeUnsubscribeToMuteAndUnmuteLocalAudio(muteUnmutecallback);
@@ -29,7 +30,7 @@ export function useToggleLocalMute() {
     } else {
       audioVideo?.realtimeMuteLocalAudio();
     }
-  }, [muted]);
+  }, [muted, audioVideo]);
 
   return { muted, toggleMute };
 }


### PR DESCRIPTION
**Issue #:** #190 
useToggleLocalMute not working when audioVideo initialized after component


**Description of changes:**
Fixes the bug above by re-initializing state & updating callback when audioVideo changes

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
Using our local chime application as well as a regression with demo/meeting

3. If you made changes to the component library, have you provided corresponding documentation changes?
Yes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
