### PR TITLE
use main primary theme color for accessible chat content

### DIFF
--- a/src/theme/light.ts
+++ b/src/theme/light.ts
@@ -380,7 +380,7 @@ const chatBubble = {
     linkColorVisited: colors.primary.darkest,
   },
   outgoing: {
-    bgd: colors.primary.light,
+    bgd: colors.primary.main,
     fontColor: colors.greys.grey10,
     linkColor: colors.greys.white,
     linkColorHover: colors.greys.grey10,


### PR DESCRIPTION
**Description of changes:**
It's been discovered that the chat bubbles don't meet the contrast level to be considered accessible. 

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? using the deque accessibility plugin

3. If you made changes to the component library, have you provided corresponding documentation changes? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
