### PR TITLE
Allow modal components to receive css classNames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed TS error inside /InfiniteList/index.tsx.
 - Fixed small visual errors in chat componnets.
 - Fixed broken snapshot tests for Badge component.
+- Fixed ModalBody component to allow custom classNames
 
 ### Added
 

--- a/src/components/ui/Chat/InfiniteList/InfiniteList.mdx
+++ b/src/components/ui/Chat/InfiniteList/InfiniteList.mdx
@@ -37,7 +37,7 @@ import { InfiniteList } from 'amazon-chime-sdk-component-library-react';
 />
 
 <InfiniteList
-  items={createChatBubbleList(insertDateHeaders(messages), memberId, actions)}
+  items={items}
   handleLoad={fetchItems}
   batchSize={50}
 />

--- a/src/components/ui/Modal/Modal.stories.tsx
+++ b/src/components/ui/Modal/Modal.stories.tsx
@@ -1,7 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useState } from 'react'
+import React, { useState } from 'react';
 import { select } from '@storybook/addon-knobs';
 
 import Flex from '../Flex';
@@ -10,7 +10,7 @@ import RadioGroup from '../RadioGroup';
 import Modal from './';
 import ModalHeader from './ModalHeader';
 import ModalBody from './ModalBody';
-import ModalButton from './ModalButton'
+import ModalButton from './ModalButton';
 import ModalButtonGroup from './ModalButtonGroup';
 import PrimaryButton from '../Button/PrimaryButton';
 import ModalDocs from './Modal.mdx';
@@ -19,11 +19,11 @@ export default {
   title: 'UI Components/Modal',
   parameters: {
     docs: {
-      page: ModalDocs.parameters.docs.page().props.children.type
-    }
+      page: ModalDocs.parameters.docs.page().props.children.type,
+    },
   },
   component: Modal,
-  excludeStories: ['ModalDemo']
+  excludeStories: ['ModalDemo'],
 };
 
 const options = [
@@ -37,12 +37,12 @@ const options = [
   },
 ];
 
