### PR TITLE
optional button in notifications

### DIFF
--- a/src/components/ui/Notification/Notification.stories.tsx
+++ b/src/components/ui/Notification/Notification.stories.tsx
@@ -8,6 +8,8 @@ import { Notification } from '.';
 import { Severity } from '../../../providers/NotificationProvider';
 import NotificationDocs from './Notification.mdx';
 import Flex from '../Flex';
+import { Cog } from '../icons';
+import Heading from '../Heading';
 
 export default {
   title: 'UI Components/Notification',
@@ -19,7 +21,7 @@ export default {
   component: Notification,
 };
 
-export const _Notification = () => {
+export const BasicNotification = () => {
   return (
     <Flex layout="fill-space-centered">
       <Notification
@@ -36,8 +38,75 @@ export const _Notification = () => {
           },
           Severity.ERROR
         )}
-        message="This is the notification message"
+        message='This is the notification message'
       />
     </Flex>
   );
+};
+
+BasicNotification.story = {
+  name: 'Basic Notification',
+};
+
+export const NotificationWithButton = () =>{
+  return (
+    <Flex layout="fill-space-centered">
+      <Notification
+        onClose={() => {
+          console.log('Close notification');
+        }}
+        severity={select(
+          'severity',
+          {
+            success: Severity.SUCCESS,
+            warning: Severity.WARNING,
+            info: Severity.INFO,
+            error: Severity.ERROR,
+          },
+          Severity.SUCCESS
+        )}
+        icon={<Cog />} 
+        message='This is the notification message'
+        buttonProps={{ label: 'Click me', onClick: () => alert('clicked'), }}
+      />
+    </Flex>
+  );
+};
+
+NotificationWithButton.story = {
+  name: 'Notification with button and custom icon',
+};
+
+export const NotificationWithCustomContent = () =>{
+  return (
+    <Flex layout="fill-space-centered">
+      <Notification
+        onClose={() => {
+          console.log('Close notification');
+        }}
+        severity={select(
+          'severity',
+          {
+            success: Severity.SUCCESS,
+            warning: Severity.WARNING,
+            info: Severity.INFO,
+            error: Severity.ERROR,
+          },
+          Severity.SUCCESS
+        )}
+        icon={<Cog />} 
+      >
+        <Heading 
+          css={`padding: 0 2rem; font-weight: bold;`} 
+          level={6}
+        >
+          This is a Heading component with custom styling
+        </Heading> 
+      </Notification>
+    </Flex>
+  );
+};
+
+NotificationWithButton.story = {
+  name: 'Notification with custom content',
 };

--- a/src/components/ui/Notification/Styled.tsx
+++ b/src/components/ui/Notification/Styled.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { NotificationProps } from '.';
 import { Severity } from '../../../providers/NotificationProvider';
 import IconButton from '../Button/IconButton';
