### PR TITLE
use children prop in RosterHeader for custom elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `tabIndex` to BaseProps
 - Add `Like`, `Dislike`, `Feedback` icons
 - Add `isSelected` prop to NavBarItem
+- Add optional children to RosterHeader for custom element rendering
 
 ### Changed
 

--- a/src/components/ui/Roster/Roster.mdx
+++ b/src/components/ui/Roster/Roster.mdx
@@ -17,7 +17,7 @@ It is made up of one RosterHeader component and multiple RosterGroup components.
 ## Importing
 
 ```javascript
-import { 
+import {
   Roster,
   RosterGroup,
   RosterHeader,
@@ -30,7 +30,7 @@ import {
 <ThemeProvider theme={lightTheme}>
   <GlobalStyles/>
   <Preview>
-  <Flex 
+  <Flex
     container
     css="height: 50vh; background: #f6f9fc;"
   >
@@ -98,7 +98,8 @@ import {
 # RosterHeader
 
 The RosterHeader component displays the title of the Roster's header and number of attendees.
-It is also equipped with the search functionality and close icon button to close the roster itself.
+It is equipped with the search functionality and close icon button to close the roster itself.
+Additionally, custom elements can be rendered into the RosterHeader via the 'children' prop.
 
 ## Example
 

--- a/src/components/ui/Roster/Roster.stories.tsx
+++ b/src/components/ui/Roster/Roster.stories.tsx
@@ -10,6 +10,9 @@ import RosterGroup from './RosterGroup';
 import RosterCell from './RosterCell';
 import RosterHeader from './RosterHeader';
 import RosterDocs from './Roster.mdx';
+import IconButton from '../Button/IconButton';
+import SignalStrength from '../icons/SignalStrength';
+import Cog from '../icons/Cog';
 
 export default {
   title: 'UI Components/Roster',
@@ -46,7 +49,6 @@ export const _Roster = () => {
           searchValue={search}
           onSearch={handleSearch}
           menu={<Menu />}
-          onMobileToggleClick={() => alert('Open Navigation')}
         />
 
         <RosterGroup>
@@ -133,7 +135,7 @@ _RosterHeader.story = 'RosterHeader';
 export const _RosterHeaderWithNavigationIcon = () => {
   const title = text('title', 'Present');
   const badge = number('badge', 4);
-  const children = text('children', '');
+
   const [search, setSearch] = useState('');
 
   const handleSearch = e => setSearch(e.target.value);
@@ -148,10 +150,7 @@ export const _RosterHeaderWithNavigationIcon = () => {
           searchValue={search}
           onSearch={handleSearch}
           menu={<Menu />}
-          onMobileToggleClick={() => alert('Open Navigation')}
-        >
-          {children}
-        </RosterHeader>
+        />
 
         <RosterGroup>
           <RosterCell name="Michael Scarn" subtitle="FBI agent" />
@@ -165,6 +164,42 @@ export const _RosterHeaderWithNavigationIcon = () => {
 };
 
 _RosterHeaderWithNavigationIcon.story = 'RosterHeaderWithNavigationIcon';
+
+export const _RosterHeaderWithCustomElements = () => {
+  const title = text('title', 'Present');
+  const badge = number('badge', 4);
+
+  const [search, setSearch] = useState('');
+
+  const handleSearch = e => setSearch(e.target.value);
+
+  return (
+    <Flex container layout="fill-space-centered" css="height: 100vh;">
+      <Flex css="width: 100%; max-width: 280px;">
+        <RosterHeader
+          title={title}
+          badge={badge}
+          onClose={() => alert('Closing')}
+          searchValue={search}
+          onSearch={handleSearch}
+          menu={<Menu />}
+        >
+          <IconButton label="test" icon={<Cog />}/>
+          <IconButton label="test" icon={<SignalStrength />}/>
+        </RosterHeader>
+        <RosterGroup>
+          <RosterCell name="Michael Scarn" subtitle="FBI agent" />
+          <RosterCell name="Prison Mike" subtitle="Inmate" />
+          <RosterCell name="Date Mike" subtitle="Bachelor" />
+          <RosterCell name="Dwight" subtitle="Assistant regional manager" />
+        </RosterGroup>
+      </Flex>
+    </Flex>
+  );
+};
+
+_RosterHeaderWithCustomElements.story = '_RosterHeaderWithCustomElements';
+
 
 export const _RosterCell = () => {
   const name = text('name', 'Stanley Hudson');

--- a/src/components/ui/Roster/RosterHeader.tsx
+++ b/src/components/ui/Roster/RosterHeader.tsx
@@ -1,7 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useState, useRef, useEffect, ChangeEvent } from 'react';
+import React, { useState, useRef, useEffect, ChangeEvent, ReactNode } from 'react';
 
 import Flex from '../Flex';
 import Badge from '../Badge';
@@ -29,6 +29,8 @@ interface RosterHeaderProps extends BaseProps {
   a11yMenuLabel?: string;
   /** Label shown for search icon button, by default it is "Open search" */
   searchLabel?: string;
+  /** Use children to render custom elements in the RosterHeader */
+  children?: ReactNode | ReactNode[];
 }
 
 const SearchBar: any = ({ onChange, onClose, value }: any) => {
@@ -78,6 +80,7 @@ export const RosterHeader: React.FC<RosterHeaderProps> = ({
   menu,
   a11yMenuLabel = '',
   searchLabel = 'Open search',
+  children,
   ...rest
 }) => {
   const [isSearching, setIsSearching] = useState(false);
@@ -120,7 +123,7 @@ export const RosterHeader: React.FC<RosterHeaderProps> = ({
         )}
 
         {menu && <PopOverMenu menu={menu} a11yMenuLabel={a11yMenuLabel} />}
-
+        {children}
         {onClose && (
           <IconButton label="Close" onClick={onClose} icon={<Remove />} />
         )}

--- a/tst/components/ui/Roster/RosterHeader.test.tsx
+++ b/tst/components/ui/Roster/RosterHeader.test.tsx
@@ -6,6 +6,8 @@ import '@testing-library/jest-dom';
 import { fireEvent } from '@testing-library/dom';
 
 import RosterHeader from '../../../../src/components/ui/Roster/RosterHeader';
+import IconBUtton from '../../../../src/components/ui/Button/IconButton';
+import Presenter from '../../../../src/components/ui/icons/Presenter';
 import lightTheme from '../../../../src/theme/light';
 import { renderWithTheme } from '../../../test-helpers';
 
@@ -67,5 +69,15 @@ describe('RosterCell', () => {
       })
     );
     expect(getByLabelText('Search')).toBeInTheDocument();
+  });
+  it('should render children if they are available', () => {
+    const component = (
+      <RosterHeader title="Present" onSearch={() => {}}>
+        <IconBUtton label="presenter" icon={<Presenter/>} />
+      </RosterHeader>
+    );
+    const { getByLabelText } = renderWithTheme(lightTheme, component);
+
+    expect(getByLabelText('presenter')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
**Issue #:** 
n/a

**Description of changes:**
The range of controls in the `RosterHeader` are very useful, but a little rigid. Allowing the rendering of children will provide some flexibility. I thought it would be helpful to incorporate it alongside the existing options, rather than make it a 'children or all of these optional props' kind of deal

**Testing**
1. Have you successfully run `npm run build:release` locally?
yes

2. How did you test these changes?
unit tests, and manual test in storybook

3. If you made changes to the component library, have you provided corresponding documentation changes?
yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
