### PR TITLE
refactor NavBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `useDevicePermissionStatus` hook as an exported component from the library.
 - Added a "dismissible" prop to Modal to optionally allow persistent modals
 - Added ZoomIn and ZoomOut icons
+- Refactored NavBar to allow static width
+- Refactored NavBarItem to use IconButton directly
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13479,6 +13479,15 @@
         "warning": "^4.0.3"
       }
     },
+    "cross-fetch": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.6.1"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -14447,26 +14456,6 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
-      }
-    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -15418,36 +15407,34 @@
       }
     },
     "fbemitter": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-2.1.1.tgz",
-      "integrity": "sha1-Uj4U/a9SSIBbsC9i78M75wP1GGU=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-3.0.0.tgz",
+      "integrity": "sha512-KWKaceCwKQU0+HPoop6gn4eOHk50bBv/VxjJtGMfwmJt3D29JpN4H4eisCtIPA+a8GVBam+ldMMpMjJUvpDyHw==",
       "dev": true,
       "requires": {
-        "fbjs": "^0.8.4"
+        "fbjs": "^3.0.0"
       }
     },
     "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.0.tgz",
+      "integrity": "sha512-dJd4PiDOFuhe7vk4F80Mba83Vr2QuK86FoxtgPmzBqEJahncp+13YCmfoa53KHCo6OnlXLG7eeMWPfB5CrpVKg==",
       "dev": true,
       "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
+        "cross-fetch": "^3.0.4",
+        "fbjs-css-vars": "^1.0.0",
         "loose-envify": "^1.0.0",
         "object-assign": "^4.1.0",
         "promise": "^7.1.1",
         "setimmediate": "^1.0.5",
         "ua-parser-js": "^0.7.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
-        }
       }
+    },
+    "fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
+      "dev": true
     },
     "fd-slicer": {
       "version": "1.1.0",
@@ -15829,13 +15816,13 @@
       }
     },
     "flux": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-3.1.3.tgz",
-      "integrity": "sha1-0jvtUVp5oi2TOrU6tK2hnQWy8Io=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.1.tgz",
+      "integrity": "sha512-emk4RCvJ8RzNP2lNpphKnG7r18q8elDYNAPx7xn+bDeOIo9FFfxEfIQ2y6YbQNmnsGD3nH1noxtLE64Puz1bRQ==",
       "dev": true,
       "requires": {
-        "fbemitter": "^2.0.0",
-        "fbjs": "^0.8.0"
+        "fbemitter": "^3.0.0",
+        "fbjs": "^3.0.0"
       }
     },
     "for-in": {
@@ -17766,28 +17753,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
       "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
       "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "dev": true,
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        }
-      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -27133,12 +27098,12 @@
       "dev": true
     },
     "react-json-view": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/react-json-view/-/react-json-view-1.19.1.tgz",
