### PR TITLE
Add style variants to Caution icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a classname to PopOverMenu component for styling access
 - Added a "dismissible" prop to Modal to optionally allow persistent modals
 - Added ZoomIn and ZoomOut icons
+- Added style variants to Caution icon
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13274,6 +13274,15 @@
         "warning": "^4.0.3"
       }
     },
+    "cross-fetch": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.6.1"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -14233,26 +14242,6 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
-      }
-    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -15166,36 +15155,34 @@
       }
     },
     "fbemitter": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-2.1.1.tgz",
-      "integrity": "sha1-Uj4U/a9SSIBbsC9i78M75wP1GGU=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-3.0.0.tgz",
+      "integrity": "sha512-KWKaceCwKQU0+HPoop6gn4eOHk50bBv/VxjJtGMfwmJt3D29JpN4H4eisCtIPA+a8GVBam+ldMMpMjJUvpDyHw==",
       "dev": true,
       "requires": {
-        "fbjs": "^0.8.4"
+        "fbjs": "^3.0.0"
       }
     },
     "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.0.tgz",
+      "integrity": "sha512-dJd4PiDOFuhe7vk4F80Mba83Vr2QuK86FoxtgPmzBqEJahncp+13YCmfoa53KHCo6OnlXLG7eeMWPfB5CrpVKg==",
       "dev": true,
       "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
+        "cross-fetch": "^3.0.4",
+        "fbjs-css-vars": "^1.0.0",
         "loose-envify": "^1.0.0",
         "object-assign": "^4.1.0",
         "promise": "^7.1.1",
         "setimmediate": "^1.0.5",
         "ua-parser-js": "^0.7.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
-        }
       }
+    },
+    "fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
+      "dev": true
     },
     "fd-slicer": {
       "version": "1.1.0",
@@ -15577,13 +15564,13 @@
       }
     },
     "flux": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-3.1.3.tgz",
-      "integrity": "sha1-0jvtUVp5oi2TOrU6tK2hnQWy8Io=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.1.tgz",
+      "integrity": "sha512-emk4RCvJ8RzNP2lNpphKnG7r18q8elDYNAPx7xn+bDeOIo9FFfxEfIQ2y6YbQNmnsGD3nH1noxtLE64Puz1bRQ==",
       "dev": true,
       "requires": {
-        "fbemitter": "^2.0.0",
-        "fbjs": "^0.8.0"
+        "fbemitter": "^3.0.0",
+        "fbjs": "^3.0.0"
       }
     },
     "for-in": {
@@ -17427,28 +17414,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
       "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
       "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "dev": true,
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        }
-      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -25434,12 +25399,12 @@
       "dev": true
     },
     "react-json-view": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/react-json-view/-/react-json-view-1.19.1.tgz",
