### PR TITLE
Override default className with prop className

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- Fixed the `MicrophoneActivity` component's `className` prop
+  overridden by the `MicVolumeIndicator` component `className`.
 
 ### Added
 

--- a/src/components/ui/MicVolumeIndicator/index.tsx
+++ b/src/components/ui/MicVolumeIndicator/index.tsx
@@ -19,18 +19,19 @@ export interface MicVolumeIndicatorProps
 
 export const MicVolumeIndicator = forwardRef(
   (
-    { muted = false, signalStrength, ...rest }: MicVolumeIndicatorProps,
+    { muted = false, signalStrength, className: propClassName, ...rest }: MicVolumeIndicatorProps,
     bgRef: Ref<HTMLDivElement>
   ) => {
     const poorConnection =
       signalStrength !== undefined && signalStrength <= 0.5;
+    const className = propClassName ? `${propClassName} ch-mic-volume-indicator` : 'ch-mic-volume-indicator';
 
     return (
       <StyledMicVolumeIndicator
-        {...rest}
+        className={className}
         signalStrength={signalStrength}
         muted={muted}
-        className="ch-mic-volume-indicator"
+        {...rest}
       >
         <Microphone
           muted={muted}


### PR DESCRIPTION
**Issue #:** 
#423 

**Description of changes:**
- Fixed the `MicrophoneActivity` component's `className` prop overridden by the `MicVolumeIndicator` component `className`.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes.

2. How did you test these changes? Tested by running and testing locally in the demo meeting app.

3. If you made changes to the component library, have you provided corresponding documentation changes? No update required.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
