### PR TITLE
Added onSearch callback for when a search is cleared

### DIFF
--- a/src/components/ui/Roster/RosterHeader.tsx
+++ b/src/components/ui/Roster/RosterHeader.tsx
@@ -88,6 +88,11 @@ export const RosterHeader: React.FC<RosterHeaderProps> = ({
   };
 
   const closeSearch = () => {
+    onSearch?.({
+      currentTarget: {
+        value: '',
+      },
+    } as React.ChangeEvent<HTMLInputElement>);
     setIsSearching(false);
     searchBtn.current?.focus();
   };

--- a/tst/components/ui/Roster/RosterHeader.test.tsx
+++ b/tst/components/ui/Roster/RosterHeader.test.tsx
@@ -1,7 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
+import React, { ChangeEvent } from 'react';
 import '@testing-library/jest-dom';
 import { fireEvent } from '@testing-library/dom';
 
@@ -28,10 +28,32 @@ describe('RosterCell', () => {
     expect(getByLabelText('Close')).toBeInTheDocument();
   });
 
-  it('should render a search button when onClose is passed', () => {
+  it('should render a search button when onSearch is passed', () => {
     const component = <RosterHeader title="Present" onSearch={() => {}} />;
     const { getByLabelText } = renderWithTheme(lightTheme, component);
     expect(getByLabelText('Open search')).toBeInTheDocument();
+  });
+
+  it('should call onSearch with "" when the search is closed', () => {
+    const mockOnSearch = jest.fn();
+    const component = <RosterHeader title="Present" onSearch={mockOnSearch} />;
+    const { getByLabelText } = renderWithTheme(lightTheme, component);
+    fireEvent(
+      getByLabelText('Open search'),
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+    expect(getByLabelText('Search')).toBeInTheDocument();
+    fireEvent(
+      getByLabelText('clear Search'),
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+    expect(mockOnSearch).toBeCalled();
   });
 
   it('should render a search button when search is pressed', () => {


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
When the RosterHeader component was in Search mode, there was no event data passed out of it when a user clicked the native "clear Search" (Note: capitalization mistake) "X" icon in the search element to signify that the search is done.


**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? `npm run test` new tests

3. If you made changes to the component library, have you provided corresponding documentation changes? No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
