### PR TITLE
Support extra properties attendee response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an optional prop `onPopOverClick` to pass a callback function to the `PopOver` UI component. This callback will be called when the `PopOver` UI component is clicked.
 - Added `--no-fail-on-empty-changeset` flag in deploy script to not fail for empty changeset.
 - Add `WithTooltip` docs, warning log if no container is found, and some additional flexibility.
+- Add index signature to `AttendeeResponse` to reflect the support of arbitrary.
 
 ### Changed
 - Bumped react and react-dom version to 17.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
 ### Added
 
-- Add support for optional keys to pass extra data in the `AttendeeResponse`.
+- Added support for optional keys to pass extra data in the `AttendeeResponse`.
+
+### Changed
+
+### Removed
 
 ## [2.2.0] - 2021-03-23
 
@@ -31,34 +37,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `WithTooltip` docs, warning log if no container is found, and some additional flexibility.
 
 ### Changed
+
 - Bumped react and react-dom version to 17.
 - Updated versions of testing-library family of packages.
 - Corrected the detection of `yesterday` in said code.
 - Wraped actions in tests with `act`, as React requests.
 
 ### Removed
+
 - [Demo] Removed call `await MeetingManager.leave()` on `endMeetingForAll` button click.
 
 ## [2.1.1] - 2021-03-10
 
 ### Fixed
+
 - Fix getAttendee populate name even after the attendee has left the meeting
 
 ## [2.1.0] - 2021-02-24
 
 ### Fixed
+
 - Fixed the `MicrophoneActivity` component's `className` prop
   overridden by the `MicVolumeIndicator` component `className`.
 - NotificatonGroups don't accept pointer-events.
 - Clean up timeouts when `useFocusIn` and `useMouseMove` hooks are unmounted.
 
 ### Added
+
 - Allow the `PopOver` UI component to stay open for multiple clicks.
 - Added `WithTooltip()` HOC and updated `RosterHeader`, `RosterCell`, `PopOverMenu`,
   `PopOver`, `NavbarItem`, `ControlbarItem`, and `ChatBubbleConatiner` to support tooltips.
 - Added documentation for components that support tooltips, exposed `WithTooltip` component and related interfaces/types.
 
 ### Changed
+
 - Render roster without waiting for getAtendee callback.
 - Update `MeetingProvider` and corresponding documentation to support
   re-usable `MeetingManager` instance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an optional prop `onPopOverClick` to pass a callback function to the `PopOver` UI component. This callback will be called when the `PopOver` UI component is clicked.
 - Added `--no-fail-on-empty-changeset` flag in deploy script to not fail for empty changeset.
 - Add `WithTooltip` docs, warning log if no container is found, and some additional flexibility.
-- Add index signature to `AttendeeResponse` to reflect the support of arbitrary.
+- Add support for optional keys to pass extra data in the `AttendeeResponse`.
 
 ### Changed
 - Bumped react and react-dom version to 17.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add support for optional keys to pass extra data in the `AttendeeResponse`.
+
 ## [2.2.0] - 2021-03-23
 
 ### Fixed
@@ -23,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an optional prop `onPopOverClick` to pass a callback function to the `PopOver` UI component. This callback will be called when the `PopOver` UI component is clicked.
 - Added `--no-fail-on-empty-changeset` flag in deploy script to not fail for empty changeset.
 - Add `WithTooltip` docs, warning log if no container is found, and some additional flexibility.
-- Add support for optional keys to pass extra data in the `AttendeeResponse`.
 
 ### Changed
 - Bumped react and react-dom version to 17.

--- a/demo/chat/src/backend/serverless/template.yaml
+++ b/demo/chat/src/backend/serverless/template.yaml
@@ -243,7 +243,7 @@ Resources:
   IdentityPool:
     Type: "AWS::Cognito::IdentityPool"
     Properties:
-      IdentityPoolName: !Sub ${DemoName}-IdentityPool
+      IdentityPoolName: !Sub ${DemoName}_IdentityPool
       AllowUnauthenticatedIdentities: true
       CognitoIdentityProviders: 
         - ClientId: !Ref UserPoolClient

--- a/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
+++ b/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
@@ -72,7 +72,7 @@ Stops the meeting session and performs cleanup. This should be called anytime a 
 
 ### `meetingManager.getAttendee`
 
-This method is expected to be supplied by the developer. You may call this function with the Chime user ID and external user ID anytime an attendee joins the meeting, and expect to be resolved with an object that has a `name` property that will be used for video nameplates and roster state.
+This method is expected to be supplied by the developer. You may call this function with the Chime user ID and external user ID anytime an attendee joins the meeting, and expect to be resolved with an object that has a `name` property that will be used for video nameplates and roster state. We also add support for optional keys, so you can also pass any other data except `name`.
 
 For example - you may want to fetch the attendee from the database, or get the name from some local application state. This is up to the developer.
 
@@ -84,6 +84,7 @@ For example - you may want to fetch the attendee from the database, or get the n
 
 interface AttendeeResponse {
   name?: string;
+  [attribute: string]: any;
 }
 ```
 

--- a/src/providers/MeetingProvider/types.ts
+++ b/src/providers/MeetingProvider/types.ts
@@ -17,6 +17,7 @@ export interface MeetingJoinData {
 
 export interface AttendeeResponse {
   name?: string;
+  [extra: string]: any;
 }
 
 export type FullDeviceInfoType = {

--- a/src/providers/MeetingProvider/types.ts
+++ b/src/providers/MeetingProvider/types.ts
@@ -17,7 +17,7 @@ export interface MeetingJoinData {
 
 export interface AttendeeResponse {
   name?: string;
-  [extra: string]: any;
+  [attribute: string]: any;
 }
 
 export type FullDeviceInfoType = {


### PR DESCRIPTION
**Issue #:** 
Reflect the support for allowing arbitrary to be passed to RosterProvider.
 
**Description of changes:**
Add index signature in AttendeeResponse.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes, passed all the test.

2. How did you test these changes?
Return flatten and nested arbitrary from api.ts in meeting demo, these arbitrary can be access by RosterProvider, and be displayed in RosterCell UI component.

3. If you made changes to the component library, have you provided corresponding documentation changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
