### PR TITLE
Add JoinedFromAnotherDevice to useMeetingStatus values, do not clear …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- Fix LocalVideo not rendering on initial attempt
+
+### Added
+- Add JoinedFromAnotherDevice meeting status
+
+### Changed
+- Allow property passthough to IconButton in NavbarItem
+
+### Removed
+
+## [2.0.0] - 2020-2-8
+
+### Fixed
 
 - Fix icon preventing clicks on `Select` components
 - Fix Github Actions build-storybook error
@@ -36,7 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a "dismissible" prop to Modal to optionally allow persistent modals
 - Added ZoomIn and ZoomOut icons
 - Added style variants to Caution icon
-- Allow property passthough to IconButton in NavbarItem
 
 ### Changed
 

--- a/src/components/sdk/LocalVideo/index.tsx
+++ b/src/components/sdk/LocalVideo/index.tsx
@@ -1,9 +1,8 @@
 // Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import styled from 'styled-components';
-import { VideoTileState } from 'amazon-chime-sdk-js';
 
 import { useAudioVideo } from '../../../providers/AudioVideoProvider';
 import { useLocalVideo } from '../../../providers/LocalVideoProvider';
@@ -25,9 +24,6 @@ export const LocalVideo: React.FC<Props> = ({ nameplate, ...rest }) => {
   const audioVideo = useAudioVideo();
   const videoEl = useRef<HTMLVideoElement>(null);
   useApplyVideoObjectFit(videoEl);
-  const [active, setActive] = useState(() =>
-    audioVideo?.hasStartedLocalVideoTile()
-  );
 
   useEffect(() => {
     if (!audioVideo || !tileId || !videoEl.current || !isVideoEnabled) {
@@ -44,36 +40,9 @@ export const LocalVideo: React.FC<Props> = ({ nameplate, ...rest }) => {
     };
   }, [audioVideo, tileId, isVideoEnabled]);
 
-  useEffect(() => {
-    if (!audioVideo) {
-      return;
-    }
-
-    const observer = {
-      videoTileDidUpdate: (tileState: VideoTileState) => {
-        if (
-          !tileState.boundAttendeeId ||
-          !tileState.localTile ||
-          !tileState.tileId ||
-          !videoEl.current
-        ) {
-          return;
-        }
-
-        if (tileState.active !== active) {
-          setActive(tileState.active);
-        }
-      },
-    };
-
-    audioVideo.addObserver(observer);
-
-    return () => audioVideo.removeObserver(observer);
-  }, [audioVideo, active]);
-
   return (
     <StyledLocalVideo
-      active={active}
+      active={isVideoEnabled}
       nameplate={nameplate}
       ref={videoEl}
       {...rest}

--- a/src/hooks/sdk/docs/useMeetingStatus.stories.mdx
+++ b/src/hooks/sdk/docs/useMeetingStatus.stories.mdx
@@ -9,7 +9,8 @@ enum MeetingStatus {
   Loading,
   Succeeded,
   Failed,
-  Ended
+  Ended,
+  JoinedFromAnotherDevice
 }
 ```
 

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -123,7 +123,6 @@ export class MeetingManager implements AudioVideoObserver {
     this.activeSpeakerListener = null;
     this.meetingStatus = MeetingStatus.Loading;
     this.publishMeetingStatus();
-    this.meetingStatusObservers = [];
     this.audioVideoObservers = {};
   }
 
@@ -232,6 +231,12 @@ export class MeetingManager implements AudioVideoObserver {
       console.log('[MeetingManager audioVideoDidStop] Meeting ended for all');
       this.meetingStatus = MeetingStatus.Ended;
       this.publishMeetingStatus();
+    } else if (sessionStatusCode === MeetingSessionStatusCode.AudioJoinedFromAnotherDevice) {
+      console.log('[MeetingManager audioVideoDidStop] Meeting joined from another device');
+      this.meetingStatus = MeetingStatus.JoinedFromAnotherDevice;
+      this.publishMeetingStatus();
+    } else {
+      console.log(`[MeetingManager audioVideoDidStop] session stopped with code ${sessionStatusCode}`);
     }
     this.leave();
   };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,7 +41,8 @@ export enum MeetingStatus {
   Loading,
   Succeeded,
   Failed,
-  Ended
+  Ended,
+  JoinedFromAnotherDevice
 }
 
 export type RosterAttendeeType = {


### PR DESCRIPTION
**Issue #:** 
#391 , #401, #354 

**Description of changes:**
- Meeting status can be associated to multiple meetings, so removing the re-initialization when a meeting ends so that subsequent meetings get the correct status
- Add JoinedFromAnotherDevice to meeting status values
- Rely on local state rather than VTDU observer for rendering `LocalVideo` to fix issue where the LocalVideo will not go active  and render on first attempt to startLocalVideo

**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes?
- Used repro steps provided in #391, verified video started on first `toggleVideo` attempt. Also confirmed current app local video behavior did not change
- Joined a meeting, left, and joined another and verified meetingStatus from `useMeetingStatus` hook was being updated

3. If you made changes to the component library, have you provided corresponding documentation changes?
yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
