### PR TITLE
Add tabIndex to base props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-#### Fixed
+### Fixed
 - Docs rename variable `rosterArray ` from the attendees list to `attendees`
 - Add base styles to ChannelList
+
+### Added
+- Add `tabIndex` to BaseProps
 
 ### Changed
 

--- a/src/components/sdk/Base/index.tsx
+++ b/src/components/sdk/Base/index.tsx
@@ -6,4 +6,6 @@ export interface BaseSdkProps {
   css?: string;
   /** Optional class names to apply to the element */
   className?: string;
+  /** Optional tab index for keyboard accessibility */
+  tabIndex?: number;
 }

--- a/src/components/ui/Base/index.ts
+++ b/src/components/ui/Base/index.ts
@@ -3,14 +3,11 @@
 
 import { SpaceProps } from 'styled-system';
 import { space } from 'styled-system';
+import { BaseSdkProps } from '../../sdk/Base';
 
-export interface BaseProps extends SpaceProps {
+export interface BaseProps extends SpaceProps, BaseSdkProps {
   /** Optional tag to render the component as a different HTML tag */
   tag?: any;
-  /** Optional css */
-  css?: string;
-  /** Optional class names to appear on the container */
-  className?: string;
 }
 
 export const baseStyles = ({ css }: BaseProps) =>


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Adds tabIndex to base props, also just extending the base SDK props since they just overlap for now

**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes? adding tabIndex props to demo and checking for build errors

3. If you made changes to the component library, have you provided corresponding documentation changes? yeah

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
