### PR TITLE
Allow PopOver to receive multiple clicks before closing

### DIFF
--- a/src/components/ui/PopOver/PopOver.stories.tsx
+++ b/src/components/ui/PopOver/PopOver.stories.tsx
@@ -86,6 +86,42 @@ BasicPopOverMenu.story = {
   name: 'Basic PopOver Menu',
 };
 
+export const PersistentPopOverMenu = () => (
+  <>
+    <Flex layout="fill-space-centered" flexDirection="column">
+      <Heading tag="p" level={6} mb={4}>
+        Click the button icon to trigger the popover
+      </Heading>
+      <PopOver
+        a11yLabel="Click me"
+        renderButton={(isOpen) => getButtonContents(isOpen)}
+        closeOnClick={false}
+      >
+        <PopOverItem
+          as="button"
+          onClick={() => console.log('clicked Option 1')}
+          children={<span>Option 1</span>}
+        />
+        <PopOverItem
+          as="button"
+          onClick={() => console.log('clicked Option 2')}
+          children={<span>Option 2</span>}
+        />
+
+        <PopOverItem
+          as="button"
+          onClick={() => console.log('clicked Option 3')}
+          children={<span>Option 3</span>}
+        />
+      </PopOver>
+    </Flex>
+  </>
+);
+
+PersistentPopOverMenu.story = {
+  name: 'Persistent PopOver Menu',
+};
+
 export const PopOverMenuWithHeader = () => (
   <Flex layout="fill-space-centered" flexDirection="column">
     <Heading tag="p" level={6} mb={4}>

--- a/src/components/ui/PopOver/index.tsx
+++ b/src/components/ui/PopOver/index.tsx
@@ -44,6 +44,8 @@ export interface PopOverProps
   a11yLabel: string;
   /** The elements that populate the menu */
   children: any;
+  /** Allow the popover to stay open for multiple clicks. */
+  closeOnClick?: boolean;
 }
 
 const getFocusableElements = (node: HTMLElement): NodeListOf<HTMLElement> => {
@@ -58,6 +60,7 @@ export const PopOver: FC<PopOverProps> = ({
   placement = 'bottom-start',
   a11yLabel,
   className,
+  closeOnClick = true,
   ...rest
 }) => {
   const menuRef = createRef<HTMLSpanElement>();
@@ -98,6 +101,9 @@ export const PopOver: FC<PopOverProps> = ({
   };
 
   const closePopover = (e: any) => {
+    if (!closeOnClick) {
+      return;
+    }
     const isSubMenuButton = e.target.closest("[data-menu='submenu']");
     return !isSubMenuButton ? setIsOpen(false) : false;
   };

--- a/tst/components/ui/PopOver/index.test.tsx
+++ b/tst/components/ui/PopOver/index.test.tsx
@@ -134,6 +134,28 @@ describe('PopOver', () => {
     expect(menu).not.toBeInTheDocument();
   });
 
+  it('should NOT close the popper when an item is selected if closeOnClick is false', () => {
+    const component = (
+      <PopOver
+        renderButton={popOverButton}
+        a11yLabel="test-label"
+        closeOnClick={false}
+      >
+        <PopOverItem children={<span>Test Item</span>} />
+      </PopOver>
+    );
+    const { getByText, getByTestId, queryByTestId } = renderWithTheme(
+      lightTheme,
+      component
+    );
+    const toggle = getByTestId('popover-toggle');
+    fireEvent.click(toggle);
+    const menu = queryByTestId('menu');
+    const item = getByText('Test Item');
+    fireEvent.click(item);
+    expect(menu).toBeInTheDocument();
+  });
+
   it('should not close the popper when a submenu item is clicked', async () => {
     const component = (
       <PopOver renderButton={popOverButton} a11yLabel="test-label">


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
See title. This should solve the issues like being unable to select multiple emojis before closing. 

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Unit and storybook
3. If you made changes to the component library, have you provided corresponding documentation changes?
Yes
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
