### PR TITLE
Fix rename component ControlBarButton to ControlBarItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `useLocalAudioInputActivityPreview` hook for direct access to microphone input value
 - Add chat message component
-- Add `isSelected` prop to `ControlBarButton` component
+- Add `isSelected` prop to `ControlBarItem` component
 - Add `UpAndDownCaret` icon component
 - Add channel list component for chat
 - Add Share Video File feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `UpAndDownCaret` icon component
 - Add channel list component for chat
 - Add Share Video File feature
+- Rename component `ControlBarButton` to `ControlBarItem`
 
 ### Changed
 

--- a/demo/meeting/src/containers/EndMeetingControl/index.tsx
+++ b/demo/meeting/src/containers/EndMeetingControl/index.tsx
@@ -4,7 +4,7 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
-  ControlBarButton,
+  ControlBarItem,
   Phone,
   Modal,
   ModalBody,
@@ -45,7 +45,7 @@ const EndMeetingControl: React.FC = () => {
 
   return (
     <>
-      <ControlBarButton icon={<Phone />} onClick={toggleModal} label="Leave" />
+      <ControlBarItem icon={<Phone />} onClick={toggleModal} label="Leave" />
       {showModal && (
         <Modal size="md" onClose={toggleModal} rootId="modal-root">
           <ModalHeader title="End Meeting" />

--- a/demo/meeting/src/containers/MeetingControls/index.tsx
+++ b/demo/meeting/src/containers/MeetingControls/index.tsx
@@ -8,7 +8,7 @@ import {
   VideoInputControl,
   ContentShareControl,
   AudioOutputControl,
-  ControlBarButton,
+  ControlBarItem,
   useUserActivityState,
   Dots
 } from 'amazon-chime-sdk-component-library-react';
@@ -36,7 +36,7 @@ const MeetingControls = () => {
         layout="undocked-horizontal"
         showLabels
       >
-        <ControlBarButton
+        <ControlBarItem
           className="mobile-toggle"
           icon={<Dots />}
           onClick={handleToggle}

--- a/src/components/sdk/MeetingControls/AudioInputControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioInputControl.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import { ControlBarButton } from '../../ui/ControlBar/ControlBarItem';
+import { ControlBarItem } from '../../ui/ControlBar/ControlBarItem';
 import { Microphone } from '../../ui/icons';
 import { useMeetingManager } from '../../../providers/MeetingProvider';
 import { useAudioInputs } from '../../../providers/DevicesProvider';
@@ -38,7 +38,7 @@ const AudioInputControl: React.FC<Props> = ({
   }));
 
   return (
-    <ControlBarButton
+    <ControlBarItem
       icon={<Microphone muted={muted} />}
       onClick={toggleMute}
       label={muted ? unmuteLabel : muteLabel}

--- a/src/components/sdk/MeetingControls/AudioOutputControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioOutputControl.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import { ControlBarButton } from '../../ui/ControlBar/ControlBarItem';
+import { ControlBarItem } from '../../ui/ControlBar/ControlBarItem';
 import { Sound } from '../../ui/icons';
 import { useMeetingManager } from '../../../providers/MeetingProvider';
 import { useAudioOutputs } from '../../../providers/DevicesProvider';
@@ -33,7 +33,7 @@ const AudioOutputControl: React.FC<Props> = ({ label = 'Speaker' }) => {
 
   return (
     <>
-      <ControlBarButton
+      <ControlBarItem
         icon={<Sound disabled={!isAudioOn} />}
         onClick={toggleAudio}
         label={label}

--- a/src/components/sdk/MeetingControls/ContentShareControl.tsx
+++ b/src/components/sdk/MeetingControls/ContentShareControl.tsx
@@ -3,7 +3,7 @@
 
 import React, { useRef } from 'react';
 
-import { ControlBarButton } from '../../ui/ControlBar/ControlBarItem';
+import { ControlBarItem } from '../../ui/ControlBar/ControlBarItem';
 import { ScreenShare } from '../../ui/icons';
 import { useContentShareState } from '../../../providers/ContentShareProvider';
 import { useContentShareControls } from '../../../providers/ContentShareProvider';
@@ -69,7 +69,7 @@ const ContentShareControl: React.FC<Props> = ({
 
   return (
     <>
-      <ControlBarButton
+      <ControlBarItem
         icon={<ScreenShare />}
         onClick={mediaUrl ? toggleVideoFileShare : toggleContentShare}
         label={label}

--- a/src/components/sdk/MeetingControls/VideoInputControl.tsx
+++ b/src/components/sdk/MeetingControls/VideoInputControl.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import { ControlBarButton } from '../../ui/ControlBar/ControlBarItem';
+import { ControlBarItem } from '../../ui/ControlBar/ControlBarItem';
 import { Camera } from '../../ui/icons';
 import { useVideoInputs } from '../../../providers/DevicesProvider';
 import { useLocalVideo } from '../../../providers/LocalVideoProvider';
@@ -33,7 +33,7 @@ const VideoInputControl: React.FC<Props> = ({ label = 'Video' }) => {
   }));
 
   return (
-    <ControlBarButton
+    <ControlBarItem
       icon={<Camera disabled={!isVideoEnabled} />}
       onClick={toggleVideo}
       label={label}

--- a/src/components/sdk/MeetingControls/docs/AudioInputControl.stories.mdx
+++ b/src/components/sdk/MeetingControls/docs/AudioInputControl.stories.mdx
@@ -5,7 +5,7 @@ import AudioInputControl from '../AudioInputControl';
 
 # AudioInputControl
 
-The `AudioInputControl` component renders a `ControlBarButton` with pop over menu options to select through multiple audio input options.
+The `AudioInputControl` component renders a `ControlBarItem` with pop over menu options to select through multiple audio input options.
 These audio input options are provided by the `useAudioInputs` hook.
 
 When you click the button, the local audio input toggles between muted/unmuted state.
@@ -24,7 +24,7 @@ import { AudioInputControl } from 'amazon-chime-sdk-component-library-react';
 import React from 'react';
 import {
   MeetingProvider,
-  AudioInputControl
+  AudioInputControl,
 } from 'amazon-chime-sdk-component-library-react';
 
 const App = () => {

--- a/src/components/sdk/MeetingControls/docs/AudioOutputControl.stories.mdx
+++ b/src/components/sdk/MeetingControls/docs/AudioOutputControl.stories.mdx
@@ -5,7 +5,7 @@ import AudioOutputControl from '../AudioOutputControl';
 
 # AudioOutputControl
 
-The `AudioOutputControl` component renders a `ControlBarButton` with pop over menu options to select through multiple audio output options.
+The `AudioOutputControl` component renders a `ControlBarItem` with pop over menu options to select through multiple audio output options.
 These audio output options are provided by the `useAudioOutputs` hook.
 
 When you click the button, the local audio output toggles between on/off state.
@@ -24,7 +24,7 @@ import { AudioOutputControl } from 'amazon-chime-sdk-component-library-react';
 import React from 'react';
 import {
   MeetingProvider,
-  AudioOutputControl
+  AudioOutputControl,
 } from 'amazon-chime-sdk-component-library-react';
 
 const App = () => {

--- a/src/components/sdk/MeetingControls/docs/ContentShareControl.stories.mdx
+++ b/src/components/sdk/MeetingControls/docs/ContentShareControl.stories.mdx
@@ -5,7 +5,7 @@ import ContentShareControl from '../ContentShareControl';
 
 # ContentShareControl
 
-The `ContentShareControl` component renders a `ControlBarButton` with pop over menu options to pause/resume screen or video file share once enabled.
+The `ContentShareControl` component renders a `ControlBarItem` with pop over menu options to pause/resume screen or video file share once enabled.
 
 When you click the button, it toggles screen share between on/off state.
 

--- a/src/components/sdk/MeetingControls/docs/VideoInputControl.stories.mdx
+++ b/src/components/sdk/MeetingControls/docs/VideoInputControl.stories.mdx
@@ -5,7 +5,7 @@ import VideoInputControl from '../VideoInputControl';
 
 # VideoInputControl
 
-The `VideoInputControl` component renders a `ControlBarButton` with pop over menu options to select through multiple video input sources.
+The `VideoInputControl` component renders a `ControlBarItem` with pop over menu options to select through multiple video input sources.
 These video input sources are provided by the `useVideoInputs` hook.
 
 When you click the button, the local video input toggles between on/off state.
@@ -24,7 +24,7 @@ import { VideoInputControl } from 'amazon-chime-sdk-component-library-react';
 import React from 'react';
 import {
   MeetingProvider,
-  VideoInputControl
+  VideoInputControl,
 } from 'amazon-chime-sdk-component-library-react';
 
 const App = () => {

--- a/src/components/ui/ControlBar/ControlBarItem.tsx
+++ b/src/components/ui/ControlBar/ControlBarItem.tsx
@@ -11,7 +11,7 @@ import { useControlBarContext } from './ControlBarContext';
 import IconButton from '../Button/IconButton';
 import { BaseProps } from '../Base';
 
-export interface ControlBarButtonProps
+export interface ControlBarItemProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'css'>,
     BaseProps {
   /** The icon of the control bar item. */
@@ -26,7 +26,7 @@ export interface ControlBarButtonProps
   isSelected?: boolean;
 }
 
-export const ControlBarButton: FC<ControlBarButtonProps> = ({
+export const ControlBarItem: FC<ControlBarItemProps> = ({
   icon,
   onClick,
   label,
@@ -72,4 +72,4 @@ export const ControlBarButton: FC<ControlBarButtonProps> = ({
   );
 };
 
-export default ControlBarButton;
+export default ControlBarItem;

--- a/src/components/ui/Navbar/NavbarItem.tsx
+++ b/src/components/ui/Navbar/NavbarItem.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import { StyledNavbarItem } from './Styled';
 import { PopOverItemProps } from '../PopOver/PopOverItem';
-import ControlBarButton from '../ControlBar/ControlBarItem';
+import ControlBarItem from '../ControlBar/ControlBarItem';
 
 export interface NavbarItemProps {
   /** Any icon from the library for button in navbar item */
@@ -25,7 +25,7 @@ export const NavbarItem = ({
   popOver = null
 }: NavbarItemProps) => (
   <StyledNavbarItem data-testid="navbar-item">
-    <ControlBarButton
+    <ControlBarItem
       onClick={onClick}
       label={label}
       icon={icon}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export { SecondaryButton } from './components/ui/Button/SecondaryButton';
 export { IconButton } from './components/ui/Button/IconButton';
 export { Checkbox } from './components/ui/Checkbox';
 export { ControlBar } from './components/ui/ControlBar';
-export { ControlBarButton } from './components/ui/ControlBar/ControlBarItem';
+export { ControlBarItem } from './components/ui/ControlBar/ControlBarItem';
 export { Flex } from './components/ui/Flex';
 export { FormField } from './components/ui/FormField';
 export { Heading } from './components/ui/Heading';

--- a/tst/components/ui/ControlBar/ControlBarItem.test.tsx
+++ b/tst/components/ui/ControlBar/ControlBarItem.test.tsx
@@ -23,8 +23,8 @@ export const controlBarItemWithPopOverProps = {
   popOver: [{ onClick: () => console.log('popover item clicked'), children: <span>option 1</span>}]
 };
 
-describe('ControlBarButton', () => {
-  it('renders a ControlBarButton', () => {
+describe('ControlBarItem', () => {
+  it('renders a ControlBarItem', () => {
     const component = <ControlBarItem {...controlBarItemProps}/>;
     const { getByTestId } = renderWithTheme(lightTheme, component)
     const el = getByTestId('control-bar-item');


### PR DESCRIPTION
**Issue #216:** 

**Description of changes:**
The component was renamed from `ControlBarButton` to` ControlBarItem` and the export name `ControlBarItem`.

Before this change, the component was exported as `ControlBarButton`

**Testing**
1. Have you successfully run `npm run build:release` locally?
yes

2. How did you test these changes?
By running the `storybook` in Chrome/FireFox/Safari

3. If you made changes to the component library, have you provided corresponding documentation changes?
yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
