### PR TITLE
Fix select component click through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- Fix icon preventing clicks on `Select` components
+
+### Added
+
+### Changed
+
+### Removed
+
+## [1.6.0] - 2020-12-14
+
+### Fixed
 - Remove needless camera selection when joining meeting
 - [Demo] Fix demo test speakers
 

--- a/src/components/ui/Select/Styled.tsx
+++ b/src/components/ui/Select/Styled.tsx
@@ -5,6 +5,10 @@ import styled from 'styled-components';
 
 export const StyledWrapper = styled.div`
   position: relative;
+
+  .ch-select-icon {
+    pointer-events: none;
+  }
 `;
 
 export const StyledSelectInput = styled.select`


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
The arrow icons on the `Select` component blocks clicks, blocking a chunk of the interaction area. Adding some CSS to let clicks pass through the icons

**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes? manually in chrome by clicking on select arrows to open the dropdown

3. If you made changes to the component library, have you provided corresponding documentation changes? n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
