### PR TITLE
Add docs, minor flexibility to WithTooltip HOC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added some key properties to `ModalButtonGroup`, which quiets some React warnings.
 - Added an optional prop `onPopOverClick` to pass a callback function to the `PopOver` UI component. This callback will be called when the `PopOver` UI component is clicked.
 - Added `--no-fail-on-empty-changeset` flag in deploy script to not fail for empty changeset.
-- Add `WithTooltip` docs, warning log if no container is found, and some additional flexibility
+- Add `WithTooltip` docs, warning log if no container is found, and some additional flexibility.
 
 ### Changed
 - Bumped react and react-dom version to 17.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added some key properties to `ModalButtonGroup`, which quiets some React warnings.
 - Added an optional prop `onPopOverClick` to pass a callback function to the `PopOver` UI component. This callback will be called when the `PopOver` UI component is clicked.
-- Add `--no-fail-on-empty-changeset` flag in deploy script to not fail for empty changeset
 - Added `--no-fail-on-empty-changeset` flag in deploy script to not fail for empty changeset.
 - Add `WithTooltip` docs, warning log if no container is found, and some additional flexibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added an optional prop `onPopOverClick` to pass a callback function to the `PopOver` UI component. This callback will be called when the `PopOver` UI component is clicked.
 - Add `--no-fail-on-empty-changeset` flag in deploy script to not fail for empty changeset
+- Add `WithTooltip` docs, warning log if no container is found, and some additional flexibility
 
 ### Changed
 

--- a/src/components/sdk/MeetingControls/AudioInputControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioInputControl.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import { ControlBarButton } from '../../ui/ControlBar/ControlBarItem';
+import { ControlBarButton } from '../../ui/ControlBar/ControlBarButton';
 import { Microphone } from '../../ui/icons';
 import { useMeetingManager } from '../../../providers/MeetingProvider';
 import { useAudioInputs } from '../../../providers/DevicesProvider';

--- a/src/components/sdk/MeetingControls/AudioOutputControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioOutputControl.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import { ControlBarButton } from '../../ui/ControlBar/ControlBarItem';
+import { ControlBarButton } from '../../ui/ControlBar/ControlBarButton';
 import { Sound } from '../../ui/icons';
 import { useMeetingManager } from '../../../providers/MeetingProvider';
 import { useAudioOutputs } from '../../../providers/DevicesProvider';

--- a/src/components/sdk/MeetingControls/ContentShareControl.tsx
+++ b/src/components/sdk/MeetingControls/ContentShareControl.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import { ControlBarButton } from '../../ui/ControlBar/ControlBarItem';
+import { ControlBarButton } from '../../ui/ControlBar/ControlBarButton';
 import { ScreenShare } from '../../ui/icons';
 import { useContentShareState } from '../../../providers/ContentShareProvider';
 import { useContentShareControls } from '../../../providers/ContentShareProvider';

--- a/src/components/sdk/MeetingControls/VideoInputControl.tsx
+++ b/src/components/sdk/MeetingControls/VideoInputControl.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import { ControlBarButton } from '../../ui/ControlBar/ControlBarItem';
+import { ControlBarButton } from '../../ui/ControlBar/ControlBarButton';
 import { Camera } from '../../ui/icons';
 import { useVideoInputs } from '../../../providers/DevicesProvider';
 import { useLocalVideo } from '../../../providers/LocalVideoProvider';

--- a/src/components/ui/Chat/ChatBubble/ChatBubbleContainer.tsx
+++ b/src/components/ui/Chat/ChatBubble/ChatBubbleContainer.tsx
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { FC, HTMLAttributes, ReactNode, Ref } from 'react';
+import React, { FC, useMemo, HTMLAttributes, ReactNode, Ref } from 'react';
 
 import { BaseProps } from '../../Base';
 import { StyledChatBubbleContainer, StyledChatBubbleInfo } from './Styled';
@@ -10,8 +10,6 @@ import { Dots } from '../../icons';
 import { IconButton } from '../../../..';
 import { IconButtonProps } from '../../Button/IconButton';
 import { Tooltipable, WithTooltip } from '../../WithTooltip';
