### PR TITLE
Fix selectAudioInputDevice error message

### DIFF
--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -364,7 +364,7 @@ export class MeetingManager implements AudioVideoObserver {
         try {
           await this.audioVideo?.chooseAudioInputDevice(receivedDevice);
         } catch (e) {
-          console.error('Failed to choose audio output device.', e);
+          console.error('Failed to choose audio input device.', e);
         }
         this.selectedAudioInputDevice = deviceId;
       }


### PR DESCRIPTION
**Issue #:** None

**Description of changes:**

Tiny fix to an error message in `MeetingManager`. I'm pretty certain this error message should say *input* instead of *output*.

**Testing**
1. Have you successfully run `npm run build:release` locally?
No (in the vacuous sense, I didn't even try)

2. How did you test these changes?
Guesswork

3. If you made changes to the component library, have you provided corresponding documentation changes?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
