### PR TITLE
Removed unused import statements from NavBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove playwright tests, scripts, and dependency
 - Removed content in ChatBubble
 - Removed showName in ChatBubble
+- Removed unused import statements from NavBar
 
 ## [1.6.0] - 2020-12-14
 

--- a/src/components/ui/Navbar/NavbarItem.tsx
+++ b/src/components/ui/Navbar/NavbarItem.tsx
@@ -6,7 +6,6 @@ import React, { ReactNode } from 'react';
 import { StyledNavbarItem } from './Styled';
 import PopOver, { Placement } from '../PopOver';
 import IconButton, { IconButtonProps }  from '../Button/IconButton';
-import useUniqueId from '../../../hooks/useUniqueId';
 
 
 export interface NavbarItemProps extends IconButtonProps {

--- a/src/components/ui/Navbar/Styled.tsx
+++ b/src/components/ui/Navbar/Styled.tsx
@@ -6,7 +6,6 @@ import styled from 'styled-components';
 import { baseSpacing, baseStyles } from '../Base';
 import { NavbarProps } from '.';
 import { NavbarItemProps } from './NavbarItem';
-import { visuallyHidden } from '../../../utils/style';
 
 import Flex from '../Flex';
 


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:**
Build was failing for the meeting demo app because of some unused imports. Removed those imports to fix the build.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes? By running `npm run build` in `demo/meeting` folder

3. If you made changes to the component library, have you provided corresponding documentation changes? Not required. Its just removing unused imports

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
