### PR TITLE
Fix a bug that made this list not reusable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed slight spacing issue in ChatBubbleContainer.
 - Fixed issue where checkmark in PopOverItem wouldn't change on hover/focus.
 - Removed unused import in ChatBubble component.
+- Fix InfiniteList to make it more flexible.
 
 ### Added
 

--- a/src/components/ui/Chat/InfiniteList/InfiniteList.stories.tsx
+++ b/src/components/ui/Chat/InfiniteList/InfiniteList.stories.tsx
@@ -7,15 +7,15 @@ import Flex from '../../Flex';
 import InfiniteList from './';
 import InfiniteListDocs from './InfiniteList.mdx';
 
-// export default {
-//   title: 'UI Components/Chat/InfiniteList',
-//   parameters: {
-//     docs: {
-//       page: InfiniteListDocs.parameters.docs.page().props.children.type
-//     }
-//   },
-//   component: InfiniteList
-// };
+export default {
+  title: 'UI Components/Chat/InfiniteList',
+  parameters: {
+    docs: {
+      page: InfiniteListDocs.parameters.docs.page().props.children.type,
+    },
+  },
+  component: InfiniteList,
+};
 
 export const BasicInfiniteList = () => {
   // All of the below code is just to fake an API call that would return a new batch of messages


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
The intersection observers need to be defined outside of the useEffect hook. Also providing root to the intersection observers seems to not add value.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Storybook
3. If you made changes to the component library, have you provided corresponding documentation changes?
n/a
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
