### PR TITLE
Fixed bug so user leaves a meeting when the use back button or naviga…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename icon (ContentShare > ScreenShare) to fix conflicting names
 - Remove unused import in Select
 - Temporarily removed ChannelList component snapshot test
+- [Demo] Fixed so a user leaves a meeting when they press the back button in the browser or navigate back to home
 
 ### Added
 

--- a/demo/meeting/src/providers/NavigationProvider.tsx
+++ b/demo/meeting/src/providers/NavigationProvider.tsx
@@ -8,6 +8,10 @@ import React, {
   useRef,
   ReactNode
 } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+
+import routes from '../constants/routes';
 
 export type NavigationContextType = {
   showNavbar: boolean;
@@ -37,6 +41,17 @@ const NavigationProvider = ({ children }: Props) => {
   const [showRoster, setShowRoster] = useState(() => isDesktop());
   const [showMetrics, setShowMetrics] = useState(false);
   const isDesktopView = useRef(isDesktop());
+
+  const location = useLocation();
+  const meetingManager = useMeetingManager();
+
+  useEffect(() => {
+    if (location.pathname.includes(routes.MEETING)) {
+      return () => { 
+        meetingManager.leave();
+      }
+    }
+  }, [location.pathname])
 
   useEffect(() => {
     const handler = () => {


### PR DESCRIPTION
…te to home

**Description of changes:**
This adds detection when a user navigates away from the /meeting page with the Back button in the browser or with the URL. 

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Joined a meeting as two users. I confirmed a user can no longer show video, send audio, or be seen in the roster when the navigate away from the meeting. 
3. If you made changes to the component library, have you provided corresponding documentation changes?
n/a
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
