### PR TITLE
Fix meeting manager to handle `setSinkId` error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Docs] Fix ContentShare docs
 - Fix non-overridable Mic prop in `RosterAttendee`
 - Fix incorrect fill-rule property on `ZoomIn` and `ZoomOut`
+- Fix meeting manager to handle `setSinkId` error
 
 ### Added
 

--- a/demo/meeting/package-lock.json
+++ b/demo/meeting/package-lock.json
@@ -3035,6 +3035,11 @@
       "integrity": "sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ==",
       "dev": true
     },
+    "@types/ua-parser-js": {
+      "version": "0.7.35",
+      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
+      "integrity": "sha512-PsPx0RLbo2Un8+ff2buzYJnZjzwhD3jQHPOG2PtVIeOhkRDddMcKU8vJtHpzzfLB95dkUi0qAkfLg2l2Fd0yrQ=="
+    },
     "@types/webpack-env": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.15.2.tgz",
@@ -3321,14 +3326,16 @@
       "dev": true
     },
     "amazon-chime-sdk-js": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-1.20.2.tgz",
-      "integrity": "sha512-M3ovG3LoE3n0WrjSt+lXIqAwCWvmP7FJ4KmWkp4WVUsLpjkxNE5vPMi29ydWBg/iETHhRmREhh2SPJJfx3PEeg==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-1.22.0.tgz",
+      "integrity": "sha512-1X/1yO8HFs4vcoi/CIRR5IxySpz4s2n6C8CErFC+bRPjeORVAmDyiy1F5WvXZm1XtAj4wa4tbuPUCoR21Dhw/Q==",
       "requires": {
         "@types/dom-mediacapture-record": "^1.0.4",
+        "@types/ua-parser-js": "^0.7.33",
         "detect-browser": "^5.1.0",
         "protobufjs": "~6.8.8",
-        "resize-observer": "^1.0.0"
+        "resize-observer": "^1.0.0",
+        "ua-parser-js": "^0.7.22"
       }
     },
     "ansi-colors": {
@@ -10459,6 +10466,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
       "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
+    },
+    "ua-parser-js": {
+      "version": "0.7.23",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+      "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA=="
     },
     "uglify-js": {
       "version": "3.4.10",

--- a/demo/meeting/src/utils/TestSound.tsx
+++ b/demo/meeting/src/utils/TestSound.tsx
@@ -15,8 +15,7 @@ class TestSound {
     maxGainValue = 0.1
   ) {
     // @ts-ignore
-    const audioContext: AudioContext = new (window.AudioContext ||
-      window.webkitAudioContext)();
+    const audioContext: AudioContext = new (window.AudioContext || window.webkitAudioContext)();
     const gainNode = audioContext.createGain();
     gainNode.gain.value = 0;
     const oscillatorNode = audioContext.createOscillator();

--- a/demo/meeting/src/utils/VersionLabel.tsx
+++ b/demo/meeting/src/utils/VersionLabel.tsx
@@ -3,9 +3,11 @@
 
 import React from 'react';
 import { Versioning } from 'amazon-chime-sdk-component-library-react';
+import { Versioning as SDKVersioning } from 'amazon-chime-sdk-js';
 
 export const VersionLabel = () => {
   const versionTag = `${Versioning.sdkName}@${Versioning.sdkVersion}`;
+  const sdkVersionTag = `${SDKVersioning.sdkName}@${SDKVersioning.sdkVersion}`;
 
   return (
     <span
@@ -17,7 +19,7 @@ export const VersionLabel = () => {
         fontSize: '0.70rem'
       }}
     >
-      {versionTag}
+      {versionTag} | {sdkVersionTag}
     </span>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10086,9 +10086,9 @@
       "dev": true
     },
     "@types/ua-parser-js": {
-      "version": "0.7.33",
-      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
-      "integrity": "sha512-ngUKcHnytUodUCL7C6EZ+lVXUjTMQb+9p/e1JjV5tN9TVzS98lHozWEFRPY1QcCdwFeMsmVWfZ3DPPT/udCyIw==",
+      "version": "0.7.35",
+      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
+      "integrity": "sha512-PsPx0RLbo2Un8+ff2buzYJnZjzwhD3jQHPOG2PtVIeOhkRDddMcKU8vJtHpzzfLB95dkUi0qAkfLg2l2Fd0yrQ==",
       "dev": true
     },
     "@types/uglify-js": {
@@ -10552,14 +10552,6 @@
         "protobufjs": "~6.8.8",
         "resize-observer": "^1.0.0",
         "ua-parser-js": "^0.7.22"
-      },
-      "dependencies": {
-        "ua-parser-js": {
-          "version": "0.7.22",
-          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
-          "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==",
-          "dev": true
-        }
       }
     },
     "ansi-align": {
@@ -24362,9 +24354,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.44",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.44.tgz",
-          "integrity": "sha512-vHPAyBX1ffLcy4fQHmDyIUMUb42gHZjPHU66nhvbMzAWJqHnySGZ6STwN3rwrnSd1FHB0DI/RWgGELgKSYRDmw==",
+          "version": "10.17.51",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.51.tgz",
+          "integrity": "sha512-KANw+MkL626tq90l++hGelbl67irOJzGhUJk6a1Bt8QHOeh9tztJx+L0AqttraWKinmZn7Qi5lJZJzx45Gq0dg==",
           "dev": true
         }
       }

