### PR TITLE
Bugfix-306: PopOver with sub menu fails to open sub menu

### DIFF
--- a/src/components/ui/PopOver/Styled.tsx
+++ b/src/components/ui/PopOver/Styled.tsx
@@ -17,6 +17,7 @@ export const StyledPopOverMenu = styled.ul`
   padding: 0.5rem 0;
   box-shadow: ${(props) => props.theme.popOver.shadow};
   z-index: ${(props) => props.theme.zIndex.popOver};
+  overflow: inherit;
 `;
 
 export const StyledPopOverToggle = styled.button`


### PR DESCRIPTION
**Issue #:** 
https://github.com/aws/amazon-chime-sdk-component-library-react/issues/306

**Description of changes:**
- Fixed issue with popover submenu being clipped due to overflow.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Locally via Storybook

3. If you made changes to the component library, have you provided corresponding documentation changes?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