-
-const IconButtonWithToolTip = WithTooltip(IconButton);
 
 export type Message = {
   /** The displayed text of the message sent. */
@@ -47,9 +45,14 @@ export const ChatBubbleContainer: FC<ChatBubbleContainerProps> = React.forwardRe
     const {
       timestamp,
       actions,
+      tooltipContainerId,
       a11yLabel = 'Open channel options',
       ...rest
     } = props;
+
+    const IconButtonWithToolTip = useMemo(
+      () => WithTooltip(IconButton, tooltipContainerId),
+    [tooltipContainerId]);
 
     const ButtonComponent = !!rest['data-tooltip']
       ? IconButtonWithToolTip

--- a/src/components/ui/ControlBar/ControlBar.mdx
+++ b/src/components/ui/ControlBar/ControlBar.mdx
@@ -2,7 +2,7 @@ import { Preview, Props } from '@storybook/addon-docs/blocks';
 import { ThemeProvider } from 'styled-components';
 
 import ControlBar from '.';
-import ControlBarItem from './ControlBarItem';
+import ControlBarButton from './ControlBarButton';
 import { ControlBarForDocs } from './ControlBar.stories';
 import { lightTheme } from '../../../theme/';
 import { GlobalStyles } from '../../../theme/GlobalStyles';
@@ -13,16 +13,16 @@ The ControlBar component displays a section of controls with icons and labels.
 
 You can place ControlBar into the parent element according to the `layout` prop, e.g. `top`, `bottom`, `right`, `left`, `undocked-horizontal`, and `undocked-vertical`.
 
-The ControlBar component contains one or more `ControlBarItem` components, which can show a label and icon. You can add a dropdown list to each ControlBarItem by setting the [popOver props](/?path=/docs/ui-components-popover--basic-pop-over-menu).
+The ControlBar component contains one or more `ControlBarButton` components, which can show a label and icon. You can add a dropdown list to each ControlBarButton by setting the [popOver props](/?path=/docs/ui-components-popover--basic-pop-over-menu).
 
-ControlBars support tooltips on any buttons by adding a `data-tooltip` property. Adding a `data-tooltip-position` property controls the tooltip position
+`ControlBarButton` support tooltips on any buttons by adding a `data-tooltip` property. Adding a `data-tooltip-position` property controls the tooltip position. The tooltip will render the `label` passed, unless a `tooltipContent` prop is passed.
 
 ## Importing
 
 ```javascript
 import {
   ControlBar,
-  ControlBarItem
+  ControlBarButton
 } from 'amazon-chime-sdk-component-library-react';
 ```
 
@@ -99,12 +99,12 @@ const laptopButtonProps = {
 
 return (
   <ControlBar showLabels layout="left">
-    <ControlBarItem {...microphoneButtonProps} />
-    <ControlBarItem {...volumeButtonProps} />
-    <ControlBarItem {...cameraButtonProps} />
-    <ControlBarItem {...dialButtonProps} />
-    <ControlBarItem {...laptopButtonProps} />
-    <ControlBarItem {...hangUpButtonProps} />
+    <ControlBarButton {...microphoneButtonProps} />
+    <ControlBarButton {...volumeButtonProps} />
+    <ControlBarButton {...cameraButtonProps} />
+    <ControlBarButton {...dialButtonProps} />
+    <ControlBarButton {...laptopButtonProps} />
+    <ControlBarButton {...hangUpButtonProps} />
   </ControlBar>
 );
 ```
@@ -114,5 +114,5 @@ return (
 #### ControlBar Component
 <Props of={ControlBar} />
 
-#### ControlBarItem Component
-<Props of={ControlBarItem} />
+#### ControlBarButton Component
+<Props of={ControlBarButton} />

--- a/src/components/ui/ControlBar/ControlBar.stories.tsx
+++ b/src/components/ui/ControlBar/ControlBar.stories.tsx
@@ -6,7 +6,7 @@ import { select, boolean } from '@storybook/addon-knobs';
 
 import { Microphone, Camera, Dialer, Sound, Phone, Laptop } from '../icons';
 import ControlBar from '.';
-import ControlBarItem from './ControlBarItem';
+import ControlBarButton from './ControlBarButton';
 import ControlBarDocs from './ControlBar.mdx';
 
 import PopOverItem from '../PopOver/PopOverItem';
@@ -88,7 +88,7 @@ export const ControlBarForDocs = () => {
 
   return (
     <ControlBar showLabels={true} layout="left" css="position: absolute;">
-      <ControlBarItem {...microphoneButtonProps}>
+      <ControlBarButton {...microphoneButtonProps}>
         <PopOverHeader title="Title text" subtitle="Subtitle text" />
         <PopOverItem as="button" onClick={() => console.log('clicked')}>
           <span>Also test content</span>
@@ -108,12 +108,12 @@ export const ControlBarForDocs = () => {
         <PopOverItem as="button" onClick={() => console.log('clicked')}>
           <span>This has very long text</span>
         </PopOverItem>
-      </ControlBarItem>
-      <ControlBarItem {...volumeButtonProps} />
-      <ControlBarItem {...cameraButtonProps} />
-      <ControlBarItem {...dialButtonProps} />
-      <ControlBarItem {...laptopButtonProps} />
-      <ControlBarItem {...hangUpButtonProps} />
+      </ControlBarButton>
+      <ControlBarButton {...volumeButtonProps} />
+      <ControlBarButton {...cameraButtonProps} />
+      <ControlBarButton {...dialButtonProps} />
+      <ControlBarButton {...laptopButtonProps} />
+      <ControlBarButton {...hangUpButtonProps} />
     </ControlBar>
   );
 };
@@ -196,16 +196,16 @@ export const _ControlBar = () => {
         'top'
       )}
     >
-      <ControlBarItem {...microphoneButtonProps} />
-      <ControlBarItem {...volumeButtonProps}>
+      <ControlBarButton {...microphoneButtonProps} />
+      <ControlBarButton {...volumeButtonProps}>
         <PopOverItem as="button" onClick={() => console.log('clicked')}>
           <span>This is more test content</span>
         </PopOverItem>
-      </ControlBarItem>
-      <ControlBarItem {...cameraButtonProps} />
-      <ControlBarItem {...dialButtonProps} />
-      <ControlBarItem {...laptopButtonProps} />
-      <ControlBarItem {...hangUpButtonProps} popOverPlacement="bottom-end">
+      </ControlBarButton>
+      <ControlBarButton {...cameraButtonProps} />
+      <ControlBarButton {...dialButtonProps} />
+      <ControlBarButton {...laptopButtonProps} />
+      <ControlBarButton {...hangUpButtonProps} popOverPlacement="bottom-end">
         <PopOverHeader title="Title text" subtitle="Subtitle text" />
         <PopOverItem as="button" onClick={() => console.log('clicked')}>
           <span>Also test content</span>
@@ -225,7 +225,7 @@ export const _ControlBar = () => {
         <PopOverItem as="button" onClick={() => console.log('clicked')}>
           <span>This is also a submenu component</span>
         </PopOverItem>
-      </ControlBarItem>
+      </ControlBarButton>
     </ControlBar>
   );
 };

--- a/src/components/ui/ControlBar/ControlBarButton.tsx
+++ b/src/components/ui/ControlBar/ControlBarButton.tsx
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { FC, ReactNode } from 'react';
+import React, { FC, ReactNode, useMemo } from 'react';
 
 import Caret from '../icons/Caret';
 import { StyledControlBarItem, isVertical } from './Styled';
@@ -11,8 +11,6 @@ import { useControlBarContext } from './ControlBarContext';
 import IconButton from '../Button/IconButton';
 import { BaseProps } from '../Base';
 import { Tooltipable, WithTooltip } from '../WithTooltip';
-
-const IconButtonWithToolTip = WithTooltip(IconButton);
 
 export interface ControlBarButtonProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'css'>,
@@ -44,16 +42,22 @@ export const ControlBarButton: FC<ControlBarButtonProps> = ({
   popOver = null,
   popOverPlacement,
   popOverLabel,
+  tooltipContainerId,
+  tooltipContent,
   children,
   ...rest
 }) => {
   const context = useControlBarContext();
 
+  const IconButtonWithToolTip = useMemo(
+    () => WithTooltip(IconButton, tooltipContainerId),
+  [tooltipContainerId]);
+
   const ButtonComponent = !!rest['data-tooltip']
     ? IconButtonWithToolTip
     : IconButton;
   const buttonComponentProps = !!rest['data-tooltip-position']
-    ? { tooltipPosition: rest['data-tooltip-position'] }
+    ? { tooltipPosition: rest['data-tooltip-position'], tooltipContent }
     : {};
 
   const renderPopOver = () => (

--- a/src/components/ui/ControlBar/ControlBarButton.tsx
+++ b/src/components/ui/ControlBar/ControlBarButton.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, ReactNode, useMemo } from 'react';

--- a/src/components/ui/ControlBar/ControlBarButton.tsx
+++ b/src/components/ui/ControlBar/ControlBarButton.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, ReactNode, useMemo } from 'react';

--- a/src/components/ui/Navbar/Navbar.mdx
+++ b/src/components/ui/Navbar/Navbar.mdx
@@ -14,7 +14,7 @@ import { GlobalStyles } from '../../../theme/GlobalStyles';
 
 The Navbar component displays a vertical menu with navigation icon buttons and labels. Navbar is constructed using the NavbarHeader and NavbarItem components.
 
-Navbars support tooltips on any buttons by adding a `data-tooltip` property. Adding a `data-tooltip-position` property controls the tooltip position
+`NavbarItem` support tooltips by adding a `data-tooltip` property. Adding a `data-tooltip-position` property controls the tooltip position. It will render the `label` as the tooltip, unless a `tooltipContent` prop is passed.
 
 ## Importing
 

--- a/src/components/ui/Navbar/NavbarItem.tsx
+++ b/src/components/ui/Navbar/NavbarItem.tsx
@@ -1,14 +1,12 @@
 // Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useMemo } from 'react';
 
 import { StyledNavbarItem } from './Styled';
 import PopOver, { Placement } from '../PopOver';
 import IconButton, { IconButtonProps } from '../Button/IconButton';
 import { Tooltipable, WithTooltip } from '../WithTooltip';
-
-const IconButtonWithToolTip = WithTooltip(IconButton);
 
 export interface NavbarItemProps extends IconButtonProps, Tooltipable {
   /* As part of IconButtonProps, any icon from the library for button in navbar item */
@@ -40,8 +38,13 @@ export const NavbarItem = ({
   badge,
   onClick,
   testId = 'navbar-item',
+  tooltipContainerId,
   ...rest
 }: NavbarItemProps) => {
+  const IconButtonWithToolTip = useMemo(
+    () => WithTooltip(IconButton, tooltipContainerId),
+  [tooltipContainerId]);
+
   const ButtonComponent = !!rest['data-tooltip']
     ? IconButtonWithToolTip
     : IconButton;

--- a/src/components/ui/Roster/PopOverMenu.tsx
+++ b/src/components/ui/Roster/PopOverMenu.tsx
@@ -1,15 +1,13 @@
 // Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { Dots } from '../icons';
 import PopOver from '../PopOver';
 import IconButton, { IconButtonProps } from '../Button/IconButton';
 import classNames from 'classnames';
 import { Tooltipable, WithTooltip } from '../WithTooltip';
-
-const IconButtonWithToolTip = WithTooltip(IconButton);
 
 interface PopOverMenuProps extends Tooltipable {
   menu: React.ReactNode;
@@ -19,10 +17,15 @@ interface PopOverMenuProps extends Tooltipable {
 
 export const PopOverMenu = ({
   menu,
-  a11yMenuLabel = '',
   buttonProps,
+  tooltipContainerId,
+  a11yMenuLabel = '',
   ...rest
 }: PopOverMenuProps) => {
+  const IconButtonWithToolTip = useMemo(
+    () => WithTooltip(IconButton, tooltipContainerId),
+  [tooltipContainerId]);
+
   const ButtonComponent = !!rest['data-tooltip']
     ? IconButtonWithToolTip
     : IconButton;
@@ -38,6 +41,7 @@ export const PopOverMenu = ({
           {...buttonComponentProps}
           {...buttonProps}
           {...props}
+          {...rest}
           className={classNames('ch-menu', buttonProps?.className)}
           icon={<Dots />}
           label={a11yMenuLabel}

--- a/src/components/ui/Roster/Roster.mdx
+++ b/src/components/ui/Roster/Roster.mdx
@@ -14,7 +14,9 @@ import { GlobalStyles } from '../../../theme/GlobalStyles';
 The Roster component displays all the attendees in a meeting including their local statuses for audio, video, content share and if running late.
 It is made up of one RosterHeader component and multiple RosterGroup components.
 
-RosterHeaders and RosterCells support tooltips on any buttons by adding a `data-tooltip` property. Adding a `data-tooltip-position` property controls the tooltip position
+RosterHeaders and RosterCells support tooltips on any buttons by adding a `data-tooltip` property. Adding a `data-tooltip-position` property controls the tooltip position.
+- The RosterHeader will use the labels supplied for the tooltip text
+- The RosterCell will render the `a11yMenuLabel` as the tooltip text
 
 ## Importing
 

--- a/src/components/ui/Roster/Roster.stories.tsx
+++ b/src/components/ui/Roster/Roster.stories.tsx
@@ -63,7 +63,6 @@ export const _Roster = () => {
           a11yMenuLabel="Roster options"
           onMobileToggleClick={() => alert('Open Navigation')}
         />
-
         <RosterGroup>
           <RosterCell
             name="Michael Scott"

--- a/src/components/ui/Roster/RosterHeader.tsx
+++ b/src/components/ui/Roster/RosterHeader.tsx
@@ -7,6 +7,7 @@ import React, {
   useEffect,
   ChangeEvent,
   ReactNode,
+  useMemo
 } from 'react';
 
 import Flex from '../Flex';
@@ -18,8 +19,6 @@ import { StyledHeader } from './Styled';
 import { PopOverMenu } from './PopOverMenu';
 import { BaseProps, FocusableProps } from '../Base';
 import { Tooltipable, WithTooltip } from '../WithTooltip';
-
-const IconButtonWithToolTip = WithTooltip(IconButton);
 
 export interface RosterHeaderProps
   extends BaseProps,
@@ -95,9 +94,14 @@ export const RosterHeader: React.FC<RosterHeaderProps> = ({
   a11yMenuLabel = '',
   searchLabel = 'Open search',
   closeLabel = 'Close',
+  tooltipContainerId,
   children,
   ...rest
 }) => {
+  const IconButtonWithToolTip = useMemo(
+    () => WithTooltip(IconButton, tooltipContainerId),
+  [tooltipContainerId]);
+
   const ButtonComponent = !!rest['data-tooltip']
     ? IconButtonWithToolTip
     : IconButton;
@@ -156,6 +160,7 @@ export const RosterHeader: React.FC<RosterHeaderProps> = ({
         {menu && (
           <PopOverMenu
             {...popOverMenuComponentProps}
+            tooltipContainerId={tooltipContainerId}
             menu={menu}
             a11yMenuLabel={a11yMenuLabel}
           />

--- a/src/components/ui/WithTooltip/WithTooltip.stories.mdx
+++ b/src/components/ui/WithTooltip/WithTooltip.stories.mdx
@@ -1,0 +1,58 @@
+import { WithTooltip } from '.'
+
+<Meta title="UI Components/WithTooltip" />
+
+# WithTooltip
+
+Returns a higher order component (HOC) that renders a tooltip. Make sure to pass an existing element container ID and spread props of the wrapped component.
+
+The `WithTooltip` function takes a component to be wrapped, and an optional container ID used to insert the tooltip into.
+If no container ID is passed, it will fallback to `Tooltip__container`. If no portal is found, it will log a warning.
+
+The wrapped component takes a `tooltipPosition` prop for placing the tooltip, and a label prop for the tooltip text.
+
+```javascript
+  type `tooltipPosition` = 'top' | 'bottom' | 'right' | 'left';
+```
+
+**Please note** - This HOC will eventually be deprecated, as we plan to create a `<Tooltip/>` component in its place. We do not recommend using this HOC.
+
+## Importing
+
+```javascript
+import { WithTooltip } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Example
+
+```jsx
+const MyComponent = (props) => {
+  return <div {...props}> hello world </div>;
+}
+
+const WrappedComponent = WithTooltip(MyComponent, "a-tooltip-container");
+
+// usage
+
+const App = () => (
+  <>
+    <WrappedComponent
+      label="Tooltip label"
+      tooltipPosition="bottom"
+    />
+    <div id="a-tooltip-container" />
+  </>
+)
+
+// Alternate usage
+
+const App = () => (
+  <>
+    <WrappedComponent
+      tooltipContent={<div>Hello world</div>}
+      tooltipPosition="bottom"
+    />
+    <div id="a-tooltip-container" />
+  </>
+)
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export { SecondaryButton } from './components/ui/Button/SecondaryButton';
 export { IconButton } from './components/ui/Button/IconButton';
 export { Checkbox } from './components/ui/Checkbox';
 export { ControlBar } from './components/ui/ControlBar';
-export { ControlBarButton } from './components/ui/ControlBar/ControlBarItem';
+export { ControlBarButton } from './components/ui/ControlBar/ControlBarButton';
 export { Flex } from './components/ui/Flex';
 export { FormField } from './components/ui/FormField';
 export { Heading } from './components/ui/Heading';

--- a/tst/components/ui/ControlBar/ControlBarButton.test.tsx
+++ b/tst/components/ui/ControlBar/ControlBarButton.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/ControlBar/ControlBarButton.test.tsx
+++ b/tst/components/ui/ControlBar/ControlBarButton.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/ControlBar/ControlBarItem.test.tsx
+++ b/tst/components/ui/ControlBar/ControlBarItem.test.tsx
@@ -5,7 +5,7 @@ import '@testing-library/jest-dom';
 import React from 'react';
 import { fireEvent } from '@testing-library/dom';
 
-import ControlBarItem from '../../../../src/components/ui/ControlBar/ControlBarItem';
+import ControlBarButton from '../../../../src/components/ui/ControlBar/ControlBarButton';
 import { Sound } from '../../../../src/components/ui/icons';
 import lightTheme from '../../../../src/theme/light';
 import { renderWithTheme } from '../../../test-helpers';
@@ -30,14 +30,14 @@ export const controlBarItemWithPopOverProps = {
 
 describe('ControlBarButton', () => {
   it('renders a ControlBarButton', () => {
-    const component = <ControlBarItem {...controlBarItemProps} />;
+    const component = <ControlBarButton {...controlBarItemProps} />;
     const { getByTestId } = renderWithTheme(lightTheme, component);
     const el = getByTestId('control-bar-item');
     expect(el).toBeInTheDocument();
   });
 
   it('should render a PopOver if multiple options are available', () => {
-    const component = <ControlBarItem {...controlBarItemWithPopOverProps} />;
+    const component = <ControlBarButton {...controlBarItemWithPopOverProps} />;
     const { getByTestId, getByText } = renderWithTheme(lightTheme, component);
     const button = getByTestId('control-bar-item-caret');
     fireEvent.click(button);
@@ -48,9 +48,9 @@ describe('ControlBarButton', () => {
 
   it('should render a PopOver if children are present', () => {
     const component = (
-      <ControlBarItem {...controlBarItemWithPopOverProps}>
+      <ControlBarButton {...controlBarItemWithPopOverProps}>
         <p>Child element</p>
-      </ControlBarItem>
+      </ControlBarButton>
     );
 
     const { getByTestId, getByText } = renderWithTheme(lightTheme, component);

--- a/tst/components/ui/ControlBar/index.test.tsx
+++ b/tst/components/ui/ControlBar/index.test.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import ControlBar from '../../../../src/components/ui/ControlBar';
 import lightTheme from '../../../../src/theme/light';
 import { renderWithTheme } from '../../../test-helpers';
-import ControlBarItem from '../../../../src/components/ui/ControlBar/ControlBarItem';
+import ControlBarButton from '../../../../src/components/ui/ControlBar/ControlBarButton';
 import { controlBarItemProps } from './ControlBarItem.test';
 
 describe('ControlBar', () => {
@@ -25,7 +25,7 @@ describe('ControlBar', () => {
   it('should pass showLabels prop to controlBarContext', async () => {
     const component = (
       <ControlBar layout="top" showLabels>
-        <ControlBarItem {...controlBarItemProps} />
+        <ControlBarButton {...controlBarItemProps} />
       </ControlBar>
     );
     const { findAllByText } = renderWithTheme(lightTheme, component);

--- a/tst/components/ui/ControlBar/index.test.tsx
+++ b/tst/components/ui/ControlBar/index.test.tsx
@@ -8,7 +8,7 @@ import ControlBar from '../../../../src/components/ui/ControlBar';
 import lightTheme from '../../../../src/theme/light';
 import { renderWithTheme } from '../../../test-helpers';
 import ControlBarButton from '../../../../src/components/ui/ControlBar/ControlBarButton';
-import { controlBarItemProps } from './ControlBarItem.test';
+import { controlBarItemProps } from './ControlBarButton.test';
 
 describe('ControlBar', () => {
   it('renders a ControlBar', () => {


### PR DESCRIPTION
**Issue #:** 
#445 

**Description of changes:**
The `WithTooltip` has a lot of flaws. The HOC may share the label prop with other components, and other components internally relying on it don't pass the container ID to the HOC.

This change...
- adds a `tooltipText` prop that can alternatively be used in place of `label`. Label will continue to be used as a fallback to avoid breaking changes
- Logs a warning if no container element is found
- Fixes some `WithTooltip` consumers that didn't allow a way for to pass a container ID
- Adds some docs around `WithTooltip`

**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes?
Manually, and by syncing the changes to Chime and seeing if there was any breakage. I did not see any

3. If you made changes to the component library, have you provided corresponding documentation changes?
Yeah

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
