### PR TITLE
Render roster without waiting for getAtendee callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Allow property passthough to IconButton in NavbarItem
+- Render roster without waiting for getAtendee callback
 
 ### Removed
 

--- a/src/providers/RosterProvider/index.tsx
+++ b/src/providers/RosterProvider/index.tsx
@@ -20,8 +20,6 @@ const RosterProvider: React.FC = ({ children }) => {
   const rosterRef = useRef<RosterType>({});
   const [roster, setRoster] = useState<RosterType>({});
 
-  meetingManager.getAttendee;
-
   useEffect(() => {
     if (!audioVideo) {
       return;
@@ -59,6 +57,14 @@ const RosterProvider: React.FC = ({ children }) => {
         attendee.externalUserId = externalUserId;
       }
 
+      rosterRef.current[attendeeId] = attendee;
+
+      // Update the roster first before waiting to fetch attendee info
+      setRoster((oldRoster) => ({
+        ...oldRoster,
+        [attendeeId]: attendee,
+      }));
+
       if (meetingManager.getAttendee) {
         const externalData = await meetingManager.getAttendee(
           attendeeId,
@@ -66,14 +72,11 @@ const RosterProvider: React.FC = ({ children }) => {
         );
 
         attendee = { ...attendee, ...externalData };
+        setRoster((oldRoster) => ({
+          ...oldRoster,
+          [attendeeId]: attendee,
+        }));
       }
-
-      rosterRef.current[attendeeId] = attendee;
-
-      setRoster((oldRoster) => ({
-        ...oldRoster,
-        [attendeeId]: attendee,
-      }));
     };
 
     audioVideo.realtimeSubscribeToAttendeeIdPresence(rosterUpdateCallback);


### PR DESCRIPTION
**Description of changes:**
Render roster without waiting for getAtendee callback so that getAttendee callback does not block roster component from populating

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes? Manually verified in the meeting demo app by adding a sleep timer in the getAttendee callback and checked that the roster was updated before the attendee name came back.

3. If you made changes to the component library, have you provided corresponding documentation changes? No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
