### PR TITLE
Check for video inputs before requests video permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix LocalVideo not rendering on initial attempt
 - Fix inconsistent snapshot for EditableChatBubble
 - [Docs] Fix mdx style rendering
+- Confirm video device exists when requesting user device permission
 
 ### Added
 

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -268,10 +268,16 @@ export class MeetingManager implements AudioVideoObserver {
       this.devicePermissionStatus = DevicePermissionStatus.IN_PROGRESS;
       this.publishDevicePermissionStatus();
       try {
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        const hasVideoInput = devices.some(value => {
+          return value.kind === 'videoinput';
+        });
+
         const stream = await navigator.mediaDevices.getUserMedia({
           audio: true,
-          video: true
+          video: hasVideoInput
         });
+
         this.devicePermissionStatus = DevicePermissionStatus.GRANTED;
         this.publishDevicePermissionStatus();
         return stream;


### PR DESCRIPTION
**Issue #:** 
#409

**Description of changes:**
Check that user has a video input device before 

**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes? 
- Joined meeting on PC with no web camera device
- Joined Meeting with web cam device

3. If you made changes to the component library, have you provided corresponding documentation changes? n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
