### PR TITLE
Strictly enforce DevicePermissionStatus type and export hook from library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jest major version
 - Changed RosterHeader 'title' prop to all for elements as well as strings
-
 - Changed senderName to optional in ChatBubble
 - Moved children inside of a div in ChatBubble
+- Changed `MeetingManager` to strictly enforce `DevicePermissionStatus` type.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added optional img to MessageAttachment
 - Added a classname to PopOverMenu component for styling access
 - Added forwardRef for Textarea
+- Added `useDevicePermissionStatus` hook as an exported component from the library.
 
 ### Changed
 

--- a/demo/meeting/src/containers/DevicePermissionPrompt.tsx
+++ b/demo/meeting/src/containers/DevicePermissionPrompt.tsx
@@ -6,11 +6,11 @@ import React from 'react';
 import {
   Modal,
   ModalBody,
-  ModalHeader
+  ModalHeader,
+  DevicePermissionStatus,
+  useDevicePermissionStatus
 } from 'amazon-chime-sdk-component-library-react';
 
-import useDevicePermissionStatus from '../hooks/useDevicePermissionStatus';
-import { DevicePermissionStatus } from '../enums';
 import Card from '../components/Card';
 
 // Show permission prompt when the user is granting the browser permissions

--- a/demo/meeting/src/enums/index.ts
+++ b/demo/meeting/src/enums/index.ts
@@ -1,9 +1,0 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-export enum DevicePermissionStatus {
-  UNSET = 'UNSET',
-  IN_PROGRESS = 'IN_PROGRESS',
-  GRANTED = 'GRANTED',
-  DENIED = 'DENIED',
-}

