### PR TITLE
Optional prop to prevent dismissing the Modal component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added poorConnection property to DeskPhone icon
 - Added optional 'id' prop for ui components
 - Added a classname to PopOverMenu component for styling access
+- Added a "dismissible" prop to Modal to optionally allow persistent modals
 
 ### Changed
 

--- a/src/components/ui/Modal/Modal.stories.tsx
+++ b/src/components/ui/Modal/Modal.stories.tsx
@@ -14,6 +14,7 @@ import ModalButton from './ModalButton';
 import ModalButtonGroup from './ModalButtonGroup';
 import PrimaryButton from '../Button/PrimaryButton';
 import ModalDocs from './Modal.mdx';
+import Heading from '../Heading';
 
 export default {
   title: 'UI Components/Modal',
@@ -63,7 +64,7 @@ export const BasicExample = () => {
     <Flex layout="fill-space-centered">
       <div style={{ width: '30rem', textAlign: 'center' }}>
         <div>
-          <h1>Modal basic example</h1>
+          <Heading level={6}>Modal basic example</Heading>
           <PrimaryButton onClick={toggleModal} label="toggle modal" />
           {showModal && (
             <Modal
@@ -110,7 +111,7 @@ export const BasicExample = () => {
   );
 };
 
-BasicExample.story = 'Basic example';
+BasicExample.story = 'Basic Example';
 
 export const largeContent = () => {
   const [showModal, setShowModal] = useState(false);
@@ -120,7 +121,7 @@ export const largeContent = () => {
     <Flex layout="fill-space-centered">
       <div style={{ width: '30rem', textAlign: 'center' }}>
         <div>
-          <h1>Modal with scrollable content</h1>
+          <Heading level={6}>Modal with scrollable content</Heading>
           <PrimaryButton onClick={toggleModal} label="toggle modal" />
 
           {showModal && (
@@ -269,8 +270,66 @@ export const largeContent = () => {
 };
 
 largeContent.story = {
-  name: 'Large content example',
+  name: 'Large Content Example',
 };
+
+export const PersistentExample = () => {
+  const [showModal, setShowModal] = useState(false);
+  const toggleModal = () => setShowModal(!showModal);
+
+  return (
+    <Flex layout="fill-space-centered">
+      <div style={{ width: 'auto', textAlign: 'center' }}>
+        <div>
+          <Heading level={6}>Persistent Modal Example</Heading>
+          <PrimaryButton onClick={toggleModal} label="open modal" />
+          {showModal && (
+            <Modal
+              size={select('size', ['md', 'lg', 'fullscreen'], 'md')}
+              onClose={null}
+              rootId="modal-root"
+              dismissible={false}
+            >
+              <ModalHeader title="This content cannot be dismissed" />
+              <ModalBody>
+                <p style={{ margin: '0 0 1rem' }}>
+                  Vivamus nisi justo, sagittis eu dolor vel, pretium placerat
+                  dolor. Vestibulum ante ipsum primis in faucibus orci luctus
+                  et ultrices posuere cubilia curae; Nullam condimentum nisi
+                  velit, id pellentesque quam facilisis dapibus. Donec orci
+                  est, faucibus at dapibus sit amet, hendrerit vitae libero.
+                  Quisque sed pellentesque diam. Fusce vitae imperdiet nisi, a
+                  elementum ante. Lorem ipsum dolor sit amet, consectetur
+                  adipiscing elit. Sed fringilla pharetra nunc, sed ornare
+                  urna congue a.
+                </p>
+                <p style={{ margin: '0 0 1rem' }}>
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                  Suspendisse urna eros, vestibulum quis gravida quis, tempus
+                  in sapien. Sed aliquet velit lectus, ac tempus dui iaculis
+                  ac. Morbi ullamcorper laoreet magna ac commodo. Aenean
+                  pharetra nulla sapien, nec interdum dolor semper quis. Ut
+                  posuere libero at scelerisque iaculis. Phasellus eu arcu
+                  ullamcorper, ultrices turpis id, pretium tellus. Integer
+                  accumsan ultrices semper. Maecenas eu scelerisque metus, nec
+                  pulvinar odio. Nunc imperdiet efficitur vehicula. Curabitur
+                  laoreet ut tellus quis sagittis. Nulla auctor vitae felis
+                  quis convallis. Nunc hendrerit imperdiet elit at auctor.
+                  Integer condimentum euismod orci vitae venenatis. Proin
+                  maximus in sem vitae auctor. Aliquam egestas, lorem vel
+                  volutpat pharetra, dolor felis malesuada lorem, vitae
+                  fermentum eros erat tempor lacus.
+                </p>
+              </ModalBody>
+            </Modal>
+          )}
+        </div>
+      </div>
+    </Flex>
+  );
+};
+
+PersistentExample.story = 'Persistent Modal Example';
 
 export const ModalDemo = () => {
   const [isOpen, setIsOpen] = useState(false);

--- a/src/components/ui/Modal/ModalButtonGroup.tsx
+++ b/src/components/ui/Modal/ModalButtonGroup.tsx
@@ -31,7 +31,8 @@ export const ModalButtonGroup: FC<ModalButtonGroupProps> = ({
   };
 
   const addCloseBehaviorToButtons = (buttons: JSX.Element[] | JSX.Element) => {
-    if (!buttons || (buttons instanceof Array && buttons.length === 0)) {
+    if (!context.dismissible || !buttons || (buttons instanceof Array && buttons.length === 0)) {
+      context.dismissible && console.warn("the 'dismissible prop prevents buttons from closing the modal");
       return buttons;
     }
     if (!(buttons instanceof Array)) {

--- a/src/components/ui/Modal/ModalContext.tsx
+++ b/src/components/ui/Modal/ModalContext.tsx
@@ -6,6 +6,7 @@ import { createContext, useContext } from 'react';
 export const ModalContext = createContext({
   onClose() {},
   labelID: '',
+  dismissible: true,
 });
 
 export const useModalContext = () => {

--- a/src/components/ui/Modal/ModalHeader.tsx
+++ b/src/components/ui/Modal/ModalHeader.tsx
@@ -35,7 +35,7 @@ export const ModalHeader: FC<ModalHeaderProps> = ({
         {title}
       </Tag>
 
-      {displayClose && (
+      {(displayClose && context?.dismissible) && (
         <IconButton
           label="Close"
           icon={<Remove />}

--- a/src/components/ui/Modal/index.tsx
+++ b/src/components/ui/Modal/index.tsx
@@ -19,27 +19,30 @@ export interface ModalProps
   extends Omit<HTMLAttributes<HTMLDivElement>, 'css'>,
     BaseProps {
   /** The callback fired when the modal is closed. */
-  onClose: () => void;
+  onClose?: () => void;
   /** The size of the modal. */
   size?: ModalSize;
   /** The rootId of the modal. */
   rootId?: string;
+  /** Optional prop to prevent the modal from closing. */
+  dismissible?: boolean;
 }
 
 export const Modal: FC<ModalProps> = ({
   size = 'md',
-  onClose,
+  onClose = () => null,
   children,
   rootId,
+  dismissible = true,
   ...rest
 }) => {
   const labelID = useUniqueId();
   const contentEl = useRef<HTMLDivElement>(null);
   const mainEl = useRef<HTMLDivElement>(null);
 
-  const modalContext = { onClose, labelID };
+  const modalContext = { onClose, labelID, dismissible };
 
-  useClickOutside(mainEl, onClose);
+  dismissible && useClickOutside(mainEl, onClose);
 
   useEffect(() => {
     // return focus to the element that triggered the

--- a/src/hooks/useClickOutside/index.tsx
+++ b/src/hooks/useClickOutside/index.tsx
@@ -5,14 +5,14 @@ import { useEffect, RefObject } from 'react';
 
 export function useClickOutside(
   ref: RefObject<HTMLElement>,
-  onClickOutside: (e: MouseEvent | TouchEvent) => void
+  onClickOutside?: (e: MouseEvent | TouchEvent) => void
 ) {
   const isOutside = (e: MouseEvent | TouchEvent) => {
     return !!ref.current && !ref.current.contains(e.target as HTMLElement);
   };
 
   const onMouseDown = (e: MouseEvent | TouchEvent) => {
-    if (isOutside(e)) {
+    if (isOutside(e) && onClickOutside) {
       onClickOutside(e);
     }
   };

--- a/tst/components/ui/Modal/ModalButtonGroup.test.tsx
+++ b/tst/components/ui/Modal/ModalButtonGroup.test.tsx
@@ -16,7 +16,7 @@ describe('ModalButtonGroup', () => {
   const secondaryButtonLbl = 'test-secondary';
   const onClose = jest.fn();
   const labelID = 'test-label';
-  const testContext = { onClose, labelID };
+  const testContext = { onClose, labelID, dismissible: true, };
 
   it('renders a group with a primary Button', () => {
     const component = (
@@ -110,5 +110,25 @@ describe('ModalButtonGroup', () => {
     fireEvent.click(modalButton);
     expect(component.props.value.onClose).toHaveBeenCalled();
     expect(getByLabelText('close')).toBeInTheDocument();
+  });
+
+  it('does not inject the onClose function into the ModalButton click handler when "dismissible" is false', () => {
+    const onClose = jest.fn();
+    const labelID = 'test-label';
+    const context = { onClose, labelID, dismissible: false };
+    const component = (
+      <ModalContext.Provider value={context}>
+        <ModalButtonGroup
+          primaryButtons={[<ModalButton label="close" closesModal />]}
+        />
+      </ModalContext.Provider>
+    );
+    const { getByTestId } = renderWithTheme(
+      lightTheme,
+      component
+    );
+    const modalButton = getByTestId('button');
+    fireEvent.click(modalButton);
+    expect(component.props.value.onClose).not.toHaveBeenCalled();
   });
 });

--- a/tst/components/ui/Modal/ModalHeader.test.tsx
+++ b/tst/components/ui/Modal/ModalHeader.test.tsx
@@ -18,8 +18,16 @@ describe('ModalHeader', () => {
     expect(el).toBeInTheDocument();
   });
 
-  it('renders a close button is displayClose !== false', () => {
-    const component = <ModalHeader title="Test Header" />;
+  it('renders a close button if displayClose !== false and "dismissable is true', () => {
+    const onClose = jest.fn();
+    const labelID = 'test-label';
+    const testContext = { onClose, labelID, dismissible: true };
+    const component = (
+      <ModalContext.Provider value={testContext}>
+        <ModalHeader title="Test Header" />
+      </ModalContext.Provider>
+    );
+   
     const { getByTestId } = renderWithTheme(lightTheme, component);
     const closeButton = getByTestId('button');
     expect(closeButton).toBeInTheDocument();
@@ -28,7 +36,7 @@ describe('ModalHeader', () => {
   it('calls the onClose function from the context provider', () => {
     const onClose = jest.fn();
     const labelID = 'test-label';
-    const testContext = { onClose, labelID };
+    const testContext = { onClose, labelID, dismissible: true };
     const component = (
       <ModalContext.Provider value={testContext}>
         <ModalHeader title="Test Header" />
@@ -38,5 +46,19 @@ describe('ModalHeader', () => {
     const closeButton = getByTestId('button');
     fireEvent.click(closeButton);
     expect(component.props.value.onClose).toHaveBeenCalled();
+  });
+
+  it('does not render a close button if "dismissible" is false', () => {
+    const onClose = jest.fn();
+    const labelID = 'test-label';
+    const testContext = { onClose, labelID, dismissible: false };
+    const component = (
+      <ModalContext.Provider value={testContext}>
+        <ModalHeader title="Test Header" />
+      </ModalContext.Provider>
+    );
+    const { queryAllByText } = renderWithTheme(lightTheme, component);
+    const closeButton = queryAllByText('close');
+    expect(closeButton).toHaveLength(0);
   });
 });

--- a/tst/components/ui/Modal/index.test.tsx
+++ b/tst/components/ui/Modal/index.test.tsx
@@ -47,4 +47,30 @@ describe('Modal', () => {
     });
     expect(component.props.onClose).toBeCalledTimes(0);
   });
+
+  it(`will not close the modal using ESC key if "dismissible" prop is set to "false"`, () => {
+    const component = (
+      <Modal size="md" rootId="modal-root" onClose={jest.fn()} dismissible={false}>
+        <p>Dummy Content</p>
+      </Modal>
+    );
+    renderWithTheme(lightTheme, component);
+    fireEvent.keyDown(document.activeElement || document.body, {
+      key: 'space',
+      keyCode: 32,
+    });
+    expect(component.props.onClose).toBeCalledTimes(0);
+  });
+
+  it(`will close the modal by clicking the background if "dismissible" prop is set to "false"`, () => {
+    const component = (
+      <Modal size="md" rootId="modal-root" onClose={jest.fn()} dismissible={false}>
+        <p>Dummy Content</p>
+      </Modal>
+    );
+    const { getByTestId } = renderWithTheme(lightTheme, component);
+    const bgd = getByTestId('modal');
+    fireEvent.click(bgd);
+    expect(component.props.onClose).toBeCalledTimes(0);
+  });
 });


### PR DESCRIPTION
**Description of changes:**
Sometimes a user flow might require a modal that needs to persist. Although there are a few ways to do that with the current modal props, it's a little convoluted, and requires the user to remember to do the following:

- pass `null` to the `onClose` prop
- set `displayClose` to false in the ModalHeader
- ensure that `ModalButtons` do not set `closesModal` to true

Introducing the `dismissible` prop will allow all of the above to be handled via a single prop. I also cleaned up the modal stories by using a `Heading` component.

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? manually and with unit tests

3. If you made changes to the component library, have you provided corresponding documentation changes? yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
