### PR TITLE
allow an optional id prop to all components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - [Demo] Add Chat Demo app
+- Added optional 'id' prop for ui components
 
 ### Changed
 - Allow arbitrary to be passed to RosterProvider

--- a/src/components/ui/Base/index.ts
+++ b/src/components/ui/Base/index.ts
@@ -8,6 +8,7 @@ import { BaseSdkProps } from '../../sdk/Base';
 export interface BaseProps extends SpaceProps, BaseSdkProps {
   /** Optional tag to render the component as a different HTML tag */
   tag?: any;
+  id?: string;
 }
 
 export interface FocusableProps {


### PR DESCRIPTION
**Issue #:** 
N/A

**Description of changes:**
Small change to `baseProps` for UI components so that they can receive an 'id' prop. This can be useful when applying `aria-describedby` attributes. 

**Testing**
1. Have you successfully run `npm run build:release` locally?
2. yes

2. How did you test these changes?   
Manually and by running unit tests

3. If you made changes to the component library, have you provided corresponding documentation changes?
The baseProps do not currently have documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
