### PR TITLE
Set node resolve to browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Add browser flag for node resolve in rollup config.
 
 ### Added
 

--- a/demo/meeting/package-lock.json
+++ b/demo/meeting/package-lock.json
@@ -2953,14 +2953,6 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
-    "@types/puppeteer": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-2.1.5.tgz",
-      "integrity": "sha512-ZZKAcX5XVEtSK+CLxz6FhofPt8y1D3yDtjGZHDFBZ4bGe8v2aaS6qBDHY4crruvpb4jsO7HKrPEx39IIqsZAUg==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/react": {
       "version": "16.9.46",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.46.tgz",
@@ -3052,11 +3044,6 @@
       "version": "0.7.35",
       "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
       "integrity": "sha512-PsPx0RLbo2Un8+ff2buzYJnZjzwhD3jQHPOG2PtVIeOhkRDddMcKU8vJtHpzzfLB95dkUi0qAkfLg2l2Fd0yrQ=="
-    },
-    "@types/uuid": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-7.0.4.tgz",
-      "integrity": "sha512-WGZCqBZZ0mXN2RxvLHL6/7RCu+OWs28jgQMP04LWfpyJlQUMTR6YU9CNJAKDgbw+EV/u687INXuLUc7FuML/4g=="
     },
     "@types/webpack-env": {
       "version": "1.15.2",
@@ -3347,10 +3334,8 @@
       "version": "file:.yalc/amazon-chime-sdk-component-library-react",
       "requires": {
         "@popperjs/core": "^2.2.2",
-        "@types/puppeteer": "^2.0.1",
-        "@types/uuid": "^7.0.3",
         "fast-memoize": "^2.5.2",
-        "react-popper": "^2.2.1",
+        "react-popper": "^2.2.4",
         "throttle-debounce": "^2.3.0",
         "uuid": "^8.0.0"
       },

--- a/demo/meeting/package.json
+++ b/demo/meeting/package.json
@@ -22,7 +22,7 @@
     "deps": "cd ../.. && npm run build && yalc publish",
     "build:fast": "webpack --config ./webpack.config.js --mode=production --devtool=false",
     "build": "npm run deps && yalc add amazon-chime-sdk-component-library-react && npm install && npm run build:fast",
-    "build:release": "npm run deps:release && npm install && npm run build:fast",
+    "build:release": "npm install && npm run build:fast",
     "postbuild": "node check-version.js",
     "start:client": "npm run build:fast && webpack-dev-server",
     "start:backend": "node server.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,10 +19,11 @@ export default {
       sourcemap: true
     }
   ],
-  external: ['crypto'],
   plugins: [
     peerDepsExternal(),
-    resolve(),
+    resolve({
+        browser: true, // This instructs the plugin to use the "browser" field in a dependency's package.json
+    }),
     commonjs(),
     typescript({ useTsconfigDeclarationDir: true }),
   ]


### PR DESCRIPTION
**Issue #:** 
The component library depends on uuid package which in turn depends on crypto but rollup did not know how to resolve this dependency (whether it comes from browser or node).
Currently, we use external to not include crypto in the result rollup but it causes uuid to use node implementation of crypto in the bundle file (The code copied from index.esm.js below use randomFillSync which is a method in node).
```
  if (poolPtr > rnds8Pool.length - 16) {
    crypto.randomFillSync(rnds8Pool);
    poolPtr = 0;
  }
```
In webpack version previous to 5, this is fine because they include polyfills for Node but it is no longer the case for Webpack 5.
Using component library with webpack would result in this error:
```
Module not found: Error: Can't resolve 'crypto' in '<your folder>/node_modules/amazon-chime-sdk-component-library-react/lib'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.
```
**Description of changes:**
Set the browser property in node resolve so that it uses the browser alternatives instead.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes? Manually build the library and compare the bundle size before and after.
Also verify the meeting and chat demo size and make sure there are no changes.

3. If you made changes to the component library, have you provided corresponding documentation changes? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
