### PR TITLE
Fix demo test speaker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Remove needless camera selection when joining meeting
+- [Demo] Fix demo test speakers
 
 ### Added
 - [Demo] Add Chat Demo app

--- a/demo/meeting/src/utils/TestSound.tsx
+++ b/demo/meeting/src/utils/TestSound.tsx
@@ -41,7 +41,7 @@ class TestSound {
     const handlingBindingAsynchronous = async () => {
       try {
         // @ts-ignore
-        await audioMixController.bindAudioDevice({ deviceId: this.sinkId });
+        await audioMixController.bindAudioDevice({ deviceId: sinkId });
       } catch (e) {
         console.error('Failed to bind audio device', e);
       }


### PR DESCRIPTION
**Issue #:** 
Demo test speaker functionality was broken

**Description of changes:**
Fixes small typo. Should eventually split this test speaker code into a separate method instead of having the async code in the constructor

**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes? manually in chrome, ff, safari on Mac

3. If you made changes to the component library, have you provided corresponding documentation changes? n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
