### PR TITLE
Allowing localisation of labels within Microphone, Share Screen and Video Quality components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added optional props to specify icon titles in the `AudioInputControl` and `ContentShareControl` components.
+- Added optional props to specify the dropdown text that shows when no video quality is selected, in the `QualitySelection` component.
+
+### Changed
+
+### Removed
+
+
+## [Unreleased]
+
+### Fixed
+
+### Added
+
 - Added support for optional keys to pass extra data in the `AttendeeResponse`.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for optional keys to pass extra data in the `AttendeeResponse`.
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.0] - 2021-04-12
+## [Unreleased]
 
 ### Fixed
 
@@ -20,25 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-
-## [Unreleased]
+## [2.3.0] - 2021-04-12
 
 ### Fixed
 - Add browser flag for node resolve in rollup config.
 
 ### Added
-
-### Changed
-
-### Removed
-
-## [Unreleased]
-
-### Fixed
-
-### Added
-
-- Added support for optional keys to pass extra data in the `AttendeeResponse`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
 ### Added
 
-- Add support for optional keys to pass extra data in the `AttendeeResponse`.
+- Added support for optional keys to pass extra data in the `AttendeeResponse`.
+
+### Changed
+
+### Removed
 
 ## [2.2.0] - 2021-03-23
 
@@ -31,34 +37,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `WithTooltip` docs, warning log if no container is found, and some additional flexibility.
 
 ### Changed
+
 - Bumped react and react-dom version to 17.
 - Updated versions of testing-library family of packages.
 - Corrected the detection of `yesterday` in said code.
 - Wraped actions in tests with `act`, as React requests.
 
 ### Removed
+
 - [Demo] Removed call `await MeetingManager.leave()` on `endMeetingForAll` button click.
 
 ## [2.1.1] - 2021-03-10
 
 ### Fixed
+
 - Fix getAttendee populate name even after the attendee has left the meeting
 
 ## [2.1.0] - 2021-02-24
 
 ### Fixed
+
 - Fixed the `MicrophoneActivity` component's `className` prop
   overridden by the `MicVolumeIndicator` component `className`.
 - NotificatonGroups don't accept pointer-events.
 - Clean up timeouts when `useFocusIn` and `useMouseMove` hooks are unmounted.
 
 ### Added
+
 - Allow the `PopOver` UI component to stay open for multiple clicks.
 - Added `WithTooltip()` HOC and updated `RosterHeader`, `RosterCell`, `PopOverMenu`,
   `PopOver`, `NavbarItem`, `ControlbarItem`, and `ChatBubbleConatiner` to support tooltips.
 - Added documentation for components that support tooltips, exposed `WithTooltip` component and related interfaces/types.
 
 ### Changed
+
 - Render roster without waiting for getAtendee callback.
 - Update `MeetingProvider` and corresponding documentation to support
   re-usable `MeetingManager` instance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add support for optional keys to pass extra data in the `AttendeeResponse`.
+
 ## [2.2.0] - 2021-03-23
 
 ### Fixed
@@ -23,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an optional prop `onPopOverClick` to pass a callback function to the `PopOver` UI component. This callback will be called when the `PopOver` UI component is clicked.
 - Added `--no-fail-on-empty-changeset` flag in deploy script to not fail for empty changeset.
 - Add `WithTooltip` docs, warning log if no container is found, and some additional flexibility.
-- Add support for optional keys to pass extra data in the `AttendeeResponse`.
 
 ### Changed
 - Bumped react and react-dom version to 17.

--- a/src/components/sdk/DeviceSelection/CameraSelection/QualitySelection.tsx
+++ b/src/components/sdk/DeviceSelection/CameraSelection/QualitySelection.tsx
@@ -14,32 +14,35 @@ import { VIDEO_INPUT_QUALITY } from '../../../../constants';
 interface Props {
   /** Label shown for video quality selection, by default it is "Video quality" */
   label?: string;
+  /** Label shown in the dropdown when no video quality has been selected yet, by default it is "Select video quality" */
+  labelForUnselected?: string;
 }
 
