### PR TITLE
Fix chat demo new channel help text

### DIFF
--- a/demo/chat/src/components/ChannelModals/NewChannelModal.css
+++ b/demo/chat/src/components/ChannelModals/NewChannelModal.css
@@ -43,12 +43,12 @@
 }
 
 .ch-type-options span:nth-child(1)::after {
-  content: ' (non-members can read and send messages)';
+  content: ' (only members can read and send messages)';
   color: #9b9da5;
 }
 
 .ch-type-options span:nth-child(2)::after {
-  content: ' (only members can read and send messages)';
+  content: ' (non-members can read and send messages)';
   color: #9b9da5;
 }
 


### PR DESCRIPTION
**Description of changes:**
Swap the help text for private and public channel so they are correct.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes? Manually verify the help text in chat demo app.

3. If you made changes to the component library, have you provided corresponding documentation changes? No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