--- a/src/components/sdk/MeetingControls/AudioOutputControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioOutputControl.tsx
@@ -8,7 +8,7 @@ import { Sound } from '../../ui/icons';
 import { useMeetingManager } from '../../../providers/MeetingProvider';
 import { useAudioOutputs } from '../../../providers/DevicesProvider';
 import { useLocalAudioOutput } from '../../../providers/LocalAudioOutputProvider';
-import { isOptionActive } from '../../../utils/device-utils';
+import { isOptionActive, supportsSetSinkId } from '../../../utils/device-utils';
 import { DeviceType } from '../../../types';
 import { PopOverItemProps } from '../../ui/PopOver/PopOverItem';
 
@@ -21,13 +21,17 @@ const AudioOutputControl: React.FC<Props> = ({ label = 'Speaker' }) => {
   const meetingManager = useMeetingManager();
   const { devices, selectedDevice } = useAudioOutputs();
   const { isAudioOn, toggleAudio } = useLocalAudioOutput();
+  const audioOutputOnClick = async (deviceId: string): Promise<void> => {
+    if (supportsSetSinkId()) {
+      await meetingManager.selectAudioOutputDevice(deviceId);
+    }
+  }
 
   const dropdownOptions: PopOverItemProps[] = devices.map(
     (device: DeviceType) => ({
       children: <span>{device.label}</span>,
       checked: isOptionActive(selectedDevice, device.deviceId),
-      onClick: (): Promise<void> =>
-        meetingManager.selectAudioOutputDevice(device.deviceId),
+      onClick: (): Promise<void> => audioOutputOnClick(device.deviceId),
     })
   );
 

--- a/src/hooks/sdk/useSelectAudioOutputDevice.tsx
+++ b/src/hooks/sdk/useSelectAudioOutputDevice.tsx
@@ -4,12 +4,15 @@
 import { useCallback } from 'react';
 
 import { useMeetingManager } from '../../providers/MeetingProvider';
+import { supportsSetSinkId } from '../../utils/device-utils';
 
 export const useSelectAudioOutputDevice = () => {
   const meetingManager = useMeetingManager();
 
   const selectDevice = useCallback(async (deviceId: string) => {
-    await meetingManager.selectAudioOutputDevice(deviceId);
+    if (supportsSetSinkId()) {
+      await meetingManager.selectAudioOutputDevice(deviceId);
+    }
   }, []);
 
   return selectDevice;

--- a/src/providers/DevicesProvider/AudioInputProvider.tsx
+++ b/src/providers/DevicesProvider/AudioInputProvider.tsx
@@ -64,7 +64,11 @@ const AudioInputProvider: React.FC = ({ children }) => {
           console.log(
             `Audio devices updated and "default" device is selected. Reselecting input.`
           );
-          await audioVideo?.chooseAudioInputDevice(selectedInputRef.current);
+          try {
+            await audioVideo?.chooseAudioInputDevice(selectedInputRef.current);
+          } catch (e) {
+            console.error(`Error in selecting audio input device - ${e}`);
+          }
         }
 
         setAudioInputs(newAudioInputs);

--- a/src/providers/LocalAudioOutputProvider/index.tsx
+++ b/src/providers/LocalAudioOutputProvider/index.tsx
@@ -26,7 +26,13 @@ const LocalAudioOutputProvider: React.FC = ({ children }) => {
     }
 
     if (audioRef.current) {
-      audioVideo.bindAudioElement(audioRef.current);
+      (async (element: HTMLAudioElement) => {
+        try {
+          await audioVideo.bindAudioElement(element);
+        } catch (e) {
+          console.error('Failed to bind audio element.', e);
+        }
+      })(audioRef.current);
     }
     return (): void => {
       audioVideo.unbindAudioElement();
@@ -41,7 +47,13 @@ const LocalAudioOutputProvider: React.FC = ({ children }) => {
     if (isAudioOn) {
       audioVideo?.unbindAudioElement();
     } else {
-      audioVideo?.bindAudioElement(audioRef.current);
+      (async (element: HTMLAudioElement) => {
+        try {
+          await audioVideo?.bindAudioElement(element);
+        } catch (e) {
+          console.error('Failed to bind audio element.', e);
+        }
+      })(audioRef.current);
     }
   }, [audioRef, audioVideo, isAudioOn]);
 

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -18,6 +18,7 @@ import {
 
 import {
   audioInputSelectionToDevice,
+  supportsSetSinkId,
   videoInputSelectionToDevice
 } from '../../utils/device-utils';
 import { MeetingStatus } from '../../types';
@@ -302,9 +303,13 @@ export class MeetingManager implements AudioVideoObserver {
       this.audioInputDevices.length
     ) {
       this.selectedAudioInputDevice = this.audioInputDevices[0].deviceId;
-      await this.audioVideo?.chooseAudioInputDevice(
-        this.audioInputDevices[0].deviceId
-      );
+      try {
+        await this.audioVideo?.chooseAudioInputDevice(
+          this.audioInputDevices[0].deviceId
+        );
+      } catch (e) {
+        console.error(`Error in selecting audio input device - ${e}`);
+      }
       this.publishSelectedAudioInputDevice();
     }
     if (
@@ -313,9 +318,15 @@ export class MeetingManager implements AudioVideoObserver {
       this.audioOutputDevices.length
     ) {
       this.selectedAudioOutputDevice = this.audioOutputDevices[0].deviceId;
-      await this.audioVideo?.chooseAudioOutputDevice(
-        this.audioOutputDevices[0].deviceId
-      );
+      if (supportsSetSinkId()) {
+        try {
+          await this.audioVideo?.chooseAudioOutputDevice(
+            this.audioOutputDevices[0].deviceId
+          );
+        } catch (e) {
+          console.error('Failed to choose audio output device.', e);
+        }
+      }
       this.publishSelectedAudioOutputDevice();
     }
     if (
@@ -332,10 +343,18 @@ export class MeetingManager implements AudioVideoObserver {
     try {
       const receivedDevice = audioInputSelectionToDevice(deviceId);
       if (receivedDevice === null) {
-        await this.audioVideo?.chooseAudioInputDevice(null);
+        try {
+          await this.audioVideo?.chooseAudioInputDevice(null);
+        } catch (e) {
+          console.error('Failed to choose audio input device.', e);
+        }
         this.selectedAudioInputDevice = null;
       } else {
-        await this.audioVideo?.chooseAudioInputDevice(receivedDevice);
+        try {
+          await this.audioVideo?.chooseAudioInputDevice(receivedDevice);
+        } catch (e) {
+          console.error('Failed to choose audio output device.', e);
+        }
         this.selectedAudioInputDevice = deviceId;
       }
       this.publishSelectedAudioInputDevice();

--- a/src/utils/device-utils.ts
+++ b/src/utils/device-utils.ts
@@ -46,3 +46,8 @@ export const isOptionActive = (
   }
   return currentDeviceId === meetingManagerDeviceId;
 };
+
+// TODO: Remove this and use DefaultBrowserBehavior.supportsSetSinkId from JS SDK v2.x
+export const supportsSetSinkId = (): boolean => {
+  return 'setSinkId' in HTMLAudioElement.prototype;
+}


### PR DESCRIPTION
**Issue #:** https://github.com/aws/amazon-chime-sdk-component-library-react/issues/365

**Description of changes:** 
- Guarded `chooseAudioOutputDevice` API by a call to `supportsSetSinkId`.
- Print out the `amazon-chime-sdk-js` version in the meeting demo app.
 

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes? 
Tested by running the meeting demo app. Hard coded `amazon-chime-sdk-js` to `2.4.0` & `1.22.0` to verify it works for both `amazon-chime-sdk-js` v1.x & v2.x

3. If you made changes to the component library, have you provided corresponding documentation changes?
It would be updated in the V2 migration doc.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
