### PR TITLE
Add className to <StyledPopOverMenu> in order to give styling access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Echo icon
 - Added poorConnection property to DeskPhone icon
 - Added optional 'id' prop for ui components
+- Added a classname to PopOverMenu component for styling access
 
 ### Changed
 

--- a/src/components/ui/PopOver/index.tsx
+++ b/src/components/ui/PopOver/index.tsx
@@ -160,6 +160,7 @@ export const PopOver: FC<PopOverProps> = ({
                 ref={ref}
                 style={style}
                 data-testid="menu"
+                className="ch-popover-menu"
               >
                 {children}
               </StyledPopOverMenu>


### PR DESCRIPTION
**Description of changes:**
Add className to <StyledPopOverMenu> in order to give styling access

**Testing**
1. Have you successfully run `npm run build:release` locally?
 Yes
2. How did you test these changes?
 Tested locally using macOS client
3. If you made changes to the component library, have you provided corresponding documentation changes?
 Yes
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
