### PR TITLE
Remove unused import in Select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed missing `audioVideo` deps in `useLocalAudioInputActivityPreview`
 - Fixed `leadingIcon` alignment in `SearchInput`
 - Rename icon (ContentShare > ScreenShare) to fix conflicting names
+- Remove unused import in Select
 
 ### Added
 

--- a/src/components/ui/Select/index.tsx
+++ b/src/components/ui/Select/index.tsx
@@ -11,7 +11,6 @@ import React, {
 
 import { StyledSelectInput, StyledWrapper } from './Styled';
 import UpAndDownCaret from '../icons/UpAndDownCaret';
-import { position } from 'styled-system';
 
 export type SelectOptions = {
   value: string | number;


### PR DESCRIPTION
**Issue #:** 
demo build fails due to unused import

**Description of changes:**
remove import

**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes? started demo after removing node_modules directories

3. If you made changes to the component library, have you provided corresponding documentation changes? n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