--- a/demo/meeting/src/utils/TestSound.tsx
+++ b/demo/meeting/src/utils/TestSound.tsx
@@ -15,8 +15,7 @@ class TestSound {
     maxGainValue = 0.1
   ) {
     // @ts-ignore
-    const audioContext: AudioContext = new (window.AudioContext ||
-      window.webkitAudioContext)();
+    const audioContext: AudioContext = new (window.AudioContext || window.webkitAudioContext)();
     const gainNode = audioContext.createGain();
     gainNode.gain.value = 0;
     const oscillatorNode = audioContext.createOscillator();

--- a/src/hooks/sdk/docs/useDevicePermissionStatus.stories.mdx
+++ b/src/hooks/sdk/docs/useDevicePermissionStatus.stories.mdx
@@ -1,0 +1,55 @@
+<Meta title="SDK Hooks/useDevicePermissionStatus" />
+
+# useDevicePermissionStatus
+
+The `useDevicePermissionStatus` hook returns the device permission status from the enum below.
+
+```javascript
+enum DevicePermissionStatus {
+  UNSET = 'UNSET',
+  IN_PROGRESS = 'IN_PROGRESS',
+  GRANTED = 'GRANTED',
+  DENIED = 'DENIED',
+}
+```
+
+### Return Value
+
+```javascript
+permission: DevicePermissionStatus;
+```
+
+## Importing
+
+```javascript
+import { useDevicePermissionStatus } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+The hook depends on the `MeetingProvider`.
+
+```jsx
+import React from 'react';
+import {
+  MeetingProvider,
+  useDevicePermissionStatus,
+  DevicePermissionStatus,
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <MeetingProvider>
+    <MyChild />
+  </MeetingProvider>
+);
+
+const MyChild = () => {
+  const meetingStatus = useMeetingStatus();
+
+  return <p>Meeting Status: {meetingStatus}</p>;
+};
+```
+
+### Dependencies
+
+- `MeetingProvider`

--- a/src/hooks/sdk/useDevicePermissionStatus.tsx
+++ b/src/hooks/sdk/useDevicePermissionStatus.tsx
@@ -8,12 +8,12 @@ import { DevicePermissionStatus } from '../../types';
 
 export function useDevicePermissionStatus() {
   const meetingManager = useMeetingManager();
-  const [permission, setPermission] = useState<string>(
+  const [permission, setPermission] = useState<DevicePermissionStatus>(
     DevicePermissionStatus.UNSET
   );
 
   useEffect(() => {
-    const callback = (updatedPermission: string): void => {
+    const callback = (updatedPermission: DevicePermissionStatus): void => {
       setPermission(updatedPermission);
     };
     meetingManager.subscribeToDevicePermissionStatus(callback);

--- a/src/hooks/sdk/useDevicePermissionStatus.tsx
+++ b/src/hooks/sdk/useDevicePermissionStatus.tsx
@@ -1,12 +1,12 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, useState } from 'react';
-import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
 
-import { DevicePermissionStatus } from '../enums';
+import { useMeetingManager } from '../../providers/MeetingProvider';
+import { DevicePermissionStatus } from '../../types';
 
-export default function useDevicePermissionStatus() {
+export function useDevicePermissionStatus() {
   const meetingManager = useMeetingManager();
   const [permission, setPermission] = useState<string>(
     DevicePermissionStatus.UNSET
@@ -24,3 +24,5 @@ export default function useDevicePermissionStatus() {
 
   return permission;
 }
+
+export default useDevicePermissionStatus;

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,6 +136,7 @@ export { useMeetingStatus } from './hooks/sdk/useMeetingStatus';
 export { useLocalAudioInputActivity } from './hooks/sdk/useLocalAudioInputActivity';
 export { useLocalAudioInputActivityPreview } from './hooks/sdk/useLocalAudioInputActivityPreview';
 export { useBandwidthMetrics } from './hooks/sdk/useBandwidthMetrics';
+export { useDevicePermissionStatus } from './hooks/sdk/useDevicePermissionStatus';
 
 // Providers
 export { NotificationProvider } from './providers/NotificationProvider';
@@ -160,7 +161,7 @@ export { lightTheme, darkTheme, GlobalStyles, StyledReset } from './theme';
 export { VideoQuality } from './hooks/sdk/useSelectVideoQuality';
 
 // enums
-export { MeetingStatus } from './types/index';
+export { MeetingStatus, DevicePermissionStatus } from './types/index';
 export { Severity, ActionType } from './providers/NotificationProvider';
 
 // Class

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -74,7 +74,7 @@ export class MeetingManager implements AudioVideoObserver {
 
   devicePermissionStatus = DevicePermissionStatus.UNSET;
 
-  devicePermissionsObservers: ((permission: string) => void)[] = [];
+  devicePermissionsObservers: ((permission: DevicePermissionStatus) => void)[] = [];
 
   activeSpeakerListener: ((activeSpeakers: string[]) => void) | null = null;
 
@@ -418,13 +418,13 @@ export class MeetingManager implements AudioVideoObserver {
   };
 
   subscribeToDevicePermissionStatus = (
-    callback: (permission: string) => void
+    callback: (permission: DevicePermissionStatus) => void
   ): void => {
     this.devicePermissionsObservers.push(callback);
   };
 
   unsubscribeFromDevicePermissionStatus = (
-    callbackToRemove: (permission: string) => void
+    callbackToRemove: (permission: DevicePermissionStatus) => void
   ): void => {
     this.devicePermissionsObservers = this.devicePermissionsObservers.filter(
       callback => callback !== callbackToRemove

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,3 +53,10 @@ export type RosterAttendeeType = {
 export type RosterType = {
   [attendeeId: string]: RosterAttendeeType;
 };
+
+export enum DevicePermissionStatus {
+  UNSET = 'UNSET',
+  IN_PROGRESS = 'IN_PROGRESS',
+  GRANTED = 'GRANTED',
+  DENIED = 'DENIED',
+};


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Change the permission type from `string` to `DevicePermissionStatus`.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Sanity test in demo app
3. If you made changes to the component library, have you provided corresponding documentation changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
