### PR TITLE
Ensure vertical alignment for roster cell icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Adjust clear behavior and minor styling of inputs
+- Changed RosterCell CSS to ensure vertical alignment of icons
 
 ### Removed
 

--- a/src/components/ui/Roster/RosterCell/Styled.tsx
+++ b/src/components/ui/Roster/RosterCell/Styled.tsx
@@ -14,6 +14,7 @@ export const StyledCell = styled.div<RosterCellProps>`
   .ch-mic {
     flex-shrink: 0;
     width: 1.5rem;
+    line-height: 0;
 
     ${({ micPosition }) =>
       micPosition === 'leading'


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Depending upon the styles applied higher up in the tree, the `Mic` icon can inherit a `line-height` that pushes the icon our of alignment. This change will prevent that.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes?
eyeballing the change in Storybook

3. If you made changes to the component library, have you provided corresponding documentation changes?
This change doesn't require documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
