### PR TITLE
Add av dep and additional cb to useLocalAudioInputActivityPreview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed `useToggleLocalMute` not working when mounted before audioVideo initialized
 
+## Unreleased
+
+### Added
+
+- Add `useLocalAudioInputActivityPreview` hook for direct access to microphone input value
+
+### Changed
+
+### Removed
+
+### Fixed
+
+- Fixed missing `audioVideo` deps in `useLocalAudioInputActivityPreview`
+
 ## [1.2.0] - 2020-09-04
 
 ### Added

--- a/src/hooks/sdk/docs/useLocalAudioInputActivity.stories.mdx
+++ b/src/hooks/sdk/docs/useLocalAudioInputActivity.stories.mdx
@@ -1,0 +1,53 @@
+<Meta title="SDK Hooks/useLocalAudioInputActivity" />
+
+# useLocalAudioInputActivity
+
+The `useLocalAudioInputActivity` calls the provided callback with the current microphone input decimal value.
+
+You can use this hook to develop a custom microphone activity preview component. Be aware that the update is high-frequency, so you should be careful when storing it in React
+
+## Parameters
+
+This hook accepts a single parameter:
+
+```javascript
+// The current audio input activity in decimal format
+- cb: (decimal: number) => void;
+```
+
+## Importing
+
+```javascript
+import { useLocalAudioInputActivity } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+The hook depends on the `AudioVideoProvider`. If you are using `MeetingProvider`, it is rendered by default.
+
+```jsx
+import React, { useRef } from 'react';
+import {
+  MeetingProvider,
+  useLocalAudioInputActivity,
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <MeetingProvider>
+    <CustomMicrophoneActivity />
+  </MeetingProvider>
+);
+
+const CustomMicrophoneActivity = () => {
+  const callback = (decimal: number) => {
+    console.log('Current audio level: ', decimal);
+  };
+  useLocalAudioInputActivity(callback);
+};
+```
+
+### Dependencies
+
+- `MeetingProvider`
+- `AudioVideoProvider`, If you are using `MeetingProvider`, `AudioVideoProvider` is rendered by default
+- `useAudioInputs`

--- a/src/hooks/sdk/useLocalAudioInputActivity.tsx
+++ b/src/hooks/sdk/useLocalAudioInputActivity.tsx
@@ -1,0 +1,67 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect } from 'react';
+
+import { useAudioVideo } from '../../providers/AudioVideoProvider';
+import { useAudioInputs } from '../../providers/DevicesProvider';
+
+export const useLocalAudioInputActivity = (cb: (decimal: number) => void) => {
+  const audioVideo = useAudioVideo();
+  const { selectedDevice } = useAudioInputs();
+
+  useEffect(() => {
+    if (!audioVideo) {
+      return;
+    }
+
+    const analyserNode = audioVideo.createAnalyserNodeForAudioInput();
+
+    if (!analyserNode?.getByteTimeDomainData) {
+      return;
+    }
+
+    const data = new Uint8Array(analyserNode.fftSize);
+    let frameIndex = 0;
+    let isMounted = true;
+    let lastDecimal: number;
+
+    function analyserNodeCallback() {
+      if (!analyserNode) {
+        return;
+      }
+
+      if (frameIndex === 0) {
+        analyserNode.getByteTimeDomainData(data);
+        const lowest = 0.01;
+        let max = lowest;
+        for (const f of data as any) {
+          max = Math.max(max, (f - 128) / 128);
+        }
+        const decimal = (Math.log(lowest) - Math.log(max)) / Math.log(lowest);
+
+        if (lastDecimal !== decimal) {
+          lastDecimal = decimal;
+
+          if (cb) {
+            cb(decimal);
+          }
+        }
+      }
+
+      frameIndex = (frameIndex + 1) % 2;
+
+      if (isMounted) {
+        requestAnimationFrame(analyserNodeCallback);
+      }
+    }
+
+    requestAnimationFrame(analyserNodeCallback);
+
+    return () => {
+      isMounted = false;
+    };
+  }, [audioVideo, selectedDevice, cb]);
+};
+
+export default useLocalAudioInputActivity;

--- a/src/hooks/sdk/useLocalAudioInputActivityPreview.tsx
+++ b/src/hooks/sdk/useLocalAudioInputActivityPreview.tsx
@@ -1,61 +1,29 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect } from 'react';
+import { useCallback } from 'react';
 
-import { useAudioVideo } from '../../providers/AudioVideoProvider';
-import { useAudioInputs } from '../../providers/DevicesProvider';
+import useLocalAudioInputActivity from './useLocalAudioInputActivity';
 
 type TransformScaleDirection = 'horizontal' | 'vertical';
 
-export const useLocalAudioInputActivityPreview = (elementRef: any, scaleDirection: TransformScaleDirection = 'horizontal') => {
-  const audioVideo = useAudioVideo();
-  const { selectedDevice } = useAudioInputs();
-
-  useEffect(() => {
-    const analyserNode = audioVideo?.createAnalyserNodeForAudioInput();
-
-    if (!analyserNode?.getByteTimeDomainData) {
-      return;
-    }
-
-    const data = new Uint8Array(analyserNode.fftSize);
-    let frameIndex = 0;
-    let isMounted = true;
-
-    function analyserNodeCallback() {
-      if (!analyserNode) {
-        return;
-      }
-
-      if (frameIndex === 0) {
-        analyserNode.getByteTimeDomainData(data);
-        const lowest = 0.01;
-        let max = lowest;
-        for (const f of data as any) {
-          max = Math.max(max, (f - 128) / 128);
-        }
-        const decimal = (Math.log(lowest) - Math.log(max)) / Math.log(lowest);
-
-        if (elementRef.current && decimal >= 0) {
-          elementRef.current.style.transform = scaleDirection === 'horizontal' 
+export const useLocalAudioInputActivityPreview = (
+  elementRef?: any,
+  scaleDirection: TransformScaleDirection | null | undefined = 'horizontal'
+) => {
+  const cb = useCallback(
+    (decimal: number) => {
+      if (elementRef.current) {
+        elementRef.current.style.transform =
+          scaleDirection === 'horizontal'
             ? `scaleX(${decimal})`
             : `scaleY(${decimal})`;
-        }
       }
-      frameIndex = (frameIndex + 1) % 2;
+    },
+    [scaleDirection]
+  );
 
-      if (isMounted) {
-        requestAnimationFrame(analyserNodeCallback);
-      }
-    }
-
-    requestAnimationFrame(analyserNodeCallback);
-
-    return () => {
-      isMounted = false;
-    };
-  }, [selectedDevice]);
+  useLocalAudioInputActivity(cb);
 };
 
 export default useLocalAudioInputActivityPreview;

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,7 @@ export { useSelectVideoInputDevice } from './hooks/sdk/useSelectVideoInputDevice
 export { useActiveSpeakersState } from './hooks/sdk/useActiveSpeakersState';
 export { useToggleLocalMute } from './hooks/sdk/useToggleLocalMute';
 export { useMeetingStatus } from './hooks/sdk/useMeetingStatus';
+export { useLocalAudioInputActivity } from './hooks/sdk/useLocalAudioInputActivity';
 export { useLocalAudioInputActivityPreview } from './hooks/sdk/useLocalAudioInputActivityPreview';
 export { useBandwidthMetrics } from './hooks/sdk/useBandwidthMetrics';
 


### PR DESCRIPTION
**Issue #:** 
- [Issue](https://github.com/aws/amazon-chime-sdk-component-library-react/issues/183) 
- [Issue](https://github.com/aws/amazon-chime-sdk-component-library-react/issues/182)

**Description of changes:**
- Adds audioVideo to dep list for `useLocalAudioInputActivityPreview`
- Takes additional cb param for custom logic


**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes? manually

3. If you made changes to the component library, have you provided corresponding documentation changes?
yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
