### PR TITLE
Hooks for selecting audio input and ouput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix icon preventing clicks on `Select` components
 
 ### Added
+- Add `useSelectAudioInputDevice`, `useSelectAudioOutputDevice` hooks
 
 ### Changed
 

--- a/src/components/sdk/DeviceSelection/MicSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/MicSelection/index.tsx
@@ -3,8 +3,8 @@
 
 import React from 'react';
 
-import { useMeetingManager } from '../../../../providers/MeetingProvider';
 import { useAudioInputs } from '../../../../providers/DevicesProvider';
+import { useSelectAudioInputDevice } from '../../../../hooks/sdk/useSelectAudioInputDevice';
 import DeviceInput from '../DeviceInput';
 
 interface Props {
@@ -18,12 +18,8 @@ export const MicSelection: React.FC<Props> = ({
   notFoundMsg = 'No microphone devices found',
   label = 'Microphone source'
 }) => {
-  const meetingManager = useMeetingManager();
+  const selectAudioInput = useSelectAudioInputDevice();
   const { devices, selectedDevice } = useAudioInputs();
-
-  async function selectAudioInput(deviceId: string) {
-    meetingManager.selectAudioInputDevice(deviceId);
-  }
 
   return (
     <DeviceInput

--- a/src/components/sdk/DeviceSelection/SpeakerSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/SpeakerSelection/index.tsx
@@ -3,8 +3,8 @@
 
 import React from 'react';
 
-import { useMeetingManager } from '../../../../providers/MeetingProvider';
 import { useAudioOutputs } from '../../../../providers/DevicesProvider';
+import useSelectAudioOutputDevice from '../../../../hooks/sdk/useSelectAudioOutputDevice';
 import DeviceInput from '../DeviceInput';
 
 interface Props {
@@ -21,11 +21,11 @@ export const SpeakerSelection: React.FC<Props> = ({
   label = 'Speaker source',
   onChange
 }) => {
-  const meetingManager = useMeetingManager();
   const { devices, selectedDevice } = useAudioOutputs();
+  const selectAudioOutput = useSelectAudioOutputDevice();
 
-  async function selectAudioOutput(deviceId: string) {
-    meetingManager.selectAudioOutputDevice(deviceId);
+  async function selectDevice(deviceId: string) {
+    selectAudioOutput(deviceId);
     onChange && onChange(deviceId);
   }
 
@@ -33,7 +33,7 @@ export const SpeakerSelection: React.FC<Props> = ({
     <DeviceInput
       label={label}
       devices={devices}
-      onChange={selectAudioOutput}
+      onChange={selectDevice}
       selectedDeviceId={selectedDevice}
       notFoundMsg={notFoundMsg}
     />

--- a/src/hooks/sdk/docs/useSelectAudioInputDevice.stories.mdx
+++ b/src/hooks/sdk/docs/useSelectAudioInputDevice.stories.mdx
@@ -1,0 +1,47 @@
+<Meta title="SDK Hooks/useSelectAudioInputDevice" />
+
+# useSelectAudioInputDevice
+
+The `useSelectAudioInputDevice` hook returns a function that selects an audio input device given a device ID.
+
+You can access the available audio input device IDs using the `useAudioInputs` hook.
+
+### Return Value
+
+```javascript
+(deviceId: string) => Promise<void>;
+```
+
+## Importing
+
+```javascript
+import { useSelectAudioInputDevice } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+The hook depends on the `MeetingProvider` being rendered.
+
+```jsx
+import React from 'react';
+import {
+  MeetingProvider,
+  useSelectAudioInputDevice
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <MeetingProvider>
+    <MyChild />
+  </MeetingProvider>
+);
+
+const MyChild = () => {
+  const selectAudioInput = useSelectAudioInputDevice();
+
+  const handleClick = () => {
+    selectAudioInput('some-device-id');
+  };
+
+  return <button onClick={handleClick}>Some device ID</button>;
+};
+```

--- a/src/hooks/sdk/docs/useSelectAudioOutputDevice.stories.mdx
+++ b/src/hooks/sdk/docs/useSelectAudioOutputDevice.stories.mdx
@@ -1,0 +1,47 @@
+<Meta title="SDK Hooks/useSelectAudioOutputDevice" />
+
+# useSelectAudioOutputDevice
+
+The `useSelectAudioOutputDevice` hook returns a function that selects an audio input device given a device ID. The browser must support `setSinkId` to select audio output devices.
+
+You can access the available audio input device IDs using the `useAudioOutputs` hook.
+
+### Return Value
+
+```javascript
+(deviceId: string) => Promise<void>;
+```
+
+## Importing
+
+```javascript
+import { useSelectAudioOutputDevice } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+The hook depends on the `MeetingProvider` being rendered.
+
+```jsx
+import React from 'react';
+import {
+  MeetingProvider,
+  useSelectAudioOutputDevice
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <MeetingProvider>
+    <MyChild />
+  </MeetingProvider>
+);
+
+const MyChild = () => {
+  const selectAudioOutput = useSelectAudioOutputDevice();
+
+  const handleClick = () => {
+    selectAudioOutput('some-device-id');
+  };
+
+  return <button onClick={handleClick}>Some device ID</button>;
+};
+```

--- a/src/hooks/sdk/docs/useSelectVideoInputDevice.stories.mdx
+++ b/src/hooks/sdk/docs/useSelectVideoInputDevice.stories.mdx
@@ -2,7 +2,7 @@
 
 # useSelectVideoInputDevice
 
-The `useSelectVideoInputDevice` hook return a function that selects a video input device given a device ID.
+The `useSelectVideoInputDevice` hook returns a function that selects a video input device given a device ID.
 
 If you pass `none` as device ID, it will stop the local video if active. A user must select a device again before being able to share their video.
 

--- a/src/hooks/sdk/useSelectAudioInputDevice.tsx
+++ b/src/hooks/sdk/useSelectAudioInputDevice.tsx
@@ -1,0 +1,21 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCallback } from 'react';
+
+import { useMeetingManager } from '../../providers/MeetingProvider';
+
+export const useSelectAudioInputDevice = () => {
+  const meetingManager = useMeetingManager();
+
+  const selectDevice = useCallback(
+    async (deviceId: string) => {
+      await meetingManager.selectAudioInputDevice(deviceId);
+    },
+    []
+  );
+
+  return selectDevice;
+};
+
+export default useSelectAudioInputDevice;

--- a/src/hooks/sdk/useSelectAudioOutputDevice.tsx
+++ b/src/hooks/sdk/useSelectAudioOutputDevice.tsx
@@ -1,0 +1,21 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCallback } from 'react';
+
+import { useMeetingManager } from '../../providers/MeetingProvider';
+
+export const useSelectAudioOutputDevice = () => {
+  const meetingManager = useMeetingManager();
+
+  const selectDevice = useCallback(
+    async (deviceId: string) => {
+      await meetingManager.selectAudioOutputDevice(deviceId);
+    },
+    []
+  );
+
+  return selectDevice;
+};
+
+export default useSelectAudioOutputDevice;

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,6 +128,8 @@ export { useAttendeeStatus } from './hooks/sdk/useAttendeeStatus';
 export { useAttendeeAudioStatus } from './hooks/sdk/useAttendeeAudioStatus';
 export { useSelectVideoQuality } from './hooks/sdk/useSelectVideoQuality';
 export { useSelectVideoInputDevice } from './hooks/sdk/useSelectVideoInputDevice';
+export { useSelectAudioInputDevice } from './hooks/sdk/useSelectAudioInputDevice';
+export { useSelectAudioOutputDevice } from './hooks/sdk/useSelectAudioOutputDevice';
 export { useActiveSpeakersState } from './hooks/sdk/useActiveSpeakersState';
 export { useToggleLocalMute } from './hooks/sdk/useToggleLocalMute';
 export { useMeetingStatus } from './hooks/sdk/useMeetingStatus';


### PR DESCRIPTION
**Issue #:** 
#321

**Description of changes:**
Exposes hooks for selecting audio input/output. For some reason we exposed hooks for video selection, but not audio.

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? manually in chrome, ff

3. If you made changes to the component library, have you provided corresponding documentation changes? yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
