### PR TITLE
Fix getAttendee populate name even after the attendee has left the meeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix removeEventListener bug for WithTooltip.
 - Reset `isAudioOn` state to `true` when `LocalAudioOutputProvider` unmounts.
+- Fix getAttendee populate name even after the attendee has left the meeting
 
 ### Added
 

--- a/src/providers/RosterProvider/index.tsx
+++ b/src/providers/RosterProvider/index.tsx
@@ -71,6 +71,10 @@ const RosterProvider: React.FC = ({ children }) => {
           externalUserId
         );
 
+        // Make sure that the attendee is still on the roster
+        if (!rosterRef.current[attendeeId]) {
+          return;
+        }
         attendee = { ...attendee, ...externalData };
         setRoster((oldRoster) => ({
           ...oldRoster,


### PR DESCRIPTION
**Issue #:** 
After #427, we will render a nameplate while waiting for result from getAttendee. However, if the attendee leaves before getAttendee callback finishes, the placeholder nameplate will be removed from the roster.  When getAttendee callback finishes, the attendee name will be updated and shown in the roster incorrectly.

**Description of changes:**
This PR adds a check to make sure that the attendee is still on roster after getAttendee callback finishes before updating the roster.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes? Manually added a wait time of 5s in getAttendee callback in the meeting demo, and did the following:
- Attendee A joined a meeting.
- Attendee B joined a meeting and left right away.
- Make sure that Attendee B did not show up in the roster after 5s.

3. If you made changes to the component library, have you provided corresponding documentation changes? No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
