### PR TITLE
Revert "Fix build-storybook error in Github Actions"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-
 - Fix icon preventing clicks on `Select` components
-- Fix Github Actions build-storybook error
 
 ### Added
-
 - Add `useSelectAudioInputDevice`, `useSelectAudioOutputDevice` hooks
 - Added Echo icon
 - Added poorConnection property to DeskPhone icon
-- Added optional 'id' prop for ui components
 
 ### Changed
 
@@ -26,16 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.6.0] - 2020-12-14
 
 ### Fixed
-
 - Remove needless camera selection when joining meeting
 - [Demo] Fix demo test speakers
 
 ### Added
-
 - [Demo] Add Chat Demo app
+- Added optional 'id' prop for ui components
 
 ### Changed
-
 - Allow arbitrary to be passed to RosterProvider
 - Allow for simlucast configuration in MeetingProvider
 - Updated button focus states to increase their accessibility

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "start": "start-storybook -p 9009",
     "test": "jest -c jest.config.js",
     "deploy-storybook": "storybook-to-ghpages",
-    "build-storybook": "build-storybook",
+    "build-storybook": "build-storybook -s public",
     "jest:integration": "jest -c jest-snapshot.config.js --verbose ./tst/snapshots/*",
     "test:snapshots-path": "jest -c jest-snapshot.config.js --verbose",
     "test:snapshots": "start-server-and-test start http-get://localhost:9009 jest:integration",


### PR DESCRIPTION
This reverts commit 5129ab73218f0dceb0d36f22fdf1cfe6d14682f9.

**Issue #:** 

**Description of changes:**
This change is causing problems in the local build script, so I am reverting. 

**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes?

3. If you made changes to the component library, have you provided corresponding documentation changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