-      "integrity": "sha512-u5e0XDLIs9Rj43vWkKvwL8G3JzvXSl6etuS5G42a8klMohZuYFQzSN6ri+/GiBptDqlrXPTdExJVU7x9rrlXhg==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/react-json-view/-/react-json-view-1.20.2.tgz",
+      "integrity": "sha512-DOGrMqhDHrvBwzwiIU/LKpZ7CFrOHrjoQ+e+d1aOJHn82t++PKuB4atiNR1Ko8UBEoGrMv44RagRSyYWTsEHKg==",
       "dev": true,
       "requires": {
-        "flux": "^3.1.3",
+        "flux": "^4.0.1",
         "react-base16-styling": "^0.6.0",
         "react-lifecycles-compat": "^3.0.4",
         "react-textarea-autosize": "^6.1.0"
@@ -28982,9 +28947,9 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.22",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
-      "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==",
+      "version": "0.7.23",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+      "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==",
       "dev": true
     },
     "unfetch": {
@@ -30153,12 +30118,6 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
-      "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A==",
-      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/src/components/ui/icons/Caution/Caution.stories.tsx
+++ b/src/components/ui/icons/Caution/Caution.stories.tsx
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-
-import { text } from '@storybook/addon-knobs';
+import { text, select } from '@storybook/addon-knobs';
 import Caution from './';
 import CautionIconDocs from './Caution.mdx';
 import Flex from '../../Flex';
@@ -20,6 +19,6 @@ export default {
 
 export const _Caution = () => (
   <Flex layout="fill-space-centered">
-    <Caution width={text('width', '2rem')} />
+    <Caution width={text('width', '2rem')} variant={select('displayStyle', ['default', 'fill-warning', 'fill-error'], 'default')} />
   </Flex>
 );

--- a/src/components/ui/icons/Caution/index.tsx
+++ b/src/components/ui/icons/Caution/index.tsx
@@ -1,12 +1,25 @@
 // Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
+import React, { FC } from 'react';
 import Svg, { SvgProps } from '../Svg';
 
-const Caution: React.SFC<SvgProps> = (props) => (
+export type CautionVariant = 'default' | 'fill-warning' | 'fill-error';
+
+import { StyledCaution } from './styled';
+
+export interface CautionProps extends SvgProps {
+  /** toggle the range of visual variants */
+  variant?: CautionVariant;
+}
+
+const Caution: FC<CautionProps> = (props) => (
   <Svg {...props}>
-    <path d="M12 6c.68 0 1.294.338 1.643.905l5.085 8.281c.35.571.365 1.258.039 1.841-.335.6-.98.972-1.682.972H6.915c-.701 0-1.345-.372-1.68-.972-.326-.583-.312-1.27.039-1.841l5.085-8.281C10.707 6.338 11.32 6 12 6zm.79 1.429c-.33-.538-1.25-.536-1.58 0L6.125 15.71c-.16.261-.167.563-.017.829.16.288.463.46.807.46h10.17c.346 0 .648-.172.809-.46.149-.266.143-.568-.018-.829zm-.218 7.18v1.219h-1.166v-1.219h1.166zm.023-5.388v1.83l-.288 2.727h-.597l-.305-2.727V9.22h1.19z" />
+    <StyledCaution fill="currentColor" variant={props.variant}>
+      <path className="ch-caution-background"  d="M18.728 15.186l-5.085-8.281C13.293 6.338 12.68 6 12 6c-.68 0-1.294.338-1.642.905l-5.085 8.281c-.351.571-.365 1.258-.04 1.841.336.6.98.972 1.68.972h10.17c.704 0 1.348-.372 1.683-.972.326-.583.312-1.27-.04-1.841"/>
+      <path className="ch-caution-exclamation"  d="M12.572 14.609v1.219h-1.166v-1.219h1.166zm.023-5.388v1.83l-.288 2.727h-.597l-.305-2.727V9.22h1.19z"/>
+      <path className="ch-caution-border"  d="M17.894 16.539c-.161.288-.463.46-.81.46H6.915c-.343 0-.645-.172-.806-.46-.15-.266-.143-.568.017-.829l5.085-8.281c.33-.536 1.25-.538 1.58 0l5.086 8.281c.16.261.167.563.018.829m.834-1.353l-5.085-8.281C13.293 6.338 12.68 6 12 6c-.68 0-1.294.338-1.642.905l-5.085 8.281c-.351.571-.365 1.258-.04 1.841.336.6.98.972 1.68.972h10.17c.704 0 1.348-.372 1.683-.972.326-.583.312-1.27-.04-1.841"/>
+    </StyledCaution>
   </Svg>
 );
 

--- a/src/components/ui/icons/Caution/styled.tsx
+++ b/src/components/ui/icons/Caution/styled.tsx
@@ -1,0 +1,51 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import styled, { css } from 'styled-components';
+import { CautionProps } from './';
+
+const defaultStyle = css`
+  .ch-caution-background {
+    fill: transparent;
+  }
+`;
+
+const warningStyle  = css`
+  .ch-caution-background {
+    fill: ${(props) => props.theme.colors.warning.primary};
+  }  
+
+  .ch-caution-exclamation {
+    fill: ${(props) => props.theme.colors.greys.white};
+  }  
+
+  .ch-caution-border {
+    fill: ${(props) => props.theme.colors.warning.primary};
+  }  
+`;
+
+const errorStyle = css`
+  .ch-caution-background {
+    fill: ${(props) => props.theme.colors.error.primary};
+  }  
+
+  .ch-caution-exclamation {
+    fill: ${(props) => props.theme.colors.greys.white};
+  }  
+
+  .ch-caution-border {
+    fill: ${(props) => props.theme.colors.error.primary};
+  }  
+`;
+
+const variantMap = {
+  "default": defaultStyle,
+  "fill-warning": warningStyle,
+  "fill-error": errorStyle,
+};
+
+export const StyledCaution = styled.g<CautionProps> `
+
+  ${(props) => variantMap[props.variant || 'default']};
+
+`;


### PR DESCRIPTION
**Description of changes:**
Recent use cases have prompted the need to display the `Caution` icon in states other than the default one. This change allows for 2 new variants for 'warning' and 'error' states, with the code written in a way that will allow for future variants. 

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? unit tests, manually and running release

3. If you made changes to the component library, have you provided corresponding documentation changes? yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