-const qualityOptions = [
-  {
-    label: 'Select video quality',
-    value: 'unselected',
-  },
-  {
-    label: VIDEO_INPUT_QUALITY['720p'],
-    value: '720p',
-  },
-  {
-    label: VIDEO_INPUT_QUALITY['540p'],
-    value: '540p',
-  },
-  {
-    label: VIDEO_INPUT_QUALITY['360p'],
-    value: '360p',
-  },
-];
 
 export const QualitySelection: React.FC<Props> = ({
   label = 'Video quality',
+  labelForUnselected = 'Select video quality'
 }) => {
   const selectVideoQuality = useSelectVideoQuality();
   const [videoQuality, setVideoQuality] = useState('unselected');
+  const qualityOptions = [
+    {
+      label: labelForUnselected,
+      value: 'unselected',
+    },
+    {
+      label: VIDEO_INPUT_QUALITY['720p'],
+      value: '720p',
+    },
+    {
+      label: VIDEO_INPUT_QUALITY['540p'],
+      value: '540p',
+    },
+    {
+      label: VIDEO_INPUT_QUALITY['360p'],
+      value: '360p',
+    },
+  ];
 
   async function selectQuality(e: ChangeEvent<HTMLSelectElement>) {
     const quality = e.target.value as VideoQuality;

--- a/src/components/sdk/MeetingControls/AudioInputControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioInputControl.tsx
@@ -17,11 +17,17 @@ interface Props {
   muteLabel?: string;
   /** The label that will be shown when microphone is unmuted, it defaults to `Unmute`. */
   unmuteLabel?: string;
+  /** Title attribute for the icon when muted, it defaults to `Muted microphone` */
+  mutedTitle?: string;
+  /** Title attribute for the icon when unmuted, it defaults to `Microphone` */
+  unmutedTitle?: string;
 }
 
 const AudioInputControl: React.FC<Props> = ({
   muteLabel = 'Mute',
   unmuteLabel = 'Unmute',
+  mutedTitle,
+  unmutedTitle
 }) => {
   const meetingManager = useMeetingManager();
   const { muted, toggleMute } = useToggleLocalMute();
@@ -39,7 +45,7 @@ const AudioInputControl: React.FC<Props> = ({
 
   return (
     <ControlBarButton
-      icon={<Microphone muted={muted} />}
+      icon={<Microphone muted={muted} mutedTitle={mutedTitle} unmutedTitle={unmutedTitle} />}
       onClick={toggleMute}
       label={muted ? unmuteLabel : muteLabel}
       popOver={dropdownOptions}

--- a/src/components/sdk/MeetingControls/AudioInputControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioInputControl.tsx
@@ -18,16 +18,16 @@ interface Props {
   /** The label that will be shown when microphone is unmuted, it defaults to `Unmute`. */
   unmuteLabel?: string;
   /** Title attribute for the icon when muted, it defaults to `Muted microphone` */
-  mutedTitle?: string;
+  mutedIconTitle?: string;
   /** Title attribute for the icon when unmuted, it defaults to `Microphone` */
-  unmutedTitle?: string;
+  unmutedIconTitle?: string;
 }
 
 const AudioInputControl: React.FC<Props> = ({
   muteLabel = 'Mute',
   unmuteLabel = 'Unmute',
-  mutedTitle,
-  unmutedTitle
+  mutedIconTitle,
+  unmutedIconTitle
 }) => {
   const meetingManager = useMeetingManager();
   const { muted, toggleMute } = useToggleLocalMute();
@@ -45,7 +45,7 @@ const AudioInputControl: React.FC<Props> = ({
 
   return (
     <ControlBarButton
-      icon={<Microphone muted={muted} mutedTitle={mutedTitle} unmutedTitle={unmutedTitle} />}
+      icon={<Microphone muted={muted} mutedTitle={mutedIconTitle} unmutedTitle={unmutedIconTitle} />}
       onClick={toggleMute}
       label={muted ? unmuteLabel : muteLabel}
       popOver={dropdownOptions}

--- a/src/components/sdk/MeetingControls/ContentShareControl.tsx
+++ b/src/components/sdk/MeetingControls/ContentShareControl.tsx
@@ -17,14 +17,14 @@ interface Props {
   /** The label that will be shown for unpausing content share button in content share control, it defaults to `Unpause`. */
   unpauseLabel?: string;
   /** Title attribute for the icon, it defaults to `Screen share`. */
-  title?: string;
+  iconTitle?: string;
 }
 
 const ContentShareControl: React.FC<Props> = ({
   label = 'Content',
   pauseLabel = 'Pause',
   unpauseLabel = 'Unpause',
-  title
+  iconTitle
 }) => {
   const { isLocalUserSharing } = useContentShareState();
   const {
@@ -43,7 +43,7 @@ const ContentShareControl: React.FC<Props> = ({
   return (
     <>
       <ControlBarButton
-        icon={<ScreenShare title={title} />}
+        icon={<ScreenShare title={iconTitle} />}
         onClick={toggleContentShare}
         label={label}
         popOver={isLocalUserSharing ? dropdownOptions : null}

--- a/src/components/sdk/MeetingControls/ContentShareControl.tsx
+++ b/src/components/sdk/MeetingControls/ContentShareControl.tsx
@@ -16,12 +16,15 @@ interface Props {
   pauseLabel?: string;
   /** The label that will be shown for unpausing content share button in content share control, it defaults to `Unpause`. */
   unpauseLabel?: string;
+  /** Title attribute for the icon, it defaults to `Screen share`. */
+  title?: string;
 }
 
 const ContentShareControl: React.FC<Props> = ({
   label = 'Content',
   pauseLabel = 'Pause',
   unpauseLabel = 'Unpause',
+  title
 }) => {
   const { isLocalUserSharing } = useContentShareState();
   const {
@@ -40,7 +43,7 @@ const ContentShareControl: React.FC<Props> = ({
   return (
     <>
       <ControlBarButton
-        icon={<ScreenShare />}
+        icon={<ScreenShare title={title} />}
         onClick={toggleContentShare}
         label={label}
         popOver={isLocalUserSharing ? dropdownOptions : null}

--- a/src/components/ui/icons/Microphone/index.tsx
+++ b/src/components/ui/icons/Microphone/index.tsx
@@ -11,6 +11,10 @@ export interface MicrophoneProps extends SvgProps {
   muted?: boolean;
   /** Whether or not should show poor connected status. */
   poorConnection?: boolean;
+  /** Title attribute for the icon when muted, it defaults to `Muted microphone` */
+  mutedTitle?: string;
+  /** Title attribute for the icon when unmuted, it defaults to `Microphone` */
+  unmutedTitle?: string;
 }
 
 function getPath(
@@ -31,6 +35,8 @@ function getPath(
 const Microphone: React.SFC<MicrophoneProps> = ({
   muted = false,
   poorConnection = false,
+  mutedTitle = 'Muted microphone',
+  unmutedTitle = 'Microphone',
   ...rest
 }) => {
   const iconPath = getPath(muted, poorConnection);
@@ -40,7 +46,7 @@ const Microphone: React.SFC<MicrophoneProps> = ({
       {...rest}
       muted={muted}
       poorConnection={poorConnection}
-      title={muted ? 'Muted microphone' : 'Microphone'}
+      title={muted ? mutedTitle : unmutedTitle}
       data-testid={
         poorConnection ? 'poor-connection-mic' : 'good-connection-mic'
       }

--- a/src/components/ui/icons/ScreenShare/index.tsx
+++ b/src/components/ui/icons/ScreenShare/index.tsx
@@ -4,8 +4,8 @@
 import React from 'react';
 import Svg, { SvgProps } from '../Svg';
 
-const ScreenShare: React.SFC<SvgProps> = (props) => (
-  <Svg {...props} title="Screen share">
+const ScreenShare: React.SFC<SvgProps> = ({title = 'Screen share', ...rest}) => (
+  <Svg {...rest} title={title}>
     <path d="M15.5 17c.276 0 .5.224.5.5s-.224.5-.5.5h-7c-.276 0-.5-.224-.5-.5s.224-.5.5-.5zM18 6c1.103 0 2 .897 2 2v6c0 1.103-.897 2-2 2H6c-1.103 0-2-.897-2-2V8c0-1.103.897-2 2-2zm0 1H6c-.552 0-1 .449-1 1v6c0 .551.448 1 1 1h12c.552 0 1-.449 1-1V8c0-.551-.448-1-1-1z" />
   </Svg>
 );


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Allow localisation of the following properties:
- Microphone icon
    - tooltip when muted
    - tooltip when unmuted
- Screen Share icon
    - tooltip
- Video Quality dropdown
    - label for unselected video quality

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
All the tests passed from the above script, and we manually verified that when we overrode the configuration in a project that uses these components, it had the desired effect.

3. If you made changes to the component library, have you provided corresponding documentation changes?
We've added comments alongside the new properties, which are written consistently with existing comments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
