### PR TITLE
Add layout prop for VideoTileGrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed RosterCell CSS to ensure vertical alignment of icons
 - [DEMO] Upgrade `webpack-dev-server` to fix `node-forge` security vulnerability alert
 - Updated `Select` caret icon
+- Allow layout prop for VideoTileGrid
 
 ### Removed
 

--- a/src/components/sdk/VideoTileGrid/index.tsx
+++ b/src/components/sdk/VideoTileGrid/index.tsx
@@ -10,7 +10,8 @@ import { useLocalVideo } from '../../../providers/LocalVideoProvider';
 import { ContentShare } from '../ContentShare';
 import { LocalVideo } from '../LocalVideo';
 import { FeaturedRemoteVideos } from '../FeaturedRemoteVideos';
-import { VideoGrid } from '../../ui/VideoGrid';
+import { RemoteVideos } from '../RemoteVideos';
+import { VideoGrid, Layout } from '../../ui/VideoGrid';
 import { BaseProps } from '../../ui/Base';
 
 const fluidStyles = `
@@ -35,17 +36,20 @@ const staticStyles = `
 interface Props extends BaseProps {
   /** A component to render when there are no remote videos present */
   noRemoteVideoView?: React.ReactNode;
+  /** The layout of the grid. */
+  layout?: Layout;
 }
 
 export const VideoTileGrid: React.FC<Props> = ({
   noRemoteVideoView,
+  layout = "featured",
   ...rest
 }) => {
   const { tileId: featureTileId } = useFeaturedTileState();
   const { tiles } = useRemoteVideoTileState();
   const { tileId: contentTileId } = useContentShareState();
   const { isVideoEnabled } = useLocalVideo();
-  const featured = !!featureTileId || !!contentTileId;
+  const featured = layout === "featured" && !!featureTileId || !!contentTileId;
   const remoteSize = tiles.length + (contentTileId ? 1 : 0);
   const gridSize =
     remoteSize > 1 && isVideoEnabled ? remoteSize + 1 : remoteSize;
@@ -53,7 +57,7 @@ export const VideoTileGrid: React.FC<Props> = ({
   return (
     <VideoGrid {...rest} size={gridSize} layout={featured ? 'featured' : null}>
       <ContentShare css="grid-area: ft;" />
-      <FeaturedRemoteVideos />
+      { layout === "featured" ? <FeaturedRemoteVideos /> : <RemoteVideos/> }
       <LocalVideo
         nameplate="Me"
         css={gridSize > 1 ? fluidStyles : staticStyles}

--- a/src/components/ui/VideoGrid/index.tsx
+++ b/src/components/ui/VideoGrid/index.tsx
@@ -6,7 +6,7 @@ import React, { createRef, useContext, createContext } from 'react';
 import { StyledGrid } from './Styled';
 import useElementAspectRatio from '../../../hooks/useElementAspectRatio';
 
-type Layout = 'standard' | 'featured' | null;
+export type Layout = 'standard' | 'featured' | null;
 
 export interface VideoGridProps extends React.HTMLAttributes<HTMLDivElement> {
   /** The number of tiles to lay out. */


### PR DESCRIPTION
**Issue #:** 
Fixes issue #211 

**Description of changes:**
Allow layout prop to VideoTileGrid for developers who want to choose between a featured video layout and a standard video layout 

**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes? manually

3. If you made changes to the component library, have you provided corresponding documentation changes? yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
