### PR TITLE
Bump chime-js-sdk version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Slight style changes to Modal and PopOver components.
 - Changed Badge props to be more flexible.
 - Changed PopOver component styling.
+- Bumped chime-sdk-js version to 1.22.
 
 ### Removed
 
 - Removed DateHeader component
+- [Demo] Removed use of depricated methods.
 
 ## [1.4.0] - 2020-11-06
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5698,6 +5698,12 @@
       "integrity": "sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ==",
       "dev": true
     },
+    "@types/ua-parser-js": {
+      "version": "0.7.33",
+      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "integrity": "sha512-ngUKcHnytUodUCL7C6EZ+lVXUjTMQb+9p/e1JjV5tN9TVzS98lHozWEFRPY1QcCdwFeMsmVWfZ3DPPT/udCyIw==",
+      "dev": true
+    },
     "@types/uglify-js": {
       "version": "3.9.3",
       "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.3.tgz",
@@ -6181,15 +6187,25 @@
       "dev": true
     },
     "amazon-chime-sdk-js": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-1.15.0.tgz",
-      "integrity": "sha512-fbRxTtqdEDU3iCMiQ23Awk4E9mY4w2m9WvPQie7z/bxe1jiEHLFMT0CFa2IzCDczf6eAPAcrRM/U+tEmDrEVJg==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-1.22.0.tgz",
+      "integrity": "sha512-1X/1yO8HFs4vcoi/CIRR5IxySpz4s2n6C8CErFC+bRPjeORVAmDyiy1F5WvXZm1XtAj4wa4tbuPUCoR21Dhw/Q==",
       "dev": true,
       "requires": {
         "@types/dom-mediacapture-record": "^1.0.4",
-        "detect-browser": "^4.7.0",
+        "@types/ua-parser-js": "^0.7.33",
+        "detect-browser": "^5.1.0",
         "protobufjs": "~6.8.8",
-        "resize-observer": "^1.0.0"
+        "resize-observer": "^1.0.0",
+        "ua-parser-js": "^0.7.22"
+      },
+      "dependencies": {
+        "ua-parser-js": {
+          "version": "0.7.22",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
+          "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==",
+          "dev": true
+        }
       }
     },
     "ansi-align": {
@@ -9523,9 +9539,9 @@
       }
     },
     "detect-browser": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-4.8.0.tgz",
-      "integrity": "sha512-f4h2dFgzHUIpjpBLjhnDIteXv8VQiUm8XzAuzQtYUqECX/eKh67ykuiVoyb7Db7a0PUSmJa3OGXStG0CbQFUVw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.0.tgz",
+      "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA==",
       "dev": true
     },
     "detect-file": {
@@ -20685,9 +20701,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.28",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-          "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==",
+          "version": "10.17.44",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.44.tgz",
+          "integrity": "sha512-vHPAyBX1ffLcy4fQHmDyIUMUb42gHZjPHU66nhvbMzAWJqHnySGZ6STwN3rwrnSd1FHB0DI/RWgGELgKSYRDmw==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@types/testing-library__react": "^10.0.1",
     "@types/throttle-debounce": "^2.1.0",
     "add": "^2.0.6",
-    "amazon-chime-sdk-js": "^1.15.0",
+    "amazon-chime-sdk-js": "^1.22.0",
     "babel-loader": "^8.1.0",
     "css-loader": "^2.1.1",
     "jest": "^25.3.0",
@@ -110,7 +110,7 @@
     "webpack-cli": "^3.3.2"
   },
   "peerDependencies": {
-    "amazon-chime-sdk-js": "^1.11.0",
+    "amazon-chime-sdk-js": "1.x || 2.x",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "styled-components": "^5.0.0",

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -132,8 +132,6 @@ export class MeetingManager implements AudioVideoObserver {
 
   async start(): Promise<void> {
     this.audioVideo?.start();
-    await this.meetingSession?.screenShare.open();
-    await this.meetingSession?.screenShareView.open();
   }
 
   async leave(): Promise<void> {
@@ -164,7 +162,6 @@ export class MeetingManager implements AudioVideoObserver {
   ): Promise<any> {
     const logger = this.createLogger(configuration);
     const deviceController = new DefaultDeviceController(logger);
-    configuration.enableWebAudio = false;
 
     this.meetingSession = new DefaultMeetingSession(
       configuration,


### PR DESCRIPTION
**Description of changes:** 
bump chime-js-sdk version to 1.22 
updated demo application to work with chime-js-sdk v1 & v2


**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? by manualy installing v1 and v2 and test app with both versions.

3. If you made changes to the component library, have you provided corresponding documentation changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
