### PR TITLE
Reset isAudioOn to true when LocalAudioOutputProvider unmounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix removeEventListener bug for WithTooltip.
+- Reset `isAudioOn` state to `true` when `LocalAudioOutputProvider` unmounts.
 
 ### Added
 

--- a/src/providers/LocalAudioOutputProvider/index.tsx
+++ b/src/providers/LocalAudioOutputProvider/index.tsx
@@ -36,6 +36,7 @@ const LocalAudioOutputProvider: React.FC = ({ children }) => {
     }
     return (): void => {
       audioVideo.unbindAudioElement();
+      setIsAudioOn(true);
     };
   }, [audioVideo]);
 


### PR DESCRIPTION
**Issue #:** 
Basically the issue is we do not reset `isAudioOn` back to true when the `LocalAudioOutputProvider` is unmounted. Hence, we start a new meeting or re-join the same left meeting the `isAudioOn` remains `false` (the speaker will show disabled which should be enabled when you join a meeting) if disabled while leaving earlier meeting.

**Description of changes:**
- To fix this, we need to reset the `isAudioOn` state to `true` when `LocalAudioOutputProvider` unmounts.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes.

2. How did you test these changes?
2.1 Run the demo/meeting app.
2.2 Join a meeting.
2.3 After you join the meeting, a meeting controls bar with mute button, video button appears at the bottom of the screen in the middle. You will see a speaker icon button in ON state by default.
2.4 Click the speaker button to turn it OFF, verify you do not get any audio out of the selected audio output device.
2.5 Now leave the meeting, without clicking the speaker button. Else it will go to ON state. You will see the speaker button has a cross showing the OFF state.
2.6 Join any meeting again and see that the speaker icon button is enabled / in ON state again. (In the bug, it would remain disabled)
2.7 Leave meeting.

3. If you made changes to the component library, have you provided corresponding documentation changes? NA.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
