### PR TITLE
Readiness for chime-js-sdk v2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed Badge props to be more flexible.
 - Changed PopOver component styling.
 - Bumped chime-sdk-js version to 1.22.
+- Added try/catch block to MeetingManager leave() function.
+- [Demo] Changed handling audio binding asynchronously.
 
 ### Removed
 
 - Removed DateHeader component
 - [Demo] Removed use of depricated methods.
+- [Demo] Removed call MeetingManager.leave() on leave button click. (dublicate)
 
 ## [1.4.0] - 2020-11-06
 

--- a/demo/meeting/src/containers/EndMeetingControl/index.tsx
+++ b/demo/meeting/src/containers/EndMeetingControl/index.tsx
@@ -27,7 +27,6 @@ const EndMeetingControl: React.FC = () => {
   const history = useHistory();
 
   const leaveMeeting = async (): Promise<void> => {
-    meetingManager.leave();
     history.push(routes.HOME);
   };
 

--- a/demo/meeting/src/utils/TestSound.tsx
+++ b/demo/meeting/src/utils/TestSound.tsx
@@ -37,9 +37,24 @@ class TestSound {
     );
     oscillatorNode.start();
     const audioMixController = new DefaultAudioMixController();
-    // @ts-ignore
-    audioMixController.bindAudioDevice({ deviceId: sinkId });
-    audioMixController.bindAudioElement(new Audio());
+
+    const handlingBindingAsynchronous = async () => {
+      try {
+        // @ts-ignore
+        await audioMixController.bindAudioDevice({ deviceId: this.sinkId });
+      } catch (e) {
+        console.error('Failed to bind audio device', e);
+      }
+
+      try {
+        // @ts-ignore
+        await audioMixController.bindAudioElement(new Audio());
+      } catch (e) {
+        console.error('Failed to bind audio element', e);
+      }
+    };
+
+    handlingBindingAsynchronous();
     audioMixController.bindAudioStream(destinationStream.stream);
     new TimeoutScheduler((rampSec * 2 + durationSec + 1) * 1000).start(() => {
       audioContext.close();

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -139,9 +139,14 @@ export class MeetingManager implements AudioVideoObserver {
       this.audioVideo.stopContentShare();
       this.audioVideo.stopLocalVideoTile();
       this.audioVideo.unbindAudioElement();
-      await this.audioVideo.chooseVideoInputDevice(null);
-      await this.audioVideo.chooseAudioInputDevice(null);
-      await this.audioVideo.chooseAudioOutputDevice(null);
+
+      try {
+        await this.audioVideo.chooseVideoInputDevice(null);
+        await this.audioVideo.chooseAudioInputDevice(null);
+        await this.audioVideo.chooseAudioOutputDevice(null);
+      } catch (e) {
+        console.log('Unable to set device to null on leave.');
+      }
 
       if (this.activeSpeakerListener) {
         this.audioVideo.unsubscribeFromActiveSpeakerDetector(


### PR DESCRIPTION

**Description of changes:**
V2 readiness at this point components works with v1 and v2 of chime-sdk-js

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? 
tested with v1 and v2 QA approved!

3. If you made changes to the component library, have you provided corresponding documentation changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
