### PR TITLE
Add chat message component enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Docs rename variable `rosterArray ` from the attendees list to `attendees`
 - Add base styles to ChannelList
+- Fixed createChatBubbleList unit test that was incorrectly named and not running
 
 ### Added
 - Add `tabIndex` to BaseProps
 
 ### Changed
 
-- Changed ChannelList props to accept and children instead of PopOveItem props
+- Changed ChannelList props to accept and children instead of PopOverItem props.
+- Added extra scroll functionality to the InfiniteList component when a new message is sent.
+- Changed Message type to only include needed properties.
 
 ## [1.3.0] - 2020-10-09
 

--- a/src/components/ui/Chat/ChatBubble/createChatBubbleList.tsx
+++ b/src/components/ui/Chat/ChatBubble/createChatBubbleList.tsx
@@ -14,11 +14,9 @@ export type Message = {
   /* The timestamp when the message was originally sent by the sender. */
   createdTimestamp: string;
   /* The timestamp of the last time the message was edited. */
-  lastUpdatedTimestamp: string;
+  lastUpdatedTimestamp?: string;
   /* Determines if a message was redacted (deleted) by a user. */
   redacted: boolean;
-  /* The unique identifier of the channel the message was sent in. */
-  channelId?: string;
   /* The display name of the sender. */
   senderName: string;
   /* The unique identifier of the sender. */

--- a/src/components/ui/Chat/InfiniteList/Styled.tsx
+++ b/src/components/ui/Chat/InfiniteList/Styled.tsx
@@ -19,6 +19,7 @@ const rotate = keyframes`
 interface StyledInfiniteListProps extends InfiniteListProps {}
 
 export const StyledInfiniteList = styled.ul<StyledInfiniteListProps>`
+  background-color: ${props => props.theme.chatBubble.container.bgd};
   overflow-y: scroll;
   display: flex;
   flex-direction: column;

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,10 @@ export { RosterGroup } from './components/ui/Roster/RosterGroup';
 export { RosterCell } from './components/ui/Roster/RosterCell';
 export { UserActivityManager } from './components/ui/UserActivityManager';
 export { ChannelList } from './components/ui/Chat/ChannelList';
-export { ChannelItem } from './components/ui/Chat/ChannelList/ChannelItem'
+export { ChannelItem } from './components/ui/Chat/ChannelList/ChannelItem';
+export { InfiniteList } from './components/ui/Chat/InfiniteList';
+export { createChatBubbleList } from './components/ui/Chat/ChatBubble/createChatBubbleList';
+export { insertDateHeaders } from './components/ui/Chat/DateHeader/insertDateHeaders';
 
 // SDK components
 export {

--- a/tst/components/ui/Chat/ChatBubble/createChatBubbleList.test.tsx
+++ b/tst/components/ui/Chat/ChatBubble/createChatBubbleList.test.tsx
@@ -4,34 +4,33 @@
 import '@testing-library/jest-dom';
 import React from 'react';
 
-import formatMessageList, { MessageProps } from '../../../../../src/components/ui/Chat/MessageList/formatMessageList';
+import createChatBubbleList, { Message } from '../../../../../src/components/ui/Chat/ChatBubble/createChatBubbleList';
+import insertDateHeaders from '../../../../../src/components/ui/Chat/DateHeader/insertDateHeaders';
 import lightTheme from '../../../../../src/theme/light';
 import { renderWithTheme } from '../../../../test-helpers';
 
 describe('InfiniteList', () => {
-  const defaultMessage: MessageProps = {
+  const defaultMessage: Message = {
     content: 'Test message',
     messageId: 'test-message-123',
     createdTimestamp: '2020-10-05T21:51:26.569Z',
     lastUpdatedTimestamp: '2020-10-05T21:51:26.569Z',
     redacted: false,
-    sender: {
-      name: 'Test User',
-      arn: 'test-user-123',
-    }
+    senderName: 'Test User',
+    senderId: 'test-user-123',
   };
   const memberId = 'test-user-abc';
 
   it('should return a list of ChatBubbles', () => {
-    const component = <ul>{formatMessageList([defaultMessage], memberId, null)}</ul>;
+    const component = <ul>{createChatBubbleList([defaultMessage], memberId, null)}</ul>;
     const { getByTestId } = renderWithTheme(lightTheme, component);
     const list = getByTestId('chat-bubble');
 
     expect(list).toBeInTheDocument();
   });
 
-  it('should render a DateHeader', () => {
-    const component = <ul>{formatMessageList([defaultMessage], memberId, null)}</ul>;
+  it('should render a DateHeader when called with insertDateHeaders helper function', () => {
+    const component = <ul>{createChatBubbleList(insertDateHeaders([defaultMessage]), memberId, null)}</ul>;
       const { getAllByTestId } = renderWithTheme(lightTheme, component);
       const dateHeaders = getAllByTestId('date-header');
   


### PR DESCRIPTION
**Description of changes:**
This commit adds new message scrolling behavior to the `<InfiniteList/>` component. If the user is at the bottom of the list and a new message appears, the list will automatically scroll down to view the new message. But if the user is not at the bottom of the list, it will not scroll, so the user can continue to read other messages. 

Additionally, this commit slightly changes the data type `Message` and correctly exports these chat components. There was also some test clean up. 

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Tested in the demo app and storybook. 
3. If you made changes to the component library, have you provided corresponding documentation changes?
n/a
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
