### PR TITLE
Adding 4 missing media regions (af-south-1, ap-northeast-2, ap-south-…

### DIFF
--- a/demo/meeting/src/constants/index.ts
+++ b/demo/meeting/src/constants/index.ts
@@ -20,12 +20,16 @@ export const MAX_REMOTE_VIDEOS = 16;
 
 export const AVAILABLE_AWS_REGIONS = {
   'us-east-1': 'United States (N. Virginia)',
+  'af-south-1': 'Africa (Cape Town)',
   'ap-northeast-1': 'Japan (Tokyo)',
+  'ap-northeast-2': 'Korea (Seoul)',
+  'ap-south-1': 'India (Mumbai)',
   'ap-southeast-1': 'Singapore',
   'ap-southeast-2': 'Australia (Sydney)',
   'ca-central-1': 'Canada',
   'eu-central-1': 'Germany (Frankfurt)',
   'eu-north-1': 'Sweden (Stockholm)',
+  'eu-south-1': 'Italy (Milan)',
   'eu-west-1': 'Ireland',
   'eu-west-2': 'United Kingdom (London)',
   'eu-west-3': 'France (Paris)',


### PR DESCRIPTION
…1, eu-south-1)

https://docs.aws.amazon.com/chime/latest/dg/chime-sdk-meetings-regions.html
https://docs.aws.amazon.com/chime/latest/APIReference/API_Meeting.html

**Issue #369: 4 missing regions in demo/meeting** 

**Description of changes:**
New regions added

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes.
```
=============================== Coverage summary ===============================
Statements   : 92.45% ( 1873/2026 )
Branches     : 76.98% ( 672/873 )
Functions    : 82.44% ( 479/581 )
Lines        : 94.61% ( 1651/1745 )
================================================================================

Test Suites: 53 passed, 53 total
Tests:       220 passed, 220 total
Snapshots:   0 total
Time:        53.688 s
Ran all test suites.

```

2. How did you test these changes?
Yes. Created meetings in all 4 regions.

3. If you made changes to the component library, have you provided corresponding documentation changes?
The changes are not in component library.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
