### PR TITLE
Optional 'endingIcon' prop for Input component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a classname to PopOverMenu component for styling access
 - Added a "dismissible" prop to Modal to optionally allow persistent modals
 - Added ZoomIn and ZoomOut icons
+- Added a "endingIcon" prop to Input component
 
 ### Changed
 

--- a/src/components/ui/Input/InputWrapper.tsx
+++ b/src/components/ui/Input/InputWrapper.tsx
@@ -7,6 +7,7 @@ import { Size } from './';
 
 export interface InputWrapperProps {
   leadingIcon?: ReactNode;
+  endingIcon?: ReactNode;
   sizing?: Size;
   className?: string;
   children?: ReactNode | ReactNode[];
@@ -14,12 +15,13 @@ export interface InputWrapperProps {
 
 export const InputWrapper = forwardRef(
   (props: InputWrapperProps, ref: Ref<HTMLSpanElement>) => {
-    const { leadingIcon, children } = props;
+    const { leadingIcon, endingIcon, children } = props;
 
     return (
       <StyledInputWrapper ref={ref} {...props} data-testid="input-wrapper">
         {leadingIcon && <span className="ch-icon">{leadingIcon}</span>}
         {children}
+        {endingIcon && <span className="ch-right-icon">{endingIcon}</span>}
       </StyledInputWrapper>
     );
   }

--- a/src/components/ui/Input/Styled.tsx
+++ b/src/components/ui/Input/Styled.tsx
@@ -24,6 +24,15 @@ export const StyledInputWrapper = styled.span<InputWrapperProps>`
     transform: translateY(-50%);
   }
 
+  > .ch-right-icon {
+    position: absolute;
+    width: 1rem;
+    right: 0.4375rem;
+    position: absolute;
+    top: 54%;
+    transform: translateY(-50%);
+  }
+
   > input {
     padding: ${(props) => getPadding(props)};
   }

--- a/src/components/ui/Input/index.tsx
+++ b/src/components/ui/Input/index.tsx
@@ -28,8 +28,10 @@ export interface InputProps
   onChange(event: ChangeEvent): void;
   /** The callback fired when the input value is cleared. */
   onClear?(): void;
-  /** The icon in the input. */
+  /** The icon in left of the input. */
   leadingIcon?: ReactNode;
+  /** The icon in right of the input. */
+  endingIcon?: ReactNode;
   /** The size of the input. */
   sizing?: Size;
   /** The value of the input. */
@@ -50,6 +52,7 @@ export const Input = forwardRef(
       onChange,
       className,
       leadingIcon,
+      endingIcon,
       showClear = true,
       ...rest
     } = props;
@@ -132,6 +135,7 @@ export const Input = forwardRef(
     return (
       <InputWrapper
         leadingIcon={leadingIcon}
+        endingIcon={endingIcon}
         sizing={sizing}
         className={`ch-input-wrapper ${className || ''}`}
       >
@@ -148,7 +152,7 @@ export const Input = forwardRef(
             setFocused(true);
           }}
         />
-        {showClear && (
+        {!endingIcon && showClear && (
           <StyledClear
             type="button"
             active={!!(onClear || (focused && value.length))}


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Add optional 'endingIcon' prop for Input component

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Tested manually

3. If you made changes to the component library, have you provided corresponding documentation changes?
Yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
