### PR TITLE
Fix snapshot tests not running on github actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,12 +3,7 @@
 
 name: CI Workflow
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches:
-      - master
+on: [pull_request]
 
 jobs:
   build:
@@ -20,25 +15,45 @@ jobs:
         node-version: [12.x]
 
     steps:
-    - name: Checkout Package
-      uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Clean Install
-      run: npm ci
-    - name: Build
-      run: npm run build:release --if-present
-    - name: Check for changes to the src folder
-      uses: tj-actions/verify-changed-files@v5
-      id: changed_files
-      with:
-        files: src
-    - name: Run Snapshot testing for src folder changes
-      if: steps.changed_files.outputs.files_changed == 'true'
-      run: npm run test:snapshots
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-        # Increase timeout for snapshot testing to 8 minutes
-        WAIT_ON_TIMEOUT: 480000
+      - name: Checkout Package
+        uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Clean Install
+        run: npm ci
+      - name: Build
+        run: npm run build:release --if-present
+      
+
+
+  require-snapshot-test:
+    name: Check if Snapshot Tests are required
+    needs: build
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - name: Checkout Package
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Check if snapshot Tests are Required
+        run: node scripts/snapshot-tests-required.js
+      - name: Run Snapshot tests
+        id: snapshot_test_required
+        if: ${{ success() }}
+        run: npm run test:snapshots
+        env:
+          # Increase timeout for snapshot testing to 8 minutes
+          WAIT_ON_TIMEOUT: 480000
+      - name: Skip Snapshot Tests
+        if: ${{ failure() }}
+        run: echo 'Snapshot tests not required!'

--- a/.github/workflows/send-pull-request-notification.yml
+++ b/.github/workflows/send-pull-request-notification.yml
@@ -2,7 +2,7 @@
 name: New Pull Request Chime Notification
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ master ]
     types: opened
     

--- a/.snapshot-watchlist
+++ b/.snapshot-watchlist
@@ -1,0 +1,24 @@
+# run snapshot tests if files in these directories change
+demos/meeting
+src/
+
+# exceptions
+!src/versioning/Versioning.ts
+!src/providers/AudioVideoProvider/docs
+!src/providers/ContentShareProvider/docs
+!src/providers/DevicesProvider/docs
+!src/providers/FeaturedVideoTileProvider/docs
+!src/providers/LocalAudioOutputProvider/docs
+!src/providers/LocalVideoProvider/docs
+!src/providers/MeetingProvider/docs
+!src/providers/NotificationProvider/docs
+!src/providers/RemoteVideoTileProvider/docs
+!src/providers/RosterProvider/docs
+!src/providers/UserActivityProvider/docs
+!src/hooks/sdk/docs
+!src/components/sdk/DeviceSelection/docs
+!src/components/sdk/MeetingControls/docs
+CHANGELOG.md
+package.json
+README.md
+package-lock.json

--- a/scripts/snapshot-tests-required.js
+++ b/scripts/snapshot-tests-required.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+
+const watchlist = fs.readFileSync('.snapshot-watchlist', 'utf-8').split("\n");
+const base = fs.readFileSync('.base-branch', 'utf8').trim();
+const commits = execSync(`git rev-list ${base}..`, {encoding: "utf8" }).trim().split('\n');
+
+let requires_snapshot_test = false
+for (const commit of commits) {
+    const commit_files = execSync(`git diff-tree --no-commit-id --name-only -r ${commit}`, {encoding: "utf8" }).trim().split('\n');
+    for (const committed_file of commit_files) {
+        let matches = false;
+        for (const stem of watchlist) {
+            if (stem == '' || stem.startsWith('#')) {
+                continue;
+            } else if (stem.startsWith('!')) {
+                if (committed_file.startsWith(stem.substring(1))) {
+                    matches = false;
+                }
+            } else if (committed_file.startsWith(stem)) {
+                matches = true;
+            }
+        }
+        if (matches) {
+            requires_snapshot_test = true;
+        }
+    }
+}
+requires_snapshot_test ? console.log('requires') : console.log('doesnt require');
+
+requires_snapshot_test ? process.exit(0) : process.exit(1);
+
+
+
+
+


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Fixes github action so that it will run snapshot tests on files listed in the snapshot watchlist

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? It has to be tested by pushing this code

3. If you made changes to the component library, have you provided corresponding documentation changes? n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
