### PR TITLE
Include prop for ControlBarButton active state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `useLocalAudioInputActivityPreview` hook for direct access to microphone input value
 - Add chat message component
+- Add `isSelected` prop to `ControlBarButton` component
 
 ### Changed
 

--- a/src/components/ui/ControlBar/ControlBarItem.tsx
+++ b/src/components/ui/ControlBar/ControlBarItem.tsx
@@ -22,12 +22,15 @@ export interface ControlBarButtonProps
   label: string;
   /** The items to render in a popover menu. When passed, the button will render an arrow to open or close a popover menu. Refer to [PopOverItem](/?path=/docs/ui-components-popover--basic-pop-over-menu) */
   popOver?: PopOverItemProps[] | null;
+  /**  Apply this prop to receive visual feedback that the button is 'active' */
+  isSelected?: boolean;
 }
 
 export const ControlBarButton: FC<ControlBarButtonProps> = ({
   icon,
   onClick,
   label,
+  isSelected = false,
   popOver = null,
   ...rest
 }) => {
@@ -40,6 +43,7 @@ export const ControlBarButton: FC<ControlBarButtonProps> = ({
       children={popOver?.map((option: PopOverItemProps, index: number) => (
         <PopOverItem {...option} key={index} />
       ))}
+      className="ch-control-bar-popover"
     />
   );
 
@@ -53,12 +57,13 @@ export const ControlBarButton: FC<ControlBarButtonProps> = ({
 
   return (
     <StyledControlBarItem
+      isSelected={isSelected}
       data-testid="control-bar-item"
       {...rest}
       {...context}
       popOver={popOver}
     >
-      <IconButton onClick={onClick} label={label} icon={icon} />
+      <IconButton onClick={onClick} label={label} icon={icon} className="ch-control-bar-item-iconButton"/>
       {!!popOver && renderPopOver()}
       {context.showLabels && (
         <div className="ch-control-bar-item-label">{label}</div>

--- a/src/components/ui/ControlBar/Styled.tsx
+++ b/src/components/ui/ControlBar/Styled.tsx
@@ -82,6 +82,7 @@ export const StyledControlBar = styled.div<StyledControlBarProps>`
 
 interface StyledControlBarItemProps extends StyledControlBarProps {
   popOver: PopOverItemProps[] | null;
+  isSelected: boolean;
 }
 
 export const StyledControlBarItem = styled.div<StyledControlBarItemProps>`
@@ -100,13 +101,10 @@ export const StyledControlBarItem = styled.div<StyledControlBarItemProps>`
       ''}
   `};
 
-  button {
-    color: ${({ theme }) => theme.controlBar.text};
-    border: none;
-    outline: none;
-    background-color: inherit;
-    grid-column-start: ${({ layout, popOver }) =>
-      isVertical(layout) && popOver ? '2' : '1'};
+  .ch-control-bar-item-iconButton {
+    color: ${({ theme, isSelected }) => isSelected ? `${theme.controlBar.selected.text}` : theme.controlBar.text};
+    background-color: ${({ isSelected, theme }) =>  isSelected ? `${theme.controlBar.selected.bgd}` : 'inherit'};
+    grid-column-start: ${({ layout, popOver }) => isVertical(layout) && popOver ? '2' : '1'};
 
     .ch-icon {
       width: 1.5rem;
@@ -114,14 +112,20 @@ export const StyledControlBarItem = styled.div<StyledControlBarItemProps>`
       background-color: inherit;
       border-radius: 100%;
     }
+  }
+
+  .ch-control-bar-popover {
+    background-color: inherit;
+    grid-column-start: ${({ layout, popOver }) => isVertical(layout) && popOver ? '2' : '1'};
+    color: ${({ theme }) => theme.controlBar.text};
+
+    .isOpen.ch-control-bar-item-caret {
+      color: ${props => props.theme.colors.primary.main};
+    }
 
     .ch-control-bar-item-caret {
       width: 1.5rem;
       height: 1.5rem;
-    }
-
-    .isOpen.ch-control-bar-item-caret {
-      color: ${props => props.theme.colors.primary.main};
     }
   }
 

--- a/src/components/ui/PopOver/index.tsx
+++ b/src/components/ui/PopOver/index.tsx
@@ -48,7 +48,8 @@ export const PopOver: FC<PopOverProps> = ({
   children,
   isSubMenu = false,
   placement = 'bottom-start',
-  a11yLabel
+  a11yLabel,
+  className,
 }) => {
   const menuRef = createRef<HTMLSpanElement>();
   const [isOpen, setIsOpen] = useState(false);
@@ -119,6 +120,7 @@ export const PopOver: FC<PopOverProps> = ({
               aria-haspopup={true}
               aria-expanded={isOpen}
               data-testid="popover-toggle"
+              className={className || ''}
             >
               {renderButton(isOpen)}
             </StyledPopOverToggle>

--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -307,7 +307,11 @@ const controlBar = {
   shadow: shadows.large,
   bgd: colors.greys.grey100,
   border: 'none',
-  opacity: 1
+  opacity: 1,
+  selected: {
+    text: buttons.primary.selected.text,
+    bgd: buttons.primary.selected.bgd,
+  },
 };
 
 const roster = {

--- a/src/theme/light.ts
+++ b/src/theme/light.ts
@@ -307,7 +307,11 @@ const controlBar = {
   shadow: shadows.large,
   bgd: colors.greys.white,
   border: `0.03125rem solid ${colors.greys.grey20}`,
-  opacity: 0.95
+  opacity: 0.95,
+  selected: {
+    text: buttons.primary.selected.text,
+    bgd: buttons.primary.selected.bgd,
+  },
 };
 
 const roster = {

--- a/src/theme/styled.d.ts
+++ b/src/theme/styled.d.ts
@@ -220,6 +220,10 @@ declare module 'styled-components' {
       bgd: string;
       border: string;
       opacity: string | number;
+      selected: {
+        text: string,
+        bgd: string,
+      }
     };
 
     roster: {


### PR DESCRIPTION
**Description of changes:**
Currently there's not way to manipulate a `button` in the `ControlBar` to give visual feedback that it is active, or toggled. This can be useful to give more visual feedback for states such as when a users' camera is on. This change introduces an optional `isActive` prop for a `ControlBarButton` component.

**Testing**
1. Have you successfully run `npm run build:release` locally?
I am experiencing issues with running snapshot tests. Other than that release ran without issue.

2. How did you test these changes?
Manually, (and hopefully with an updated snapshot test when I can get them to work).

3. If you made changes to the component library, have you provided corresponding documentation changes?
Yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