-const TestRadioGroup: React.FC<{}> = props => {
+const TestRadioGroup: React.FC<{}> = (props) => {
   const [value, setValue] = useState('personal');
 
   const handleChange = (evt: any) => {
     setValue(evt.target.value);
-  }
+  };
 
   return (
     <FormField
@@ -53,7 +53,7 @@ const TestRadioGroup: React.FC<{}> = props => {
       label="Select from the meeting ID to use"
     />
   );
-}
+};
 
 export const BasicExample = () => {
   const [showModal, setShowModal] = useState(false);
@@ -61,33 +61,46 @@ export const BasicExample = () => {
 
   return (
     <Flex layout="fill-space-centered">
-      <div style={{ width: '30rem', 'textAlign': 'center'}}>
+      <div style={{ width: '30rem', textAlign: 'center' }}>
         <div>
           <h1>Modal basic example</h1>
-            <PrimaryButton
-              onClick={toggleModal}
-              label="toggle modal"
-            />
+          <PrimaryButton onClick={toggleModal} label="toggle modal" />
           {showModal && (
             <Modal
               size={select('size', ['md', 'lg', 'fullscreen'], 'md')}
               onClose={toggleModal}
-              rootId='modal-root'
+              rootId="modal-root"
             >
-              <ModalHeader title="Start an instant meeting"/>
+              <ModalHeader title="Start an instant meeting" />
 
               <ModalBody>
-                <p style={{ 'margin': '0 0 0.5rem' }}>
-                Start this meeting with your personal meeting ID or generate a new, unique and private meeting ID.
+                <p style={{ margin: '0 0 0.5rem' }}>
+                  Start this meeting with your personal meeting ID or generate a
+                  new, unique and private meeting ID.
                 </p>
                 <TestRadioGroup />
               </ModalBody>
               <ModalButtonGroup
                 primaryButtons={[
-                  <ModalButton onClick={() => alert("I will close the modal next")} variant="primary" label="submit" closesModal />,
-                  <ModalButton variant="secondary" label="cancel" closesModal />
+                  <ModalButton
+                    onClick={() => alert('I will close the modal next')}
+                    variant="primary"
+                    label="submit"
+                    closesModal
+                  />,
+                  <ModalButton
+                    variant="secondary"
+                    label="cancel"
+                    closesModal
+                  />,
                 ]}
-                secondaryButtons={  <ModalButton onClick={() => alert("I won't close the modal")} variant="secondary" label="another action" />}
+                secondaryButtons={
+                  <ModalButton
+                    onClick={() => alert("I won't close the modal")}
+                    variant="secondary"
+                    label="another action"
+                  />
+                }
               />
             </Modal>
           )}
@@ -95,7 +108,7 @@ export const BasicExample = () => {
       </div>
     </Flex>
   );
-}
+};
 
 BasicExample.story = 'Basic example';
 
@@ -105,37 +118,146 @@ export const largeContent = () => {
 
   return (
     <Flex layout="fill-space-centered">
-      <div style={{ width: '30rem', 'textAlign': 'center'}}>
+      <div style={{ width: '30rem', textAlign: 'center' }}>
         <div>
           <h1>Modal with scrollable content</h1>
-          <PrimaryButton
-            onClick={toggleModal}
-            label="toggle modal"
-          />
+          <PrimaryButton onClick={toggleModal} label="toggle modal" />
 
           {showModal && (
             <Modal
               size={select('size', ['md', 'lg', 'fullscreen'], 'md')}
               onClose={toggleModal}
-              rootId='modal-root'
+              rootId="modal-root"
             >
-              <ModalHeader title="Scrollable content example"/>
+              <ModalHeader title="Scrollable content example" />
               <ModalBody>
-                <div style={{ 'margin': '0 0 1rem' }}>
-                  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse urna eros, vestibulum quis gravida quis, tempus in sapien. Sed aliquet velit lectus, ac tempus dui iaculis ac. Morbi ullamcorper laoreet magna ac commodo. Aenean pharetra nulla sapien, nec interdum dolor semper quis. Ut posuere libero at scelerisque iaculis. Phasellus eu arcu ullamcorper, ultrices turpis id, pretium tellus. Integer accumsan ultrices semper. Maecenas eu scelerisque metus, nec pulvinar odio. Nunc imperdiet efficitur vehicula. Curabitur laoreet ut tellus quis sagittis. Nulla auctor vitae felis quis convallis. Nunc hendrerit imperdiet elit at auctor. Integer condimentum euismod orci vitae venenatis. Proin maximus in sem vitae auctor. Aliquam egestas, lorem vel volutpat pharetra, dolor felis malesuada lorem, vitae fermentum eros erat tempor lacus.</p>
-                  <p>Duis tempus sagittis consectetur. Aliquam ut ante eu elit laoreet condimentum. Pellentesque nunc leo, egestas a porttitor sed, euismod tempor neque. Aenean a est eu mauris elementum venenatis. Cras sit amet ex pellentesque augue suscipit dignissim. Donec tempor lacinia orci non elementum. Fusce quis elit est. Nullam magna tortor, dapibus quis maximus varius, dapibus a nunc. Proin eget magna posuere justo ullamcorper posuere sit amet at quam. Donec lacinia libero vel tellus efficitur, vitae posuere enim porta. Suspendisse vitae tellus vitae tellus semper cursus ornare in nunc. Mauris molestie velit eu malesuada pellentesque.</p>
-                  <p>Vivamus nisi justo, sagittis eu dolor vel, pretium placerat dolor. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nullam condimentum nisi velit, id pellentesque quam facilisis dapibus. Donec orci est, faucibus at dapibus sit amet, hendrerit vitae libero. Quisque sed pellentesque diam. Fusce vitae imperdiet nisi, a elementum ante. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed fringilla pharetra nunc, sed ornare urna congue a.</p>
-                  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse urna eros, vestibulum quis gravida quis, tempus in sapien. Sed aliquet velit lectus, ac tempus dui iaculis ac. Morbi ullamcorper laoreet magna ac commodo. Aenean pharetra nulla sapien, nec interdum dolor semper quis. Ut posuere libero at scelerisque iaculis. Phasellus eu arcu ullamcorper, ultrices turpis id, pretium tellus. Integer accumsan ultrices semper. Maecenas eu scelerisque metus, nec pulvinar odio. Nunc imperdiet efficitur vehicula. Curabitur laoreet ut tellus quis sagittis. Nulla auctor vitae felis quis convallis. Nunc hendrerit imperdiet elit at auctor. Integer condimentum euismod orci vitae venenatis. Proin maximus in sem vitae auctor. Aliquam egestas, lorem vel volutpat pharetra, dolor felis malesuada lorem, vitae fermentum eros erat tempor lacus.</p>
-                  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse urna eros, vestibulum quis gravida quis, tempus in sapien. Sed aliquet velit lectus, ac tempus dui iaculis ac. Morbi ullamcorper laoreet magna ac commodo. Aenean pharetra nulla sapien, nec interdum dolor semper quis. Ut posuere libero at scelerisque iaculis. Phasellus eu arcu ullamcorper, ultrices turpis id, pretium tellus. Integer accumsan ultrices semper. Maecenas eu scelerisque metus, nec pulvinar odio. Nunc imperdiet efficitur vehicula. Curabitur laoreet ut tellus quis sagittis. Nulla auctor vitae felis quis convallis. Nunc hendrerit imperdiet elit at auctor. Integer condimentum euismod orci vitae venenatis. Proin maximus in sem vitae auctor. Aliquam egestas, lorem vel volutpat pharetra, dolor felis malesuada lorem, vitae fermentum eros erat tempor lacus.</p>
-                  <p>Duis tempus sagittis consectetur. Aliquam ut ante eu elit laoreet condimentum. Pellentesque nunc leo, egestas a porttitor sed, euismod tempor neque. Aenean a est eu mauris elementum venenatis. Cras sit amet ex pellentesque augue suscipit dignissim. Donec tempor lacinia orci non elementum. Fusce quis elit est. Nullam magna tortor, dapibus quis maximus varius, dapibus a nunc. Proin eget magna posuere justo ullamcorper posuere sit amet at quam. Donec lacinia libero vel tellus efficitur, vitae posuere enim porta. Suspendisse vitae tellus vitae tellus semper cursus ornare in nunc. Mauris molestie velit eu malesuada pellentesque.</p>
-                  <p>Vivamus nisi justo, sagittis eu dolor vel, pretium placerat dolor. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nullam condimentum nisi velit, id pellentesque quam facilisis dapibus. Donec orci est, faucibus at dapibus sit amet, hendrerit vitae libero. Quisque sed pellentesque diam. Fusce vitae imperdiet nisi, a elementum ante. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed fringilla pharetra nunc, sed ornare urna congue a.</p>
-                  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse urna eros, vestibulum quis gravida quis, tempus in sapien. Sed aliquet velit lectus, ac tempus dui iaculis ac. Morbi ullamcorper laoreet magna ac commodo. Aenean pharetra nulla sapien, nec interdum dolor semper quis. Ut posuere libero at scelerisque iaculis. Phasellus eu arcu ullamcorper, ultrices turpis id, pretium tellus. Integer accumsan ultrices semper. Maecenas eu scelerisque metus, nec pulvinar odio. Nunc imperdiet efficitur vehicula. Curabitur laoreet ut tellus quis sagittis. Nulla auctor vitae felis quis convallis. Nunc hendrerit imperdiet elit at auctor. Integer condimentum euismod orci vitae venenatis. Proin maximus in sem vitae auctor. Aliquam egestas, lorem vel volutpat pharetra, dolor felis malesuada lorem, vitae fermentum eros erat tempor lacus.</p>
+                <div style={{ margin: '0 0 1rem' }}>
+                  <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                    Suspendisse urna eros, vestibulum quis gravida quis, tempus
+                    in sapien. Sed aliquet velit lectus, ac tempus dui iaculis
+                    ac. Morbi ullamcorper laoreet magna ac commodo. Aenean
+                    pharetra nulla sapien, nec interdum dolor semper quis. Ut
+                    posuere libero at scelerisque iaculis. Phasellus eu arcu
+                    ullamcorper, ultrices turpis id, pretium tellus. Integer
+                    accumsan ultrices semper. Maecenas eu scelerisque metus, nec
+                    pulvinar odio. Nunc imperdiet efficitur vehicula. Curabitur
+                    laoreet ut tellus quis sagittis. Nulla auctor vitae felis
+                    quis convallis. Nunc hendrerit imperdiet elit at auctor.
+                    Integer condimentum euismod orci vitae venenatis. Proin
+                    maximus in sem vitae auctor. Aliquam egestas, lorem vel
+                    volutpat pharetra, dolor felis malesuada lorem, vitae
+                    fermentum eros erat tempor lacus.
+                  </p>
+                  <p>
+                    Duis tempus sagittis consectetur. Aliquam ut ante eu elit
+                    laoreet condimentum. Pellentesque nunc leo, egestas a
+                    porttitor sed, euismod tempor neque. Aenean a est eu mauris
+                    elementum venenatis. Cras sit amet ex pellentesque augue
+                    suscipit dignissim. Donec tempor lacinia orci non elementum.
+                    Fusce quis elit est. Nullam magna tortor, dapibus quis
+                    maximus varius, dapibus a nunc. Proin eget magna posuere
+                    justo ullamcorper posuere sit amet at quam. Donec lacinia
+                    libero vel tellus efficitur, vitae posuere enim porta.
+                    Suspendisse vitae tellus vitae tellus semper cursus ornare
+                    in nunc. Mauris molestie velit eu malesuada pellentesque.
+                  </p>
+                  <p>
+                    Vivamus nisi justo, sagittis eu dolor vel, pretium placerat
+                    dolor. Vestibulum ante ipsum primis in faucibus orci luctus
+                    et ultrices posuere cubilia curae; Nullam condimentum nisi
+                    velit, id pellentesque quam facilisis dapibus. Donec orci
+                    est, faucibus at dapibus sit amet, hendrerit vitae libero.
+                    Quisque sed pellentesque diam. Fusce vitae imperdiet nisi, a
+                    elementum ante. Lorem ipsum dolor sit amet, consectetur
+                    adipiscing elit. Sed fringilla pharetra nunc, sed ornare
+                    urna congue a.
+                  </p>
+                  <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                    Suspendisse urna eros, vestibulum quis gravida quis, tempus
+                    in sapien. Sed aliquet velit lectus, ac tempus dui iaculis
+                    ac. Morbi ullamcorper laoreet magna ac commodo. Aenean
+                    pharetra nulla sapien, nec interdum dolor semper quis. Ut
+                    posuere libero at scelerisque iaculis. Phasellus eu arcu
+                    ullamcorper, ultrices turpis id, pretium tellus. Integer
+                    accumsan ultrices semper. Maecenas eu scelerisque metus, nec
+                    pulvinar odio. Nunc imperdiet efficitur vehicula. Curabitur
+                    laoreet ut tellus quis sagittis. Nulla auctor vitae felis
+                    quis convallis. Nunc hendrerit imperdiet elit at auctor.
+                    Integer condimentum euismod orci vitae venenatis. Proin
+                    maximus in sem vitae auctor. Aliquam egestas, lorem vel
+                    volutpat pharetra, dolor felis malesuada lorem, vitae
+                    fermentum eros erat tempor lacus.
+                  </p>
+                  <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                    Suspendisse urna eros, vestibulum quis gravida quis, tempus
+                    in sapien. Sed aliquet velit lectus, ac tempus dui iaculis
+                    ac. Morbi ullamcorper laoreet magna ac commodo. Aenean
+                    pharetra nulla sapien, nec interdum dolor semper quis. Ut
+                    posuere libero at scelerisque iaculis. Phasellus eu arcu
+                    ullamcorper, ultrices turpis id, pretium tellus. Integer
+                    accumsan ultrices semper. Maecenas eu scelerisque metus, nec
+                    pulvinar odio. Nunc imperdiet efficitur vehicula. Curabitur
+                    laoreet ut tellus quis sagittis. Nulla auctor vitae felis
+                    quis convallis. Nunc hendrerit imperdiet elit at auctor.
+                    Integer condimentum euismod orci vitae venenatis. Proin
+                    maximus in sem vitae auctor. Aliquam egestas, lorem vel
+                    volutpat pharetra, dolor felis malesuada lorem, vitae
+                    fermentum eros erat tempor lacus.
+                  </p>
+                  <p>
+                    Duis tempus sagittis consectetur. Aliquam ut ante eu elit
+                    laoreet condimentum. Pellentesque nunc leo, egestas a
+                    porttitor sed, euismod tempor neque. Aenean a est eu mauris
+                    elementum venenatis. Cras sit amet ex pellentesque augue
+                    suscipit dignissim. Donec tempor lacinia orci non elementum.
+                    Fusce quis elit est. Nullam magna tortor, dapibus quis
+                    maximus varius, dapibus a nunc. Proin eget magna posuere
+                    justo ullamcorper posuere sit amet at quam. Donec lacinia
+                    libero vel tellus efficitur, vitae posuere enim porta.
+                    Suspendisse vitae tellus vitae tellus semper cursus ornare
+                    in nunc. Mauris molestie velit eu malesuada pellentesque.
+                  </p>
+                  <p>
+                    Vivamus nisi justo, sagittis eu dolor vel, pretium placerat
+                    dolor. Vestibulum ante ipsum primis in faucibus orci luctus
+                    et ultrices posuere cubilia curae; Nullam condimentum nisi
+                    velit, id pellentesque quam facilisis dapibus. Donec orci
+                    est, faucibus at dapibus sit amet, hendrerit vitae libero.
+                    Quisque sed pellentesque diam. Fusce vitae imperdiet nisi, a
+                    elementum ante. Lorem ipsum dolor sit amet, consectetur
+                    adipiscing elit. Sed fringilla pharetra nunc, sed ornare
+                    urna congue a.
+                  </p>
+                  <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                    Suspendisse urna eros, vestibulum quis gravida quis, tempus
+                    in sapien. Sed aliquet velit lectus, ac tempus dui iaculis
+                    ac. Morbi ullamcorper laoreet magna ac commodo. Aenean
+                    pharetra nulla sapien, nec interdum dolor semper quis. Ut
+                    posuere libero at scelerisque iaculis. Phasellus eu arcu
+                    ullamcorper, ultrices turpis id, pretium tellus. Integer
+                    accumsan ultrices semper. Maecenas eu scelerisque metus, nec
+                    pulvinar odio. Nunc imperdiet efficitur vehicula. Curabitur
+                    laoreet ut tellus quis sagittis. Nulla auctor vitae felis
+                    quis convallis. Nunc hendrerit imperdiet elit at auctor.
+                    Integer condimentum euismod orci vitae venenatis. Proin
+                    maximus in sem vitae auctor. Aliquam egestas, lorem vel
+                    volutpat pharetra, dolor felis malesuada lorem, vitae
+                    fermentum eros erat tempor lacus.
+                  </p>
                 </div>
               </ModalBody>
               <ModalButtonGroup
                 primaryButtons={[
                   <ModalButton variant="primary" label="submit" closesModal />,
-                  <ModalButton variant="secondary" label="cancel" closesModal />
+                  <ModalButton
+                    variant="secondary"
+                    label="cancel"
+                    closesModal
+                  />,
                 ]}
               />
             </Modal>
@@ -143,9 +265,8 @@ export const largeContent = () => {
         </div>
       </div>
     </Flex>
-
   );
-}
+};
 
 largeContent.story = {
   name: 'Large content example',
@@ -155,19 +276,39 @@ export const ModalDemo = () => {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <>
-      <PrimaryButton label='Open Modal' onClick={() => setIsOpen(true)} />
-      {isOpen && <Modal size='md' onClose={() => setIsOpen(false)} rootId='modal-root'>
-        <ModalHeader title='Modal header' displayClose={true} />
-        <ModalBody>
-          <p style={{ 'color': '#616672', 'fontSize': '14px','margin': '0 0 0.5rem' }}>
-            This is information presented in a modal
-          </p>
-          <ModalButtonGroup
-            primaryButtons={[<ModalButton onClick={() => {}} label='submit' variant='primary' />]}
-            secondaryButtons={[<ModalButton onClick={() => {}} label='More info' variant='secondary' />]}
-          />
-        </ModalBody>
-      </Modal>}
+      <PrimaryButton label="Open Modal" onClick={() => setIsOpen(true)} />
+      {isOpen && (
+        <Modal size="md" onClose={() => setIsOpen(false)} rootId="modal-root">
+          <ModalHeader title="Modal header" displayClose={true} />
+          <ModalBody>
+            <p
+              style={{
+                color: '#616672',
+                fontSize: '14px',
+                margin: '0 0 0.5rem',
+              }}
+            >
+              This is information presented in a modal
+            </p>
+            <ModalButtonGroup
+              primaryButtons={[
+                <ModalButton
+                  onClick={() => {}}
+                  label="submit"
+                  variant="primary"
+                />,
+              ]}
+              secondaryButtons={[
+                <ModalButton
+                  onClick={() => {}}
+                  label="More info"
+                  variant="secondary"
+                />,
+              ]}
+            />
+          </ModalBody>
+        </Modal>
+      )}
     </>
   );
 };

--- a/src/components/ui/Modal/ModalBody.tsx
+++ b/src/components/ui/Modal/ModalBody.tsx
@@ -1,11 +1,20 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { FC } from 'react';
+import React, { FC, HTMLAttributes } from 'react';
+import { BaseProps } from '../Base';
 import { StyledModalBody } from './Styled';
 
-export const ModalBody: FC<{}> = ({ children }) => {
-  return <StyledModalBody data-testid="modal-body">{children}</StyledModalBody>;
+interface ModalBodyProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'css'>,
+    BaseProps {}
+
+export const ModalBody: FC<ModalBodyProps> = ({ children, ...rest }) => {
+  return (
+    <StyledModalBody data-testid="modal-body" {...rest}>
+      {children}
+    </StyledModalBody>
+  );
 };
 
 export default ModalBody;

--- a/src/components/ui/Modal/ModalHeader.tsx
+++ b/src/components/ui/Modal/ModalHeader.tsx
@@ -21,7 +21,8 @@ export interface ModalHeaderProps
 export const ModalHeader: FC<ModalHeaderProps> = ({
   tag: Tag = 'div',
   displayClose = true,
-  title
+  title,
+  ...rest
 }) => {
   const context = useModalContext();
   const handleClick = () => {
@@ -29,7 +30,7 @@ export const ModalHeader: FC<ModalHeaderProps> = ({
   };
 
   return (
-    <StyledModalHeader>
+    <StyledModalHeader {...rest}>
       <Tag className="ch-title" id={context.labelID}>
         {title}
       </Tag>

--- a/src/components/ui/Modal/index.tsx
+++ b/src/components/ui/Modal/index.tsx
@@ -11,10 +11,13 @@ import ModalContext from './ModalContext';
 
 import useClickOutside from '../../../hooks/useClickOutside';
 import useUniqueId from '../../../hooks/useUniqueId';
+import { BaseProps } from '../Base';
 
 export type ModalSize = 'md' | 'lg' | 'fullscreen';
 
-export interface ModalProps extends HTMLAttributes<HTMLDivElement> {
+export interface ModalProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'css'>,
+    BaseProps {
   /** The callback fired when the modal is closed. */
   onClose: () => void;
   /** The size of the modal. */
@@ -57,8 +60,8 @@ export const Modal: FC<ModalProps> = ({
       }
     };
 
-    window.addEventListener('keydown', e => onKeydown(e));
-    return () => window.removeEventListener('keydown', e => onKeydown(e));
+    window.addEventListener('keydown', (e) => onKeydown(e));
+    return () => window.removeEventListener('keydown', (e) => onKeydown(e));
   }, []);
 
   return (


### PR DESCRIPTION
**Description of changes:**
Change prop tree to allow modal components to receive custom classNames.

Also fixed one old line in InfiniteScrollingList documentation.

**Testing**
1. Have you successfully run `npm run build:release` locally?
yes
2. How did you test these changes?
storybook
3. If you made changes to the component library, have you provided corresponding documentation changes?
n/a
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
