### PR TITLE
Added buttonProps passthrough for RosterCell and PopOverMenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add class to DateHeader component.
 - Add Attachment icon
 - Added passthrough for a react node in the subtitle of PopOverHeader
+- Add `buttonProps` passthrough for `RosterCell` and `PopOverMenu`
 
 ### Changed
 

--- a/src/components/ui/Roster/PopOverMenu.tsx
+++ b/src/components/ui/Roster/PopOverMenu.tsx
@@ -5,21 +5,28 @@ import React from 'react';
 
 import { Dots } from '../icons';
 import PopOver from '../PopOver';
-import IconButton from '../Button/IconButton';
+import IconButton, { IconButtonProps } from '../Button/IconButton';
+import classNames from 'classnames';
 
 interface PopOverMenuProps {
   menu: React.ReactNode;
   a11yMenuLabel?: string;
+  buttonProps?: Partial<IconButtonProps>;
 }
 
-export const PopOverMenu = ({ menu, a11yMenuLabel = '' }: PopOverMenuProps) => (
+export const PopOverMenu = ({
+  menu,
+  a11yMenuLabel = '',
+  buttonProps,
+}: PopOverMenuProps) => (
   <PopOver
     className="ch-menu"
     a11yLabel={a11yMenuLabel}
     renderButtonWrapper={(isActive, props) => (
       <IconButton
+        {...buttonProps}
         {...props}
-        className="ch-menu"
+        className={classNames("ch-menu", buttonProps?.className)}
         icon={<Dots />}
         label={a11yMenuLabel}
       />

--- a/src/components/ui/Roster/RosterCell/index.tsx
+++ b/src/components/ui/Roster/RosterCell/index.tsx
@@ -9,6 +9,7 @@ import { BaseProps, FocusableProps } from '../../Base';
 import { Microphone, Camera, ScreenShare } from '../../icons';
 import { StyledCell } from './Styled';
 import { PopOverMenu } from '../PopOverMenu';
+import { IconButtonProps } from '../../Button/IconButton';
 
 type MicPosition = 'leading' | 'grouped';
 
@@ -37,6 +38,8 @@ export interface RosterCellProps extends BaseProps, FocusableProps {
   a11yMenuLabel?: string;
   /** The icon to depict moderator or presentor status . */
   extraIcon?: React.ReactNode;
+  /** extra properties to pass through to the menu button */
+  buttonProps?: Partial<IconButtonProps>;
 }
 
 function getVideoIcon(
@@ -69,6 +72,7 @@ export const RosterCell: React.FC<RosterCellProps> = (props) => {
     microphone,
     a11yMenuLabel = '',
     extraIcon,
+    buttonProps,
   } = props;
 
   const videoIcon = getVideoIcon(videoEnabled, sharingContent);
@@ -94,7 +98,13 @@ export const RosterCell: React.FC<RosterCellProps> = (props) => {
           {videoIcon}
         </>
       )}
-      {menu && <PopOverMenu menu={menu} a11yMenuLabel={a11yMenuLabel} />}
+      {menu && (
+        <PopOverMenu
+          menu={menu}
+          a11yMenuLabel={a11yMenuLabel}
+          buttonProps={buttonProps}
+        />
+      )}
     </StyledCell>
   );
 };


### PR DESCRIPTION

**Description of changes:**
Added buttonProps passthrough for RosterCell and PopOverMenu

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? tested in another code base

3. If you made changes to the component library, have you provided corresponding documentation changes? yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
