### PR TITLE
Update realtimeUnsubscribeFromVolumeIndicator to receive callback param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added optional `timestamp` prop in ChatBubble
 - Added forwardRef for ChatBubbleContainer
 - Added optional img to MessageAttachment
+- Added a classname to PopOverMenu component for styling access
+- Added forwardRef for Textarea
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Docs] Fix ContentShare docs
 - Fix non-overridable Mic prop in `RosterAttendee`
 - Fix incorrect fill-rule property on `ZoomIn` and `ZoomOut`
+- [Demo] Fix closing roster from stopping active speaker detection.
 
 ### Added
 
@@ -46,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed senderName to optional in ChatBubble
 - Moved children inside of a div in ChatBubble
 - Changed `MeetingManager` to strictly enforce `DevicePermissionStatus` type.
+- Update `realtimeUnsubscribeFromVolumeIndicator` interface to also accept a callback param.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ZoomIn and ZoomOut icons
 - Refactored NavBar to allow static width
 - Refactored NavBarItem to use IconButton directly
+- Added optional `timestamp` prop in ChatBubble
+- Added forwardRef for ChatBubbleContainer
+- Added optional img to MessageAttachment
 
 ### Changed
 
@@ -48,9 +51,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed showName in ChatBubble
 - Change control bar theme opacity to 1
 
+- Changed senderName to optional in ChatBubble
+- Moved children inside of a div in ChatBubble
+
 ### Removed
 
 - Remove playwright tests, scripts, and dependency
+- Removed content in ChatBubble
+- Removed showName in ChatBubble
 
 ## [1.6.0] - 2020-12-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,9 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed showName in ChatBubble
 - Change control bar theme opacity to 1
 - Changed RosterHeader 'title' prop to all for elements as well as strings
-
 - Changed senderName to optional in ChatBubble
 - Moved children inside of a div in ChatBubble
+- Changed `MeetingManager` to strictly enforce `DevicePermissionStatus` type.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed content in ChatBubble
 - Removed showName in ChatBubble
 - Change control bar theme opacity to 1
+- Changed RosterHeader 'title' prop to all for elements as well as strings
 
 - Changed senderName to optional in ChatBubble
 - Moved children inside of a div in ChatBubble

--- a/demo/chat/package-lock.json
+++ b/demo/chat/package-lock.json
@@ -59,7 +59,7 @@
       }
     },
     "@aws-amplify/api-rest": {
-      "version": "1.2.16",
+      "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-1.2.6.tgz",
       "integrity": "sha512-UiDrz2o/01+nAMlhNUe2wpoRA5qH5crVp4qVm8FgxQ3HsmQmITJdP+KwmrUxlqwZbTqcoeH14t3Iq5MoRQlCkQ==",
       "requires": {
@@ -181,7 +181,7 @@
       }
     },
     "@aws-amplify/storage": {
-      "version": "3.3.16",
+      "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-3.3.6.tgz",
       "integrity": "sha512-AM3SAW/iP8Qmmdo7wQCWLEsL1B8iY/hEysF0Vbw+huq4vftzObNHhE6WFLwkBT0xAUAL/Mh2akiJa4tc7iX44g==",
       "requires": {
@@ -2856,9 +2856,9 @@
       "dev": true
     },
     "@types/ua-parser-js": {
-      "version": "0.7.33",
-      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
-      "integrity": "sha512-ngUKcHnytUodUCL7C6EZ+lVXUjTMQb+9p/e1JjV5tN9TVzS98lHozWEFRPY1QcCdwFeMsmVWfZ3DPPT/udCyIw==",
+      "version": "0.7.35",
+      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
+      "integrity": "sha512-PsPx0RLbo2Un8+ff2buzYJnZjzwhD3jQHPOG2PtVIeOhkRDddMcKU8vJtHpzzfLB95dkUi0qAkfLg2l2Fd0yrQ==",
       "dev": true
     },
     "@webassemblyjs/ast": {
@@ -3095,9 +3095,9 @@
       "dev": true
     },
     "amazon-chime-sdk-js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.1.0.tgz",
-      "integrity": "sha512-VW4TfM187AAT5R9NT2rIxDc2nAncHuAerLPaDQPFaSEINrZ79eoZP5xPasv70Z8WaJrM8WSPo6eo5xWE00OnKQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.4.0.tgz",
+      "integrity": "sha512-exkplOKaGk7yZIlS6cUFPBLKEJYHI5a1NZD1SIUqLsyCyGxyEZbPqra+jfyEE5Cadu9xqGoK3tcIzz1R9Ila4g==",
       "dev": true,
       "requires": {
         "@types/dom-mediacapture-record": "^1.0.4",
@@ -8782,9 +8782,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.46",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.46.tgz",
-          "integrity": "sha512-Tice8a+sJtlP9C1EUo0DYyjq52T37b3LexVu3p871+kfIBIN+OQ7PKPei1oF3MgF39olEpUfxaLtD+QFc1k69Q==",
+          "version": "10.17.51",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.51.tgz",
+          "integrity": "sha512-KANw+MkL626tq90l++hGelbl67irOJzGhUJk6a1Bt8QHOeh9tztJx+L0AqttraWKinmZn7Qi5lJZJzx45Gq0dg==",
           "dev": true
         }
       }
