### PR TITLE
Fix search icon alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,25 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased]
 
 ### Fixed
-
 - Fixed `useToggleLocalMute` not working when mounted before audioVideo initialized
-
-## Unreleased
+- Fixed missing `audioVideo` deps in `useLocalAudioInputActivityPreview`
+- Fixed `leadingIcon` alignment in `SearchInput`
 
 ### Added
-
 - Add `useLocalAudioInputActivityPreview` hook for direct access to microphone input value
 
 ### Changed
 
 ### Removed
-
-### Fixed
-
-- Fixed missing `audioVideo` deps in `useLocalAudioInputActivityPreview`
 
 ## [1.2.0] - 2020-09-04
 

--- a/src/components/ui/Input/Styled.tsx
+++ b/src/components/ui/Input/Styled.tsx
@@ -20,7 +20,7 @@ export const StyledInputWrapper = styled.span<InputWrapperProps>`
     width: 1rem;
     left: 0.1875rem;
     position: absolute;
-    top: ${props => (props.sizing === 'sm' ? '0.25rem' : '0.5rem')};
+    top: ${(props) => (props.sizing === 'sm' ? '0.35rem' : '0.6rem')};
   }
 
   > input {


### PR DESCRIPTION

**Description of changes:**
Before:
<img width="307" alt="Screen Shot 2020-08-10 at 3 09 50 PM" src="https://user-images.githubusercontent.com/20075335/92514352-9a229e00-f1c6-11ea-96c6-8febffff8555.png">

Now:
![Screen Shot 2020-09-08 at 11 22 48 AM](https://user-images.githubusercontent.com/20075335/92514263-75c6c180-f1c6-11ea-8985-67df991104f1.png)


**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes?

3. If you made changes to the component library, have you provided corresponding documentation changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
