### PR TITLE
clean up timeouts when hooks are unmounted

### DIFF
--- a/src/hooks/useFocusIn/index.tsx
+++ b/src/hooks/useFocusIn/index.tsx
@@ -28,6 +28,9 @@ export function useFocusIn(el: RefObject<any>, delay = 3000) {
     el.current.addEventListener('focusout', onFocusOut);
 
     return (): void => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
       el.current.removeEventListener('focusin', onFocusIn);
       el.current.removeEventListener('focusout', onFocusOut);
     };

--- a/src/hooks/useMouseMove/index.tsx
+++ b/src/hooks/useMouseMove/index.tsx
@@ -23,6 +23,9 @@ export function useMouseMove(el: RefObject<any>, delay = 3000) {
     el.current.addEventListener('mousemove', onMouseMove);
 
     return (): void => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
       el.current.removeEventListener('mousemove', onMouseMove);
     };
   }, [el]);


### PR DESCRIPTION
**Description of changes:**
When `useMouseMove` and `useFocusIn` are unmounted, we don't currently clean up the timeouts that are set on the `ref` object. This change will ensure that the timeouts are removed. 


**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? manually in a browser

3. If you made changes to the component library, have you provided corresponding documentation changes? n/a, this is a bug fix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
