### PR TITLE
Remove needless camera selection when calling MeetingManager.join, al…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- Remove needless camera selection when joining meeting
 
 ### Added
 - [Demo] Add Chat Demo app
 
 ### Changed
 - Allow arbitrary to be passed to RosterProvider
+- Allow for simlucast configuration in MeetingProvider
 
 ### Removed
 

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -92,8 +92,14 @@ export class MeetingManager implements AudioVideoObserver {
 
   postLoggerConfig: PostLogConfig | null = null;
 
+  simulcastEnabled: boolean = false;
+
   constructor(config: ManagerConfig) {
     this.logLevel = config.logLevel;
+
+    if (config.simulcastEnabled) {
+      this.simulcastEnabled = config.simulcastEnabled;
+    }
 
     if (config.postLogConfig) {
       this.postLoggerConfig = config.postLogConfig;
@@ -125,6 +131,12 @@ export class MeetingManager implements AudioVideoObserver {
       meetingInfo,
       attendeeInfo
     );
+
+    if (this.simulcastEnabled) {
+      this.configuration.enableUnifiedPlanForChromiumBasedBrowsers = true;
+      this.configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
+    };
+
     this.meetingRegion = meetingInfo.MediaRegion;
     this.meetingId = this.configuration.meetingId;
     await this.initializeMeetingSession(this.configuration);
@@ -312,9 +324,6 @@ export class MeetingManager implements AudioVideoObserver {
       this.videoInputDevices.length
     ) {
       this.selectedVideoInputDevice = this.videoInputDevices[0].deviceId;
-      await this.audioVideo?.chooseVideoInputDevice(
-        this.videoInputDevices[0].deviceId
-      );
       this.publishSelectedVideoInputDevice();
     }
   }

--- a/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
+++ b/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
@@ -29,7 +29,7 @@ const MyApp = () => {
 
 ## Constructor
 
-Accepts `logLevel` provided by `MeetingProvider` to initialize meeting session log level. Check [MeetingProvider](/?path=/docs/sdk-providers-meetingprovider--page) documentation for more details on `logLevel`.
+Accepts a config object of `logLevel`, `postLogConfig`, and `simulcastEnabled` that will be used when initializing a meeting session. See [MeetingProvider](/?path=/docs/sdk-providers-meetingprovider--page) documentation for more details.
 
 ## Interface
 

--- a/src/providers/MeetingProvider/index.tsx
+++ b/src/providers/MeetingProvider/index.tsx
@@ -20,6 +20,8 @@ interface Props {
   logLevel?: LogLevel;
   /** Configuration for a MeetingSessionPOSTLogger */
   postLogConfig?: PostLogConfig;
+  /** Whether or not to enable simulcast for the meeting session */
+  simulcastEnabled?: boolean;
 }
 
 export const MeetingContext = createContext<MeetingManager | null>(null);
@@ -27,10 +29,11 @@ export const MeetingContext = createContext<MeetingManager | null>(null);
 export const MeetingProvider: React.FC<Props> = ({
   logLevel = LogLevel.WARN,
   postLogConfig,
+  simulcastEnabled = false,
   children,
 }) => {
   const [meetingManager] = useState(
-    () => new MeetingManager({ logLevel, postLogConfig })
+    () => new MeetingManager({ logLevel, postLogConfig, simulcastEnabled })
   );
 
   return (

--- a/src/providers/MeetingProvider/types.ts
+++ b/src/providers/MeetingProvider/types.ts
@@ -39,4 +39,5 @@ export interface PostLogConfig {
 export interface ManagerConfig {
   logLevel: LogLevel;
   postLogConfig?: PostLogConfig;
+  simulcastEnabled?: boolean;
 }


### PR DESCRIPTION
**Issue #:** 
#261, #286

**Description of changes:**
- 261: We are preemptively calling `chooseVideoInputDevice` within `meetingManager.join`, which triggers the camera light to show regardless if we're showing video or not.

The [toggleVideo](https://github.com/aws/amazon-chime-sdk-component-library-react/blob/master/src/providers/LocalVideoProvider/index.tsx#L47) function and the [PreviewVideo](https://github.com/aws/amazon-chime-sdk-component-library-react/blob/master/src/components/sdk/PreviewVideo/index.tsx#L39) component already call `chooseVideoInputDevice`, so the initial call we make within `join` provides no value and needlessly triggers the camera light

- 286: Allow simulcast config to be set and used for creating a meeting session

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes?
- Removed the routing to stay on the home page when starting a meeting and verified no camera light
- Joined a meeting, verified there was no camera light on the meeting page when my video had not been started. Checked that preview and toggling video worked normally
- Passed simulcast config and joined a meeting, worked normally

3. If you made changes to the component library, have you provided corresponding documentation changes? yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