-      "integrity": "sha512-u5e0XDLIs9Rj43vWkKvwL8G3JzvXSl6etuS5G42a8klMohZuYFQzSN6ri+/GiBptDqlrXPTdExJVU7x9rrlXhg==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/react-json-view/-/react-json-view-1.20.2.tgz",
+      "integrity": "sha512-DOGrMqhDHrvBwzwiIU/LKpZ7CFrOHrjoQ+e+d1aOJHn82t++PKuB4atiNR1Ko8UBEoGrMv44RagRSyYWTsEHKg==",
       "dev": true,
       "requires": {
-        "flux": "^3.1.3",
+        "flux": "^4.0.1",
         "react-base16-styling": "^0.6.0",
         "react-lifecycles-compat": "^3.0.4",
         "react-textarea-autosize": "^6.1.0"
@@ -30739,9 +30704,9 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.22",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
-      "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==",
+      "version": "0.7.23",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+      "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==",
       "dev": true
     },
     "unfetch": {
@@ -31910,12 +31875,6 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
-      "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A==",
-      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/src/components/ui/Button/Button.stories.tsx
+++ b/src/components/ui/Button/Button.stories.tsx
@@ -11,6 +11,11 @@ import IconButton from './IconButton';
 import Meeting from '../icons/Meeting';
 import ButtonDocs from './Button.mdx';
 import Flex from '../Flex';
+import Badge from '../Badge';
+import Cog from '../icons/Cog';
+import Chat from '../icons/Chat';
+import Caution from '../icons/Caution';
+import SignalStrength from '../icons/SignalStrength'
 
 export default {
   title: 'UI Components/Form/Buttons',
@@ -61,7 +66,7 @@ export const _IconButton = () => {
       <IconButton
         selected={boolean('Selected', false)}
         label="click me"
-        icon={<Meeting />}
+        icon={<SignalStrength />}
         iconSize={select('iconSize', ['sm', 'md', 'lg'], 'sm')}
         disabled={boolean('Disabled', false)}
       />
@@ -71,4 +76,40 @@ export const _IconButton = () => {
 
 _IconButton.story = {
   name: 'Icon button',
+};
+
+export const _IconButtoWithBadge = () => {
+  return (
+    <Flex layout="fill-space-centered">
+      <IconButton
+        selected={boolean('Selected', false)}
+        label="click me"
+        icon={<SignalStrength />}
+        iconSize={select('iconSize', ['sm', 'md', 'lg'], 'sm')}
+        badge={<Badge value="7"/>}
+      />
+    </Flex>
+  );
+};
+
+_IconButtoWithBadge.story = {
+  name: 'Icon button with badge',
+};
+
+export const _IconButtoWithBadgeIcon = () => {
+  return (
+    <Flex layout="fill-space-centered">
+      <IconButton
+        selected={boolean('Selected', false)}
+        label="click me"
+        icon={<SignalStrength />}
+        iconSize={select('iconSize', ['sm', 'md', 'lg'], 'sm')}
+        badge={<Caution width="1.5rem" css={`top: 0; right: 0;`} />}
+      />
+    </Flex>
+  );
+};
+
+_IconButtoWithBadgeIcon.story = {
+  name: 'Icon button with badge icon',
 };

--- a/src/components/ui/Button/IconButton.tsx
+++ b/src/components/ui/Button/IconButton.tsx
@@ -3,12 +3,19 @@
 
 import React, { forwardRef } from 'react';
 import Button, { ButtonProps } from './';
+import { StyledIconButtonWrapper } from './Styled';
 
-export interface IconButtonProps extends ButtonProps {}
+export interface IconButtonProps extends ButtonProps {
+  /** Render a component to the top right area of the IconButton */
+  badge?: React.ReactNode | React.ReactNode[];
+}
 
 export const IconButton = forwardRef(
   (props: IconButtonProps, ref: React.Ref<HTMLButtonElement>) => (
-    <Button ref={ref} variant="icon" {...props} />
+    <StyledIconButtonWrapper>
+      <Button ref={ref} variant="icon" {...props} />
+      {props.badge}
+    </StyledIconButtonWrapper>
   )
 );
 

--- a/src/components/ui/Button/Styled.tsx
+++ b/src/components/ui/Button/Styled.tsx
@@ -136,6 +136,12 @@ export const StyledSecondaryButton = css<ButtonProps>`
   }
 `;
 
+const badgeLayout = {
+  'sm': css`top: -15%; left: 76%;`,
+  'md': css`top: 4%; left: 76%;`,
+  'lg': css`top: 10%; left: 76%;`,
+};
+
 export const StyledIconButton = css<ButtonProps>`
   background-color: ${(props) =>
     props.selected
@@ -195,4 +201,16 @@ export const StyledIconButton = css<ButtonProps>`
     color: ${(props) => props.theme.buttons.icon.disabled.text};
     cursor: not-allowed;
   }
+
+  + * {
+    position: absolute;
+    font-size: 0.55rem;
+    z-index: 1;
+    ${({ iconSize }) => iconSize ? badgeLayout[iconSize] : badgeLayout['sm']}
+  }
+`;
+
+export const StyledIconButtonWrapper = styled.span`
+  display: inline-block;
+  position: relative;
 `;

--- a/src/components/ui/ControlBar/Styled.tsx
+++ b/src/components/ui/ControlBar/Styled.tsx
@@ -120,9 +120,12 @@ export const StyledControlBarItem = styled.div<StyledControlBarItemProps>`
     }
   `};
 
-  .ch-control-bar-item-iconButton {
+  > :first-child {
     grid-column-start: ${({ layout, popOver, children }) =>
       isVertical(layout) && (popOver || children) ? '2' : '1'};
+  }
+
+  .ch-control-bar-item-iconButton {
 
     .ch-icon {
       width: 1.5rem;

--- a/src/components/ui/Modal/ModalHeader.tsx
+++ b/src/components/ui/Modal/ModalHeader.tsx
@@ -36,12 +36,13 @@ export const ModalHeader: FC<ModalHeaderProps> = ({
       </Tag>
 
       {(displayClose && context?.dismissible) && (
-        <IconButton
-          label="Close"
-          icon={<Remove />}
-          className="ch-close-button"
-          onClick={handleClick}
-        />
+        <span className="ch-close-button">
+          <IconButton
+            label="Close"
+            icon={<Remove />}
+            onClick={handleClick}
+          />
+        </span>
       )}
     </StyledModalHeader>
   );

--- a/src/components/ui/Navbar/Navbar.stories.tsx
+++ b/src/components/ui/Navbar/Navbar.stories.tsx
@@ -10,6 +10,15 @@ import NavbarItem from './NavbarItem';
 import { Attendees, LeaveMeeting, Information } from '../icons';
 import Flex from '../Flex';
 import NavbarDocs from './Navbar.mdx';
+import Share from '../icons/Share';
+import Badge from '../Badge';
+import Cog from '../icons/Cog';
+
+import PopOverItem from '../PopOver/PopOverItem';
+import PopOverSubMenu from '../PopOver/PopOverSubMenu';
+import PopOverSeparator from '../PopOver/PopOverSeparator';
+import PopOverHeader from '../PopOver/PopOverHeader';
+
 
 export default {
   title: 'UI Components/Navbar',
@@ -27,30 +36,65 @@ export const _Navbar = () => {
   };
 
   return (
-    <Navbar flexDirection="column" container>
-      <NavbarHeader onClose={handleOnClose} />
-      <Flex>
+    <Navbar 
+      flexDirection="column" 
+      container
+      responsive={boolean('Responsive (enable and resize to see responsive layout)', true)}
+    >
+      <NavbarHeader onClose={handleOnClose} title="is this thing on?" />
+      <Flex css={`margin-top: 0rem;`}>
         <NavbarItem
-          icon={<Information />}
-          onClick={() => alert('Information')}
-          label="Bridge Information"
-          isSelected={boolean('isSelected', false)}
+          icon={<Share/>}
+          onClick={() => alert('Do not Leave Meeting')}
+          label="Bridge Info"
+          showLabel={boolean('showLabel', true)}
         />
+  
         <NavbarItem
           icon={<Attendees />}
           onClick={() => alert('Attendees')}
           label="Attendees"
-          isSelected={boolean('isSelected', false)}
+          badge={<Badge value="7"/>}
+          showLabel={boolean('showLabel', true)}
         />
+
+        <NavbarItem
+          icon={<Cog />}
+          label="Settings"
+          showLabel={boolean('showLabel', true)}
+        >
+          <PopOverItem as="button" onClick={() => console.log('clicked')}>
+            <span>Also test content</span>
+          </PopOverItem>
+          <PopOverSeparator />
+          <PopOverItem as="button" onClick={() => console.log('clicked')}>
+            <span>This is more test content</span>
+          </PopOverItem>
+          <PopOverSubMenu text="This is a submenu">
+            <PopOverItem as="button" onClick={() => console.log('clicked')}>
+              <span>This is also a submenu component</span>
+            </PopOverItem>
+            <PopOverItem as="button" onClick={() => console.log('clicked')}>
+              <span>This is also a submenu component</span>
+            </PopOverItem>
+          </PopOverSubMenu>
+          <PopOverItem as="button" onClick={() => console.log('clicked')}>
+            <span>This has very long text</span>
+          </PopOverItem>
+        </NavbarItem>
       </Flex>
       <Flex marginTop="auto">
         <NavbarItem
           icon={<LeaveMeeting />}
           onClick={() => alert('Leave Meeting')}
           label="Leave Meeting"
-          isSelected={boolean('isSelected', false)}
+          showLabel={boolean('showLabel', true)}
         />
       </Flex>
     </Navbar>
   );
+};
+
+_Navbar.story = {
+  name: 'NavBar with options',
 };

--- a/src/components/ui/Navbar/NavbarHeader.tsx
+++ b/src/components/ui/Navbar/NavbarHeader.tsx
@@ -15,18 +15,14 @@ export interface NavbarHeaderProps extends BaseProps, FocusableProps {
   onClose?: () => void;
 }
 
-export const NavbarHeader: React.FC<NavbarHeaderProps> = ({
-  title,
-  onClose,
-  ...rest
-}: NavbarHeaderProps) => (
-  <StyledHeader {...rest}>
-    <span className="ch-title">{title}</span>
-    {onClose && (
+export const NavbarHeader: React.FC<NavbarHeaderProps> = (props: NavbarHeaderProps) => (
+  <StyledHeader {...props}>
+    <span className="ch-title">{props.title}</span>
+    {props.onClose && (
       <IconButton
         className="ch-btn-close"
         label="Close"
-        onClick={onClose}
+        onClick={props.onClose}
         icon={<Remove />}
       />
     )}

--- a/src/components/ui/Navbar/NavbarItem.tsx
+++ b/src/components/ui/Navbar/NavbarItem.tsx
@@ -1,52 +1,85 @@
 // Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import { StyledNavbarItem } from './Styled';
-import { PopOverItemProps } from '../PopOver/PopOverItem';
-import ControlBarButton from '../ControlBar/ControlBarItem';
-import { FocusableProps, BaseProps } from '../Base';
+import PopOver, { Placement } from '../PopOver';
+import IconButton, { IconButtonProps }  from '../Button/IconButton';
+import useUniqueId from '../../../hooks/useUniqueId';
 
-export interface NavbarItemProps extends FocusableProps, BaseProps {
-  /** Any icon from the library for button in navbar item */
-  icon: JSX.Element;
-  /** The callback fired when the icon is clicked */
+
+export interface NavbarItemProps extends IconButtonProps {
+  /* As part of IconButtonProps, any icon from the library for button in navbar item */
+  icon: any;
+  /* As part of IconButtonProps, The callback fired when the icon is clicked */
   onClick: () => void;
-  /** Label for navbar item */
+  /* As part of IconButtonProps, a label for navbar button */
   label: string;
-  /** PopOver menu if needed in navbar item */
-  popOver?: PopOverItemProps[] | null;
-  /**  Apply this prop to receive visual feedback that the button is 'active' */
-  isSelected?: boolean;
+  /* As part of IconButtonProps, an optional badge or icon to display adjacent to the IconButton*/
+  badge?: ReactNode | ReactNode[];
+  /* As part of IconButtonProps, an optional flag to notify if the button is in a selected state. */
+  selected?: boolean;
+  /* Including badgeProps will result in the children contents rendering in a PopOver */
+  children?: ReactNode | ReactNode[];
+  /* Defines the placement of PopOver menu, if used */
+  placement?: Placement;
+  /* Render the label text below the IconButton */
+  showLabel?: boolean;
 }
 
 export const NavbarItem = ({
-  onClick,
   label,
+  children,
+  placement = "right-start",
   icon,
-  isSelected = false,
-  popOver = null,
+  showLabel = false,
+  badge,
+  onClick,
   ...rest
-}: NavbarItemProps) => (
-  <StyledNavbarItem data-testid="navbar-item" {...rest}>
-    <ControlBarButton
-      onClick={onClick}
-      label={label}
-      icon={icon}
-      popOver={popOver}
-      isSelected={isSelected}
-    />
-    {label && (
-      <span
-        data-testid="navbar-label"
+}: NavbarItemProps) => {
+
+  return (
+    <StyledNavbarItem data-testid="navbar-item" showLabel={showLabel}> 
+      {children 
+        ? 
+        <PopOver
+          placement={placement}
+          a11yLabel={label}
+          renderButtonWrapper={(isActive, props) => (
+            <IconButton  
+              onClick={onClick}
+              selected={isActive} 
+              icon={icon} 
+              badge={badge}
+              label={label}
+              {...props}
+            />
+          )}
+        >
+          {children}
+        </PopOver> 
+        : 
+        <IconButton
+          icon={icon} 
+          label={label}
+          onClick={onClick}
+          badge={badge}
+          {...rest}
+        />
+      }
+    
+      <label 
         className="ch-navigation-bar-item-label"
+        data-testid="navbar-label"
         onClick={onClick}
       >
         {label}
-      </span>
-    )}
-  </StyledNavbarItem>
-);
+      </label>
+    
+    </StyledNavbarItem>
+    
+  );
+}
 
 export default NavbarItem;

--- a/src/components/ui/Navbar/Styled.tsx
+++ b/src/components/ui/Navbar/Styled.tsx
@@ -4,54 +4,22 @@
 import styled from 'styled-components';
 
 import { baseSpacing, baseStyles } from '../Base';
-import Flex from '../Flex';
 import { NavbarProps } from '.';
+import { NavbarItemProps } from './NavbarItem';
+import { visuallyHidden } from '../../../utils/style';
 
-export const StyledNavbar = styled(Flex)<NavbarProps>`
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  width: 20rem;
-  max-width: 100%;
-  color: ${(props) => props.theme.navbar.text};
-  background-color: ${({ theme }) => theme.navbar.bgd};
-
-  ${({ theme }) => theme.mediaQueries.min.md} {
-    width: 4.25rem;
-    padding-left: 0;
-  }
-
-  ${baseStyles}
-  ${baseSpacing}
-`;
-
-export const StyledNavbarItem = styled.div`
-  display: flex;
-  align-items: center;
-  height: 3rem;
-
-  ${({ theme }) => theme.mediaQueries.max.xs} {
-    margin-left: 0.5rem;
-
-    .ch-navigation-bar-item-label {
-      margin-left: 0.625rem;
-    }
-  }
-
-  ${({ theme }) => theme.mediaQueries.min.md} {
-    .ch-navigation-bar-item-label {
-      display: none;
-    }
-    margin-left: 0.5rem;
-  }
-`;
+import Flex from '../Flex';
 
 export const StyledHeader = styled.div`
   display: flex;
   height: 3rem;
   align-items: center;
-  border-bottom: 0.03125rem solid ${({ theme }) => theme.navbar.headerBorder};
+  border-bottom: ${({ theme }) => `0.03125rem solid ${theme.navbar.headerBorder}`};
   padding: 1rem;
+
+  .ch-title {
+    flex: 1;
+  }
 
   .ch-btn-close {
     margin-left: auto;
@@ -61,4 +29,62 @@ export const StyledHeader = styled.div`
   ${({ theme }) => theme.mediaQueries.min.md} {
     display: none;
   }
+`;
+
+export const StyledNavbarItem = styled.div<Partial<NavbarItemProps>>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 4.25rem;
+  min-height: 3rem;
+  flex-direction: column;
+  padding: 0 0.25rem;
+
+
+  .ch-navigation-bar-item-label {
+    text-align: center;
+    display: ${({ showLabel }) => showLabel ? 'block' : 'none'}; 
+    font-size: ${({ theme }) => theme.fontSizes.footnote.fontSize};
+    width: 100%;
+    padding: 0 0.25rem;
+    margin-bottom: 1.5rem;
+  }
+`;
+
+export const StyledNavbar = styled(Flex)<NavbarProps>`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  max-width: 100%;
+  color: ${(props) => props.theme.navbar.text};
+  background-color: ${({ theme }) => theme.navbar.bgd};
+  width: 4.25rem;
+  padding-top: 1rem;
+
+  ${({ theme, responsive }) => theme.mediaQueries.max.md} {
+    width: ${(props) => props.responsive ? `20rem` : `4.25rem;`};
+    padding-top: ${(props) => props.responsive ? `0` : `1rem`};
+
+    ${StyledHeader} {
+      display: ${(props) => props.responsive ? `flex` : `none`};
+    }
+
+    ${StyledNavbarItem} {
+      ${(props) => props.responsive && ` 
+        width: auto;
+        flex-direction: row;
+
+        .ch-navigation-bar-item-label {
+          font-size: 1rem;
+          text-align: left;
+          margin-left: 1.5rem;
+          margin-bottom: 0;
+          display: block;
+        }`
+      };
+    }
+  }
+
+  ${baseStyles}
+  ${baseSpacing}
 `;

--- a/src/components/ui/Navbar/index.tsx
+++ b/src/components/ui/Navbar/index.tsx
@@ -7,22 +7,27 @@ import { StyledNavbar } from './Styled';
 import { FlexProps } from '../Flex';
 import { FocusableProps, BaseProps } from '../Base';
 
+
 export interface NavbarProps extends FlexProps, BaseProps, FocusableProps {
   /** Classname to apply custom CSS styles */
   className?: string;
   /** Any react components or HTML elements */
   children?: any;
+  /** optionally render a responsive layout at mobile breakpoints  */
+  responsive?: boolean;
 }
 
 export const Navbar: React.FC<NavbarProps> = ({
   children,
   className,
+  responsive = true,
   ...rest
 }: NavbarProps) => (
   <StyledNavbar
     data-testid="navigation-bar"
     {...rest}
     className={className || ''}
+    responsive={responsive}
   >
     {children}
   </StyledNavbar>

--- a/src/components/ui/icons/Svg.tsx
+++ b/src/components/ui/icons/Svg.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-export interface SvgProps extends React.SVGAttributes<HTMLOrSVGElement> {
+export interface SvgProps extends React.SVGAttributes<HTMLOrSVGElement>  {
   /** CSS classname to apply custom styles. */
   className?: string;
   /** Defines the position and dimension of an SVG viewport. viewBox attribute is a list of four numbers: min-x, min-y, width and height. */
@@ -14,6 +14,8 @@ export interface SvgProps extends React.SVGAttributes<HTMLOrSVGElement> {
   height?: string;
   /** The title of a SVG component. */
   title?: string;
+  /** Optional styling via styled component string. */
+  css?: string;
 }
 
 const Svg: React.FC<SvgProps> = ({

--- a/tst/components/ui/Button/IconButton.test.tsx
+++ b/tst/components/ui/Button/IconButton.test.tsx
@@ -8,6 +8,7 @@ import IconButton from '../../../../src/components/ui/Button/IconButton';
 import Meeting from '../../../../src/components/ui/icons/Meeting';
 import lightTheme from '../../../../src/theme/light';
 import { renderWithTheme } from '../../../test-helpers';
+import Badge from '../../../../src/components/ui/Badge';
 
 describe('Icon Button', () => {
   it('should render an icon Button', () => {
@@ -34,5 +35,14 @@ describe('Icon Button', () => {
     const labelSpan = getByTestId('button-label');
 
     expect(labelSpan).toHaveStyle({ height: '1px', width: '1px' });
+  });
+
+  it('should render the value of the "badge" prop if that value exists', () => {
+    const badgeContent = <Badge className="test-badge" value={'test'} />;
+    const labelText = 'Icon Button';
+    const component = <IconButton label={labelText} badge={badgeContent} icon={<Meeting />} />;
+    const { getByText } = renderWithTheme(lightTheme, component);
+    const el = getByText('test');
+    expect(el).toBeInTheDocument();
   });
 });

--- a/tst/components/ui/Navbar/NavbarItem.test.tsx
+++ b/tst/components/ui/Navbar/NavbarItem.test.tsx
@@ -9,6 +9,7 @@ import lightTheme from '../../../../src/theme/light';
 import { renderWithTheme } from '../../../test-helpers';
 import { Information } from '../../../../src/components/ui/icons';
 import NavbarItem from '../../../../src/components/ui/Navbar/NavbarItem';
+import Badge from '../../../../src/components/ui/Badge';
 
 describe('NavbarItem', () => {
   it('should render a NavbarItem', () => {
@@ -24,12 +25,13 @@ describe('NavbarItem', () => {
     expect(navbarItem).toBeInTheDocument();
   });
 
-  it('should render a label when passed', () => {
+  it('should render a label when passed and prop "showLabel" is true', () => {
     const component = (
       <NavbarItem
         icon={<Information />}
         onClick={() => console.log('Information clicked')}
         label="Bridge Information"
+        showLabel
       />
     );
     const { getByTestId } = renderWithTheme(lightTheme, component);
@@ -37,7 +39,7 @@ describe('NavbarItem', () => {
     expect(navbarItem).toHaveTextContent('Bridge Information');
   });
 
-  it('should render a icon button', () => {
+  it('should render an iconButton', () => {
     const component = (
       <NavbarItem
         icon={<Information />}
@@ -46,7 +48,7 @@ describe('NavbarItem', () => {
       />
     );
     const { getByTestId } = renderWithTheme(lightTheme, component);
-    expect(getByTestId('control-bar-item')).toBeInTheDocument();
+    expect(getByTestId('button')).toBeInTheDocument();
   });
 
   it('should call onClick once if clicked on navbar label', () => {
@@ -55,6 +57,7 @@ describe('NavbarItem', () => {
         icon={<Information />}
         onClick={jest.fn()}
         label="Bridge Information"
+        showLabel
       />
     );
     const { getByTestId } = renderWithTheme(lightTheme, component);
@@ -67,5 +70,38 @@ describe('NavbarItem', () => {
       })
     );
     expect(component.props.onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render a PopOver component if there are children', () => {
+    const component = (
+      <NavbarItem
+        icon={<Information />}
+        onClick={jest.fn()}
+        label="Bridge Information"
+        showLabel
+      >
+        <p>Test Child</p>
+      </NavbarItem>
+    );
+    const { getByTestId } = renderWithTheme(lightTheme, component);
+    const popOver = getByTestId('popover');
+    expect(popOver).toBeInTheDocument();
+  });
+
+  it('should render an additional component via the "badge" prop', () => {
+    const badge = <Badge value="11" />;
+    const component = (
+      <NavbarItem
+        icon={<Information />}
+        onClick={jest.fn()}
+        label="Bridge Information"
+        showLabel
+        badge={badge}
+      >
+        <p>Test Child</p>
+      </NavbarItem>
+    );
+    const { getByTestId } = renderWithTheme(lightTheme, component);
+    expect(getByTestId('badge')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
**Description of changes:**

This would be a breaking change as it changes the API contract of the `NavBar` component.

Optionally allow the `IconButton` component to render another element via a `badge` prop.
Refactor the `NavBarItem` component so that it use `IconButton` directly, and accept `children` as content for a `PopOver`. (this is the breaking change)
Optionally prevent responsive styles for the `NavBa`r by introducing a responsive prop that developers can use to keep the `NavBa`r at a static width throughout different breakpoint sizes.
Testing


**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes?

3. If you made changes to the component library, have you provided corresponding documentation changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
