### PR TITLE
Fix popover submenu being hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue where checkmark in PopOverItem wouldn't change on hover/focus.
 - Removed unused import in ChatBubble component.
 - Fix InfiniteList to make it more flexible.
+- Fix Popover Submenu being hidden.
 
 ### Added
 

--- a/src/components/ui/PopOver/Styled.tsx
+++ b/src/components/ui/PopOver/Styled.tsx
@@ -7,7 +7,6 @@ import { ellipsis } from '../../../utils/style';
 export const StyledPopOverMenu = styled.ul`
   width: fit-content;
   max-width: 22rem;
-  ${ellipsis};
   background-color: ${(props) => props.theme.popOver.menuBgd};
   border: ${(props) => props.theme.popOver.menuBorder};
   margin: 0;


### PR DESCRIPTION
**Issue #:** 
306
**Description of changes:**
Fix issue 306. Caused by a recent change to popover styles.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Storybook
3. If you made changes to the component library, have you provided corresponding documentation changes?
n/a
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
