### PR TITLE
Fix build-storybook error in Github Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+
 - Fix icon preventing clicks on `Select` components
+- Fix Github Actions build-storybook error
 
 ### Added
+
 - Add `useSelectAudioInputDevice`, `useSelectAudioOutputDevice` hooks
 - Added Echo icon
 - Added poorConnection property to DeskPhone icon
+- Added optional 'id' prop for ui components
 
 ### Changed
 
@@ -22,14 +26,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.6.0] - 2020-12-14
 
 ### Fixed
+
 - Remove needless camera selection when joining meeting
 - [Demo] Fix demo test speakers
 
 ### Added
+
 - [Demo] Add Chat Demo app
-- Added optional 'id' prop for ui components
 
 ### Changed
+
 - Allow arbitrary to be passed to RosterProvider
 - Allow for simlucast configuration in MeetingProvider
 - Updated button focus states to increase their accessibility

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "start": "start-storybook -p 9009",
     "test": "jest -c jest.config.js",
     "deploy-storybook": "storybook-to-ghpages",
-    "build-storybook": "build-storybook -s public",
+    "build-storybook": "build-storybook",
     "jest:integration": "jest -c jest-snapshot.config.js --verbose ./tst/snapshots/*",
     "test:snapshots-path": "jest -c jest-snapshot.config.js --verbose",
     "test:snapshots": "start-server-and-test start http-get://localhost:9009 jest:integration",


### PR DESCRIPTION
**Description of changes:**
Removing "-s public" flag from the build-storybook script which attempts to load static files from the public folder. This flag is not needed and causes the build to fail when run in Github Actions.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Submitted a test workflow to run build-storybook in a Github Actions flow. This script is normally only run on release.

3. If you made changes to the component library, have you provided corresponding documentation changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
