### PR TITLE
Allow arbitrary to be passed to RosterProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Added
+
+### Changed
+- Allow arbitrary to be passed to RosterProvider
+
+### Removed
+
+## [1.5.0] - 2020-11-20
+
+### Fixed
+
 - Fixed ModalBody component to allow custom classNames
 - Fixed PopOver components to allow custom classNames
 - Fixed small visual errors in chat componnets.
@@ -41,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed DateHeader component
 - [Demo] Removed use of depricated methods.
-- [Demo] Removed call MeetingManager.leave() on leave button click. (dublicate)
+- [Demo] Removed call MeetingManager.leave() on leave button click. (duplicate)
 
 ## [1.4.0] - 2020-11-06
 

--- a/src/components/ui/icons/HandRaise/Styled.tsx
+++ b/src/components/ui/icons/HandRaise/Styled.tsx
@@ -1,7 +1,6 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
 import styled from 'styled-components';
 
 export const StyledCircle = styled.circle`

--- a/src/providers/RosterProvider/docs/RosterProvider.stories.mdx
+++ b/src/providers/RosterProvider/docs/RosterProvider.stories.mdx
@@ -2,7 +2,7 @@
 
 # RosterProvider
 
-The `RosterProvider` provides the state of the roster.
+The `RosterProvider` provides the state of the roster. You must provide the `MeetingManager` with a `getAttendee` function in order to get names. Additional data returned from the `getAttendee` function will be available through the `RosterProvider`.
 
 ### State
 

--- a/src/providers/RosterProvider/index.tsx
+++ b/src/providers/RosterProvider/index.tsx
@@ -65,9 +65,7 @@ const RosterProvider: React.FC = ({ children }) => {
           externalUserId
         );
 
-        if (externalData.name) {
-          attendee.name = externalData.name;
-        }
+        attendee = { ...attendee, ...externalData };
       }
 
       rosterRef.current[attendeeId] = attendee;


### PR DESCRIPTION
**Issue #:** 
issue #278 

**Description of changes:**
Allow developers to pass additional data to RosterProvider if needed

**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes?
Added a random property in the demo's getAttendee function, verified video tiles and roster worked as intended

3. If you made changes to the component library, have you provided corresponding documentation changes?
yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
