### PR TITLE
Add support for re-usable MeetingManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Fixed
 - Fixed the `MicrophoneActivity` component's `className` prop
@@ -16,8 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Render roster without waiting for getAtendee callback.
+- Update `MeetingProvider` and corresponding documentation to support
+  re-usable `MeetingManager` instance.
 
-- Render roster without waiting for getAtendee callback
 
 ### Removed
 

--- a/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
+++ b/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
@@ -4,6 +4,11 @@
 
 The `MeetingManager` is a class that helps integration with the SDK. It is tied to the `MeetingProvider` and is primarily responsible for joining, starting, and leaving your meeting.
 
+You can pass in the same `MeetingManager` instance to multiple different `MeetingProvider`s through props. This will override new `MeetingManager` instance creation inside
+the `MeetingProvider`. This is to support very specific cases where you may have different React trees within you applications. For example, you are migrating
+from an Angular application to a React application.
+
+
 You can access the `MeetingManager` instance with the `useMeetingManager` hook.
 
 ## Usage
@@ -84,6 +89,7 @@ interface AttendeeResponse {
 
 #### Example
 
+1. `MeetingManager` instance is created internally in the `MeetingProvider` and can be retrived using `useMeetingManager` hook.
 ```jsx
 import { MeetingProvider, useMeetingManager } from 'amazon-chime-sdk-component-library-react';
 
@@ -108,3 +114,28 @@ const MyApp = () => {
   }, [])
 }
 ```
+
+2. Share the same `MeetingManager` instance with multiple different `MeetingProvider`s.
+
+You can create a new `MeetingManager` instance and then pass it as a prop to your `MeetingProvider`s. If not passed,
+a new `MeetingManager` instance will be created internally with each `MeetingProvider` when rendered; and, 
+you will get the `MeetingManager` instance associated with that particular `MeetingProvider` when `useMeetingManager` hook is called.
+
+```jsx
+import { MeetingProvider, useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+
+const Root = () => {
+  const meetingManager = new MeetingManager({ logLevel: LogLevel.INFO });
+  
+  return (
+    <MeetingProvider meetingManager={meetingManager}>
+      <MyApp1 />
+    <MeetingProvider/>
+
+    <MeetingProvider meetingManager={meetingManager}>
+      <MyApp2 />
+    <MeetingProvider/>
+  ); 
+}
+```
+

--- a/src/providers/MeetingProvider/docs/MeetingProvider.stories.mdx
+++ b/src/providers/MeetingProvider/docs/MeetingProvider.stories.mdx
@@ -17,7 +17,7 @@ import { MeetingProvider } from 'amazon-chime-sdk-component-library-react';
 
 ## Usage
 
-Render the `MeetingProvider` near the root of your application.
+1. Render the `MeetingProvider` near the root of your application.
 
 ```jsx
 import React from 'react';
@@ -28,6 +28,26 @@ const App = () => (
     <MyApp />
   </MeetingProvider>
 );
+```
+
+2. Render two `MeetingProvider`s near the root of your application with the same `MeetingManager` instance.
+
+```jsx
+import { MeetingProvider, useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+
+const Root = () => {
+  const meetingManager = new MeetingManager({ logLevel: LogLevel.INFO });
+  
+  return (
+    <MeetingProvider meetingManager={meetingManager}>
+      <MyApp1 />
+    <MeetingProvider/>
+
+    <MeetingProvider meetingManager={meetingManager}>
+      <MyApp2 />
+    <MeetingProvider/>
+  ); 
+}
 ```
 
 ## Props
@@ -61,3 +81,13 @@ interface PostLogConfig = {
   logLevel: LogLevel
 }
 ```
+
+#### simulcastEnabled
+To enable simulcast for the meeting pass the `simulcastEnabled` prop with value set to `true`. By default, it is `false`.
+For more information on Simulcast, check Amazon Chime JS SDK [simulcast guide](https://github.com/aws/amazon-chime-sdk-js/blob/master/guides/05_Simulcast.md).
+
+#### meetingManager
+There may be use cases to re-use the same `MeetingManager` instance accross multiple different `MeetingProvider`s.
+Hence, you can create a new `MeetingManager` instance and then pass it as a prop to your `MeetingProvider`s. If not passed,
+a new `MeetingManager` instance will be created internally with each `MeetingProvider` when rendered; and, 
+you will get the `MeetingManager` instance associated with that particular `MeetingProvider` when `useMeetingManager` hook is called.

--- a/src/providers/MeetingProvider/index.tsx
+++ b/src/providers/MeetingProvider/index.tsx
@@ -22,6 +22,10 @@ interface Props {
   postLogConfig?: PostLogConfig;
   /** Whether or not to enable simulcast for the meeting session */
   simulcastEnabled?: boolean;
+  /** Pass a `MeetingManager` instance if you want to share this instance 
+   * across multiple different `MeetingProvider`s.
+  */
+  meetingManager?: MeetingManager;
 }
 
 export const MeetingContext = createContext<MeetingManager | null>(null);
@@ -30,10 +34,11 @@ export const MeetingProvider: React.FC<Props> = ({
   logLevel = LogLevel.WARN,
   postLogConfig,
   simulcastEnabled = false,
+  meetingManager: meetingManagerProp,
   children,
 }) => {
   const [meetingManager] = useState(
-    () => new MeetingManager({ logLevel, postLogConfig, simulcastEnabled })
+    () => meetingManagerProp || new MeetingManager({ logLevel, postLogConfig, simulcastEnabled })
   );
 
   return (


### PR DESCRIPTION
**Issue #:** 
None.

**Description of changes:**
- Update `MeetingProvider` and corresponding documentation to support
  re-usable `MeetingManager` instance.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes.

2. How did you test these changes? Tested running the demo app locally.

3. If you made changes to the component library, have you provided corresponding documentation changes? Yes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
