### PR TITLE
Toggle ch-popover-active class to highlight a focused or hovered popo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated versions of testing-library family of packages.
 - Corrected the detection of `yesterday` in said code.
 - Wraped actions in tests with `act`, as React requests.
+- Toggle `ch-popover-active` class to highlight a focused or hovered popoverItem.
 
 ### Removed
 

--- a/src/components/ui/PopOver/Styled.tsx
+++ b/src/components/ui/PopOver/Styled.tsx
@@ -50,8 +50,7 @@ export const StyledPopOverItem = styled.li`
     text-decoration: none;
     outline: 0;
 
-    &:hover,
-    &:focus {
+    &.ch-popover-active {
       background-color: ${(props) => props.theme.popOver.active.itemBgd};
       color: ${(props) => props.theme.popOver.active.itemText};
       outline: 0;


### PR DESCRIPTION
Toggle ch-popover-active class to highlight a focused or hovered popoverItem

**Issue #:** 

**Description of changes:**


**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Run the release script
3. If you made changes to the component library, have you provided corresponding documentation changes?
Yes
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
