### PR TITLE
Docs rename variable from the attendees list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+#### Fixed
+- Docs rename variable `rosterArray ` from the attendees list to `attendees`
+
+
 ## [1.3.0] - 2020-10-09
 
 ### Fixed

--- a/src/providers/RosterProvider/docs/RosterProvider.stories.mdx
+++ b/src/providers/RosterProvider/docs/RosterProvider.stories.mdx
@@ -39,7 +39,7 @@ const App = () => (
 
 const MyChild = () => {
   const { roster } = useRosterState();
-  const rosterArray = Object.values(roster);
+  const attendees = Object.values(roster);
 
   const attendeeItems = attendees.map(attendee => {
     const { chimeAttendeeId, name } = attendee;

--- a/src/providers/RosterProvider/docs/useRosterState.stories.mdx
+++ b/src/providers/RosterProvider/docs/useRosterState.stories.mdx
@@ -46,7 +46,7 @@ const App = () => (
 
 const MyChild = () => {
   const { roster } = useRosterState();
-  const rosterArray = Object.values(roster);
+  const attendees = Object.values(roster);
 
   const attendeeItems = attendees.map(attendee => {
     const { chimeAttendeeId, name } = attendee;


### PR DESCRIPTION
**Description of changes:**
rename variable `rosterArray ` from the attendees list to `attendees`

#### docs:  sdk-hooks userosterstate.
```diff
-  const rosterArray = Object.values(roster);
+  const attendees = Object.values(roster);

const attendeeItems = attendees.map(attendee => 
```

#### docs: sdk-providers rosterprovider.
```diff
-  const rosterArray = Object.values(roster);
+  const attendees = Object.values(roster);

const attendeeItems = attendees.map(attendee => 
```

**Testing**
1. Have you successfully run `npm run build:release` locally?
yes

2. How did you test these changes?
By running the `storybook`

3. If you made changes to the component library, have you provided corresponding documentation changes?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
