### PR TITLE
Dependabot security fix axios

### DIFF
--- a/demo/chat/package-lock.json
+++ b/demo/chat/package-lock.json
@@ -59,7 +59,7 @@
       }
     },
     "@aws-amplify/api-rest": {
-      "version": "1.2.6",
+      "version": "1.2.16",
       "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-1.2.6.tgz",
       "integrity": "sha512-UiDrz2o/01+nAMlhNUe2wpoRA5qH5crVp4qVm8FgxQ3HsmQmITJdP+KwmrUxlqwZbTqcoeH14t3Iq5MoRQlCkQ==",
       "requires": {
@@ -181,7 +181,7 @@
       }
     },
     "@aws-amplify/storage": {
-      "version": "3.3.6",
+      "version": "3.3.16",
       "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-3.3.6.tgz",
       "integrity": "sha512-AM3SAW/iP8Qmmdo7wQCWLEsL1B8iY/hEysF0Vbw+huq4vftzObNHhE6WFLwkBT0xAUAL/Mh2akiJa4tc7iX44g==",
       "requires": {


### PR DESCRIPTION
**Issue #:** 
Security Update Dependabot for axion requesting v0.21.1

**Description of changes:**
update amplify-js/storage version from 3.3.6 to 3.3.16
update amplify-js/api-rest version from 1.2.6 to 1.2.16

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?

3. If you made changes to the component library, have you provided corresponding documentation changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