@@ -10706,9 +10706,9 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.22",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
-      "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==",
+      "version": "0.7.23",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+      "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==",
       "dev": true
     },
     "uglify-js": {

--- a/demo/chat/package.json
+++ b/demo/chat/package.json
@@ -27,7 +27,7 @@
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
     "@babel/runtime": "^7.11.2",
-    "amazon-chime-sdk-js": "^2.1.0",
+    "amazon-chime-sdk-js": "^2.4.x",
     "aws-sdk": "^2.797.0",
     "babel-loader": "^8.1.0",
     "css-loader": "^4.3.0",

--- a/demo/meeting/package-lock.json
+++ b/demo/meeting/package-lock.json
@@ -3035,6 +3035,11 @@
       "integrity": "sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ==",
       "dev": true
     },
+    "@types/ua-parser-js": {
+      "version": "0.7.35",
+      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
+      "integrity": "sha512-PsPx0RLbo2Un8+ff2buzYJnZjzwhD3jQHPOG2PtVIeOhkRDddMcKU8vJtHpzzfLB95dkUi0qAkfLg2l2Fd0yrQ=="
+    },
     "@types/webpack-env": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.15.2.tgz",
@@ -3321,14 +3326,16 @@
       "dev": true
     },
     "amazon-chime-sdk-js": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-1.20.2.tgz",
-      "integrity": "sha512-M3ovG3LoE3n0WrjSt+lXIqAwCWvmP7FJ4KmWkp4WVUsLpjkxNE5vPMi29ydWBg/iETHhRmREhh2SPJJfx3PEeg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.4.0.tgz",
+      "integrity": "sha512-exkplOKaGk7yZIlS6cUFPBLKEJYHI5a1NZD1SIUqLsyCyGxyEZbPqra+jfyEE5Cadu9xqGoK3tcIzz1R9Ila4g==",
       "requires": {
         "@types/dom-mediacapture-record": "^1.0.4",
+        "@types/ua-parser-js": "^0.7.33",
         "detect-browser": "^5.1.0",
         "protobufjs": "~6.8.8",
-        "resize-observer": "^1.0.0"
+        "resize-observer": "^1.0.0",
+        "ua-parser-js": "^0.7.22"
       }
     },
     "ansi-colors": {
@@ -10459,6 +10466,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
       "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
+    },
+    "ua-parser-js": {
+      "version": "0.7.23",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+      "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA=="
     },
     "uglify-js": {
       "version": "3.4.10",

--- a/demo/meeting/package.json
+++ b/demo/meeting/package.json
@@ -8,7 +8,7 @@
     "@types/webpack-env": "^1.15.1",
     "@typescript-eslint/eslint-plugin": "^2.19.2",
     "@typescript-eslint/parser": "^2.19.2",
-    "amazon-chime-sdk-js": "^1.20.0",
+    "amazon-chime-sdk-js": "^2.4.x",
     "aws-sdk": "^2.731.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10086,9 +10086,9 @@
       "dev": true
     },
     "@types/ua-parser-js": {
-      "version": "0.7.33",
-      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
-      "integrity": "sha512-ngUKcHnytUodUCL7C6EZ+lVXUjTMQb+9p/e1JjV5tN9TVzS98lHozWEFRPY1QcCdwFeMsmVWfZ3DPPT/udCyIw==",
+      "version": "0.7.35",
+      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
+      "integrity": "sha512-PsPx0RLbo2Un8+ff2buzYJnZjzwhD3jQHPOG2PtVIeOhkRDddMcKU8vJtHpzzfLB95dkUi0qAkfLg2l2Fd0yrQ==",
       "dev": true
     },
     "@types/uglify-js": {
@@ -10541,9 +10541,9 @@
       "dev": true
     },
     "amazon-chime-sdk-js": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-1.22.0.tgz",
