### PR TITLE
Allow property passthrough to IconButton in NavbarItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a "dismissible" prop to Modal to optionally allow persistent modals
 - Added ZoomIn and ZoomOut icons
 - Added style variants to Caution icon
+- Allow property passthough to IconButton in NavbarItem
 
 ### Changed
 

--- a/src/components/ui/Navbar/NavbarItem.tsx
+++ b/src/components/ui/Navbar/NavbarItem.tsx
@@ -39,45 +39,46 @@ export const NavbarItem = ({
 }: NavbarItemProps) => {
 
   return (
-    <StyledNavbarItem data-testid="navbar-item" showLabel={showLabel}> 
-      {children 
-        ? 
+    <StyledNavbarItem data-testid="navbar-item" showLabel={showLabel}>
+      {children
+        ?
         <PopOver
           placement={placement}
           a11yLabel={label}
           renderButtonWrapper={(isActive, props) => (
-            <IconButton  
+            <IconButton
               onClick={onClick}
-              selected={isActive} 
-              icon={icon} 
+              selected={isActive}
+              icon={icon}
               badge={badge}
               label={label}
+              {...rest}
               {...props}
             />
           )}
         >
           {children}
-        </PopOver> 
-        : 
+        </PopOver>
+        :
         <IconButton
-          icon={icon} 
+          icon={icon}
           label={label}
           onClick={onClick}
           badge={badge}
           {...rest}
         />
       }
-    
-      <label 
+
+      <label
         className="ch-navigation-bar-item-label"
         data-testid="navbar-label"
         onClick={onClick}
       >
         {label}
       </label>
-    
+
     </StyledNavbarItem>
-    
+
   );
 }
 


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Allow property passthrough to IconButton in NavbarItem

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? manually

3. If you made changes to the component library, have you provided corresponding documentation changes? yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
