### PR TITLE
Add sdk version validation check on components demo

### DIFF
--- a/demo/meeting/check-version.js
+++ b/demo/meeting/check-version.js
@@ -1,0 +1,22 @@
+const fs = require('fs-extra');
+const path = require("path");
+
+console.log(`Checking to see if the installed Amazon Chime JS SDK verison is compatible with the current demo.`);
+
+let componentsSdkVersion = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'node_modules/amazon-chime-sdk-component-library-react/package.json'), 'utf-8')).peerDependencies['amazon-chime-sdk-js'].toString();
+let sdkVersion = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'node_modules/amazon-chime-sdk-js/package.json'), 'utf-8')).version.toString();
+console.log(`The components demo supports the 'amazon-chime-sdk-js' versions: ${componentsSdkVersion}`);
+console.log(`The 'amazon-chime-sdk-js' version installed is: ${sdkVersion}`);
+
+const sdkVersions = sdkVersion.split(`.`);
+const componentsSdkVersions = componentsSdkVersion.substring(1).split(`.`);
+for (var i = 0; i < sdkVersions.length; i++) {
+    if (sdkVersions[i] < componentsSdkVersions[i]) {
+        console.error("The SDK version installed in the components library meeting demo is not supported.");
+        process.exit(1);
+    }
+}
+
+console.log("OK: Installed SDK Version is supported on the components meeting demo.");
+process.exit(0);
+

--- a/demo/meeting/package.json
+++ b/demo/meeting/package.json
@@ -22,6 +22,7 @@
     "deps": "cd ../.. && npm run build && yalc publish",
     "build:fast": "webpack --config ./webpack.config.js --mode=production --devtool=false",
     "build": "npm run deps && yalc add amazon-chime-sdk-component-library-react && npm install && npm run build:fast",
+    "postbuild": "node check-version.js",
     "start:client": "npm run build:fast && webpack-dev-server",
     "start:backend": "node server.js",
     "start:fast": "concurrently \"npm run start:client\" \"npm run start:backend\"",


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Add a SDK version checking script that will validate that the SDK node module installed on the components library is supported.

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? running the script locally

3. If you made changes to the component library, have you provided corresponding documentation changes? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