+import SecondaryButton from '../Button/SecondaryButton';
 import { baseStyles, baseSpacing } from '../Base';
 
 interface StyledNotificationProps extends NotificationProps {
@@ -13,49 +14,60 @@ interface StyledNotificationProps extends NotificationProps {
 }
 
 export const StyledCloseIconButton = styled(IconButton)``;
+export const StyledNotificationButton = styled(SecondaryButton)``;
 
 export const StyledNotification = styled.div<StyledNotificationProps>`
+  align-items: center;
   position: relative;
   display: inline-flex;
-  align-items: flex-start;
+  align-items: center;
   color: ${({ theme, severity }) => theme.notification[severity].text};
   background-color: ${({ theme, severity }) => theme.colors[severity].primary};
-  padding: 0.5rem;
+  padding: 0.75rem;
   box-shadow: ${({ theme }) => theme.notification.shadow};
   border-radius: 0.25rem;
-  margin: 0.5rem;
+  margin: 0.75rem;
   max-width: 45rem;
 
   .ch-severity-icon {
     width: 1.5rem;
     flex-shrink: 0;
-    margin-top: 0.25rem;
   }
 
   .ch-message {
     display: flex;
     flex-flow: column wrap;
     font-size: ${(props) => props.theme.fontSizes.text.fontSize};
-    font-size: ${(props) => props.theme.fontSizes.text.lineHeight};
+    line-height: ${(props) => props.theme.fontSizes.text.lineHeight};
     letter-spacing: -0.005625rem;
-    margin: 0.5rem 3.3125rem 0.375rem 0.75rem;
+    margin: 0.5rem 0.75rem;
+
+    &:empty {
+      margin: 0;
+    }
   }
 
-  ${StyledCloseIconButton} {
+  ${StyledNotificationButton} {
+    margin-right: 1.6rem;
+    border-color: ${({ theme, severity }) => theme.notification[severity].text};
+  }
+
+  ${StyledCloseIconButton},
+  ${StyledNotificationButton} {
     background-color: ${({ theme, severity }) =>
       theme.colors[severity].primary};
     color: ${({ theme, severity }) =>
       theme.notification[severity].closeButton.text}};
   }
 
-  ${StyledCloseIconButton}:hover, ${StyledCloseIconButton}:focus {
+  ${StyledCloseIconButton}:hover, ${StyledCloseIconButton}:focus, ${StyledNotificationButton}:hover, ${StyledNotificationButton}:focus {
     background-color: ${({ theme, severity }) =>
       theme.notification[severity].closeButton.hover.bgd};
     color: ${({ theme, severity }) =>
       theme.notification[severity].closeButton.hover.text};
   }
 
-  ${StyledCloseIconButton}:active {
+  ${StyledCloseIconButton}:active, ${StyledNotificationButton}:active {
     background-color: ${({ theme, severity }) =>
       theme.notification[severity].closeButton.active.bgd};
     color: ${({ theme, severity }) =>
@@ -65,3 +77,5 @@ export const StyledNotification = styled.div<StyledNotificationProps>`
   ${baseSpacing}
   ${baseStyles}
 `;
+
+

--- a/src/components/ui/Notification/index.tsx
+++ b/src/components/ui/Notification/index.tsx
@@ -1,10 +1,11 @@
 // Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useEffect, HTMLAttributes } from 'react';
+import React, { useEffect, HTMLAttributes, ReactNode } from 'react';
 
-import { StyledNotification, StyledCloseIconButton } from './Styled';
+import { StyledNotification, StyledCloseIconButton, StyledNotificationButton } from './Styled';
 import { Caution, CheckRound, Information, Remove, Clock } from '../icons';
+import { ButtonProps } from '../Button';
 import { BaseProps } from '../Base';
 
 export const DEFAULT_DELAY: number = 6000;
@@ -31,6 +32,12 @@ export interface NotificationProps
   autoCloseDelay?: number;
   /** CSS classname to apply custom styles. */
   className?: string;
+  /** For rendering a button element adjacent to the message */
+  buttonProps?: ButtonProps;
+  /** optional icon to override the default */
+  icon?: ReactNode;
+  /** optional content to render in the body of the notification */
+  children?: ReactNode | ReactNode[];
 }
 
 const iconMapping = {
@@ -49,6 +56,9 @@ export const Notification: React.FC<NotificationProps> = (props) => {
     autoCloseDelay = DEFAULT_DELAY,
     severity = Severity.ERROR,
     className,
+    buttonProps,
+    icon,
+    children,
   } = props;
 
   const ariaLive = severity === Severity.ERROR ? 'assertive' : 'polite';
@@ -73,11 +83,13 @@ export const Notification: React.FC<NotificationProps> = (props) => {
       data-testid="notification"
     >
       <div className="ch-severity-icon" data-testid="severity-icon">
-        {iconMapping[severity]}
+        {icon ? icon : iconMapping[severity]}
       </div>
       <output className="ch-message" data-testid="message" role={ariaRole}>
         {message}
       </output>
+      {buttonProps && <StyledNotificationButton aria-hidden {...buttonProps}/>}
+      {children}
       {onClose && (
         <StyledCloseIconButton
           label="close"

--- a/tst/components/ui/Notification/index.test.tsx
+++ b/tst/components/ui/Notification/index.test.tsx
@@ -3,15 +3,31 @@
 
 import React from 'react';
 import '@testing-library/jest-dom';
-import { fireEvent } from '@testing-library/dom';
+import { fireEvent, getByText } from '@testing-library/dom';
 
 import lightTheme from '../../../../src/theme/light';
 import { renderWithTheme } from '../../../test-helpers';
 import Notification from '../../../../src/components/ui/Notification';
 import { Severity } from '../../../../src/providers/NotificationProvider';
+import Echo from '../../../../src/components/ui/icons/Echo';
 
 const getNotificationComponent = () => (
   <Notification onClose={jest.fn()} severity={Severity.ERROR} message="Hello" />
+);
+
+const getNotificationWithOptionalProps = () => (
+  <Notification
+    icon={<Echo />} 
+    onClose={jest.fn()}
+    severity={Severity.SUCCESS}
+    message='Hello'
+    buttonProps={{ 
+      label: 'click me', 
+      onClick: jest.fn(), 
+    }}
+  >
+    <p>This is custom content</p>
+  </Notification>
 );
 
 describe('Notification', () => {
@@ -60,5 +76,29 @@ describe('Notification', () => {
     const closeButton = getByTestId('button');
     fireEvent.click(closeButton);
     expect(notificationComponent.props.onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Notification with optional props', () => {
+  it('renders a notification with a button', () => {
+    const notificationComponent = getNotificationWithOptionalProps();
+    const {  getByText } = renderWithTheme(lightTheme, notificationComponent);
+    const button = getByText('click me');
+    expect(button).toBeInTheDocument();
+  });
+
+  it('renders a notification with a custom icon', () => {
+    const notificationComponent = getNotificationWithOptionalProps();
+    const { getByTestId } = renderWithTheme(lightTheme, notificationComponent);
+    const severityIconEl = getByTestId('severity-icon');
+    expect(severityIconEl.children[0].classList.contains('Svg')).toBe(true)
+    expect(severityIconEl).toBeInTheDocument();
+  });
+
+  it('renders children if any are provided', () => {
+    const notificationComponent = getNotificationWithOptionalProps();
+    const { getByText } = renderWithTheme(lightTheme, notificationComponent);
+    const content = getByText('This is custom content');
+    expect(content).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
**Description of changes:**
There are 3 changes in this PR:
- Add an optional button to accompany the notification message.
- Allow users to optionally override the default icon with a custom element.
- Add an option `children` slot for custom content

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes? Manually, and with unit tests

3. If you made changes to the component library, have you provided corresponding documentation changes? Yes. The docs are updated as well as more storybook stories.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
