### PR TITLE
Add class to DateHeader component for easier styling access.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Docs rename variable `rosterArray ` from the attendees list to `attendees`
+
+- Docs rename variable `rosterArray` from the attendees list to `attendees`
 - Add base styles to ChannelList
 - Fixed createChatBubbleList unit test that was incorrectly named and not running
 - Fixed TS error inside /InfiniteList/index.tsx.
 
 ### Added
+
 - Add `tabIndex` to BaseProps
 - Add `Like`, `Dislike`, `Feedback` icons
 - Add `isSelected` prop to NavBarItem
 - Add optional children to RosterHeader for custom element rendering
 - Add optional `icon` property for `Radio` and `RadioGroup` to allow for rendering an icon instead of a label
-- Add Document icon and MessageAttachment components. 
+- Add Document icon and MessageAttachment components.
 - Add stories and tests for all ChatBubble components.
+- Add class to DateHeader component.
 
 ### Changed
 
@@ -32,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed ChatBubble component props for simplicity.
 
 ### Removed
+
 - Removed createChatBubbleList function.
 - Removed exports and stories for unreleased chat components
 

--- a/src/components/ui/Chat/DateHeader/index.tsx
+++ b/src/components/ui/Chat/DateHeader/index.tsx
@@ -19,6 +19,7 @@ export interface DateHeaderProps
 export const DateHeader: FC<DateHeaderProps> = (props) => (
   <Badge
     data-testid="date-header"
+    className="ch-date-header"
     value={formatDate(props.date, props.locale, props.dateOptions)}
   />
 );


### PR DESCRIPTION

**Description of changes:**
Adds a className to the `<DateHeader>` component for easier access to styling, especially when using the `insertDateHeaders` helper function and the user doesn't access the `<DateHeader>` component directly. 

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Used the components in a demo
3. If you made changes to the component library, have you provided corresponding documentation changes?
n/a
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
