### PR TITLE
Add linkColors for incoming and outgoing chat in chatBubble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Attachment, Dock, and Emoji picker icons
 - Added HandRaise and ListHandRaise icons
 - Added ConnectionProblem icon
+- Added linkColors for incoming and outgoing chat in chatBubble
 
 ### Changed
 

--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -374,10 +374,18 @@ const chatBubble = {
   incoming: {
     bgd: colors.greys.grey80,
     fontColor: colors.greys.grey30,
+    linkColor: colors.primary.main,
+    linkColorHover: colors.primary.dark,
+    linkColorActive: colors.primary.darker,
+    linkColorVisited: colors.primary.darkest,
   },
   outgoing: {
     bgd: colors.primary.dark,
     fontColor: colors.greys.grey70,
+    linkColor: colors.greys.grey80,
+    linkColorHover: colors.greys.grey70,
+    linkColorActive: colors.greys.grey60,
+    linkColorVisited: colors.greys.grey50,
   },
   container: {
     fontColor: colors.greys.grey30,

--- a/src/theme/light.ts
+++ b/src/theme/light.ts
@@ -374,10 +374,18 @@ const chatBubble = {
   incoming: {
     bgd: colors.greys.white,
     fontColor: colors.greys.grey60,
+    linkColor: colors.primary.main,
+    linkColorHover: colors.primary.dark,
+    linkColorActive: colors.primary.darker,
+    linkColorVisited: colors.primary.darkest,
   },
   outgoing: {
     bgd: colors.primary.light,
     fontColor: colors.greys.grey10,
+    linkColor: colors.greys.white,
+    linkColorHover: colors.greys.grey10,
+    linkColorActive: colors.greys.grey20,
+    linkColorVisited: colors.greys.grey30,
   },
   container: {
     fontColor: colors.greys.grey70,


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Add linkColors for incoming and outgoing chat in chatBubble

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Tested manually

3. If you made changes to the component library, have you provided corresponding documentation changes?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
