### PR TITLE
Only apply pointer-events to notifications, not notification-groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix serverless deploy script to work on Windows
 - [Tests] Update outdated snapshots
 - [Chat Demo] Fix double API calls on channel click.
+- NotificatonGroups don't accept pointer-events
 
 ### Added
 

--- a/src/components/ui/Notification/Styled.tsx
+++ b/src/components/ui/Notification/Styled.tsx
@@ -28,6 +28,7 @@ export const StyledNotification = styled.div<StyledNotificationProps>`
   border-radius: 0.25rem;
   margin: 0.75rem;
   max-width: 45rem;
+  pointer-events: auto;
 
   .ch-severity-icon {
     width: 1.5rem;
@@ -77,5 +78,3 @@ export const StyledNotification = styled.div<StyledNotificationProps>`
   ${baseSpacing}
   ${baseStyles}
 `;
-
-

--- a/src/components/ui/NotificationGroup/Styled.tsx
+++ b/src/components/ui/NotificationGroup/Styled.tsx
@@ -12,4 +12,5 @@ export const StyledNotificationGroup = styled.div`
   flex-direction: column;
   align-items: center;
   z-index: ${(props) => props.theme.zIndex.notificationGroup};
+  pointer-events: none;
 `;


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**

Only apply pointer-events to notifications, not notification-groups


**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? manually

3. If you made changes to the component library, have you provided corresponding documentation changes? yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
