### PR TITLE
Fix layout bug with Checkbox in Formfield

### DIFF
--- a/src/components/ui/Checkbox/index.tsx
+++ b/src/components/ui/Checkbox/index.tsx
@@ -51,5 +51,7 @@ export const Checkbox: FC<CheckboxProps> = (props: CheckboxProps) => {
     </>
   );
 };
+Checkbox.displayName = 'Checkbox';
+
 
 export default Checkbox;

--- a/src/components/ui/icons/HandRaise/Styled.tsx
+++ b/src/components/ui/icons/HandRaise/Styled.tsx
@@ -1,7 +1,6 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
 import styled from 'styled-components';
 
 export const StyledCircle = styled.circle`


### PR DESCRIPTION
**Issue #:** 
https://github.com/aws/amazon-chime-sdk-component-library-react/issues/247

**Description of changes:**
fix a bug related to showing the wrong layout for checkbox labels when used in a formfield. This fix will show the label correctly, after the checkbox.

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes?
locally created a formfield and added the checkbox as the layout type and verified the layout. 

3. If you made changes to the component library, have you provided corresponding documentation changes?
n/a
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