-      "integrity": "sha512-1X/1yO8HFs4vcoi/CIRR5IxySpz4s2n6C8CErFC+bRPjeORVAmDyiy1F5WvXZm1XtAj4wa4tbuPUCoR21Dhw/Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.4.0.tgz",
+      "integrity": "sha512-exkplOKaGk7yZIlS6cUFPBLKEJYHI5a1NZD1SIUqLsyCyGxyEZbPqra+jfyEE5Cadu9xqGoK3tcIzz1R9Ila4g==",
       "dev": true,
       "requires": {
         "@types/dom-mediacapture-record": "^1.0.4",
@@ -10552,14 +10552,6 @@
         "protobufjs": "~6.8.8",
         "resize-observer": "^1.0.0",
         "ua-parser-js": "^0.7.22"
-      },
-      "dependencies": {
-        "ua-parser-js": {
-          "version": "0.7.22",
-          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
-          "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==",
-          "dev": true
-        }
       }
     },
     "ansi-align": {
@@ -24362,9 +24354,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.44",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.44.tgz",
-          "integrity": "sha512-vHPAyBX1ffLcy4fQHmDyIUMUb42gHZjPHU66nhvbMzAWJqHnySGZ6STwN3rwrnSd1FHB0DI/RWgGELgKSYRDmw==",
+          "version": "10.17.50",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.50.tgz",
+          "integrity": "sha512-vwX+/ija9xKc/z9VqMCdbf4WYcMTGsI0I/L/6shIF3qXURxZOhPQlPRHtjTpiNhAwn0paMJzlOQqw6mAGEQnTA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@types/testing-library__react": "^10.0.1",
     "@types/throttle-debounce": "^2.1.0",
     "add": "^2.0.6",
-    "amazon-chime-sdk-js": "^1.22.0",
+    "amazon-chime-sdk-js": "^2.4.x",
     "babel-loader": "^8.1.0",
     "css-loader": "^2.1.1",
     "jest": "^26.6.3",
@@ -104,7 +104,7 @@
     "webpack-cli": "^3.3.2"
   },
   "peerDependencies": {
-    "amazon-chime-sdk-js": "1.x || 2.x",
+    "amazon-chime-sdk-js": "^2.4.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "styled-components": "^5.0.0",

--- a/src/components/sdk/MicrophoneActivity/index.tsx
+++ b/src/components/sdk/MicrophoneActivity/index.tsx
@@ -26,13 +26,21 @@ export const MicrophoneActivity: React.FC<Props> = ({
       return;
     }
 
-    audioVideo.realtimeSubscribeToVolumeIndicator(attendeeId, (_, volume) => {
+    const callback = (
+      _: string,
+      volume: number | null,
+      __: boolean | null,
+      ___: number | null
+    ) => {
       if (bgEl.current) {
         bgEl.current.style.transform = `scaleY(${volume})`;
       }
-    });
+    };
 
-    return () => audioVideo.realtimeUnsubscribeFromVolumeIndicator(attendeeId);
+    audioVideo.realtimeSubscribeToVolumeIndicator(attendeeId, callback);
+
+    return () =>
+      audioVideo.realtimeUnsubscribeFromVolumeIndicator(attendeeId, callback);
   }, [attendeeId]);
 
   return (

--- a/src/components/ui/Chat/MessageAttachment/Styled.tsx
+++ b/src/components/ui/Chat/MessageAttachment/Styled.tsx
@@ -44,9 +44,7 @@ export const StyledMessageAttachmentContent = styled.div`
   }
 `;
 
-export const StyledMessageAttachment = styled.div<
-  StyledMessageAttachmentProps
->`
+export const StyledMessageAttachment = styled.div<StyledMessageAttachmentProps>`
   color: ${(props) => props.theme.messageAttachment.content.fontColor};
   display: flex;
   flex-direction: column;

--- a/src/components/ui/Chat/MessageAttachment/index.tsx
+++ b/src/components/ui/Chat/MessageAttachment/index.tsx
@@ -4,7 +4,10 @@
 import React, { FC, HTMLAttributes } from 'react';
 
 import { BaseProps } from '../../Base';
-import { StyledMessageAttachment, StyledMessageAttachmentContent } from './Styled';
+import {
+  StyledMessageAttachment,
+  StyledMessageAttachmentContent,
+} from './Styled';
 import { Document } from '../../icons';
 
 export interface MessageAttachmentProps
@@ -23,7 +26,7 @@ export interface MessageAttachmentProps
   /** How to handle onClick of the image. */
   imgOnClick?: () => void;
   /** How to handle onLoad of the image. */
-  imgOnLoad? : () => void;
+  imgOnLoad?: () => void;
   /** The size of attachment. */
   size?: string;
 }
@@ -46,7 +49,7 @@ export const MessageAttachment: FC<MessageAttachmentProps> = ({
             {name}
           </a>
           <span className="ch-attachment-size">{size}</span>
-        </div>       
+        </div>
       </StyledMessageAttachmentContent>
       {renderImg && (
         <img

--- a/src/hooks/sdk/useAttendeeAudioStatus.tsx
+++ b/src/hooks/sdk/useAttendeeAudioStatus.tsx
@@ -31,7 +31,8 @@ export function useAttendeeAudioStatus(attendeeId: string) {
 
     audioVideo.realtimeSubscribeToVolumeIndicator(attendeeId, callback);
 
-    return () => audioVideo.realtimeUnsubscribeFromVolumeIndicator(attendeeId);
+    return () =>
+      audioVideo.realtimeUnsubscribeFromVolumeIndicator(attendeeId, callback);
   }, [audioVideo, attendeeId]);
 
   return {


### PR DESCRIPTION
**Issue #:** 
https://github.com/aws/amazon-chime-sdk-component-library-react/issues/280

**Description of changes:**
- Update the `realtimeUnsubscribeFromVolumeIndicator` method to optionally receive a `callback` param to match the interface updated in the `amazon-chime-sdk-js@2.4`.
- Update the meeting demo application to use the new callback param which no longer causes active speaker detection to stop after closing the roster.
**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Updated the demo application and saw active speaker detection working after unsubscribing from volume indicators (closing the roster).
3. If you made changes to the component library, have you provided corresponding documentation changes?
Yes
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
