### PR TITLE
Added space for extraIcons in RosterCell, Moved menu to show even when "running late"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added extra scroll functionality to the InfiniteList component when a new message is sent.
 - Changed Message type to only include needed properties.
 - Changed ChatBubble to composed components to support redact and edit.
+- Changed RosterCell to support extra icons and menus when running late
 
 ### Removed
 - Removed createChatBubbleList function.

--- a/src/components/ui/Roster/RosterCell/index.tsx
+++ b/src/components/ui/Roster/RosterCell/index.tsx
@@ -35,6 +35,8 @@ export interface RosterCellProps extends BaseProps {
   menu?: React.ReactNode;
   /** The label for availability, it defaults to an empty string. */
   a11yMenuLabel?: string;
+  /** The icon to depict moderator or presentor status . */
+  extraIcon: React.ReactNode;
 }
 
 function getVideoIcon(
@@ -66,6 +68,7 @@ export const RosterCell: React.FC<RosterCellProps> = (props) => {
     poorConnection = false,
     microphone,
     a11yMenuLabel = '',
+    extraIcon,
   } = props;
 
   const videoIcon = getVideoIcon(videoEnabled, sharingContent);
@@ -87,10 +90,11 @@ export const RosterCell: React.FC<RosterCellProps> = (props) => {
       ) : (
         <>
           {showMic && <div className="ch-mic">{mic}</div>}
+          {extraIcon}
           {videoIcon}
-          {menu && <PopOverMenu menu={menu} a11yMenuLabel={a11yMenuLabel} />}
         </>
       )}
+      {menu && <PopOverMenu menu={menu} a11yMenuLabel={a11yMenuLabel} />}
     </StyledCell>
   );
 };


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Added space for extraIcons in RosterCell, Moved menu to show even when "running late"

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? tested in another repro via CR

3. If you made changes to the component library, have you provided corresponding documentation changes? yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
