### PR TITLE
Fix RosterAttendee overriding mic prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix icon preventing clicks on `Select` components
 - Fix Github Actions build-storybook error
 - [Docs] Fix ContentShare docs
+- Fix non-overridable Mic prop in `RosterAttendee`
 
 ### Added
 

--- a/src/components/sdk/RosterAttendee/index.tsx
+++ b/src/components/sdk/RosterAttendee/index.tsx
@@ -27,8 +27,8 @@ export const RosterAttendee: React.FC<RosterAttendeeProps> = ({
       muted={muted}
       videoEnabled={videoEnabled}
       sharingContent={sharingContent}
-      {...rest}
       microphone={<MicrophoneActivity attendeeId={attendeeId} />}
+      {...rest}
     />
   );
 };


### PR DESCRIPTION
**Issue #:** 
#347 

**Description of changes:**
Spreading before mic prop prevents anyone from passing a custom mic to the component

**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes? manually

3. If you made changes to the component library, have you provided corresponding documentation changes? n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
