### PR TITLE
Add Observer to select input device error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added optional props to specify icon titles in the `AudioInputControl` and `ContentShareControl` components.
 - Added optional props to specify the dropdown text that shows when no video quality is selected, in the `QualitySelection` component.
-
+- Added observer to `selectAudioInputDeviceError` and `selectVideoInputDeviceError` to deliver the error from SDK level to client application level.
+  
 ### Changed
+
 - Change `package-lock` to V2 to support NPM 7.
 - Update `engines` field in `package.json` to include Node 16
 
@@ -27,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.3.0] - 2021-04-12
 
 ### Fixed
+
 - Add browser flag for node resolve in rollup config.
 
 ### Added

--- a/demo/meeting/src/providers/ErrorProvider.tsx
+++ b/demo/meeting/src/providers/ErrorProvider.tsx
@@ -17,11 +17,11 @@ export function getErrorContext() {
 }
 
 export default function ErrorProvider({ children }: Props) {
-  const [errorMessage, setErrorMesage] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
   const ErrorContext = getErrorContext();
 
   const updateErrorMessage = (message: string): void => {
-    setErrorMesage(message);
+    setErrorMessage(message);
   };
 
   const providerValue = {

--- a/demo/meeting/src/views/DeviceSetup/index.tsx
+++ b/demo/meeting/src/views/DeviceSetup/index.tsx
@@ -3,8 +3,7 @@
 
 import React from 'react';
 import { Heading } from 'amazon-chime-sdk-component-library-react';
-
-import JoinMeetingDetails from '../../containers/MeetingJoinDetails';
+import MeetingJoinDetails from '../../containers/MeetingJoinDetails';
 import { StyledLayout } from './Styled';
 import DeviceSelection from '../../components/DeviceSelection';
 
@@ -14,7 +13,7 @@ const DeviceSetup: React.FC = () => (
       Device settings
     </Heading>
     <DeviceSelection />
-    <JoinMeetingDetails />
+    <MeetingJoinDetails />
   </StyledLayout>
 );
 

--- a/src/providers/DevicesProvider/AudioInputProvider.tsx
+++ b/src/providers/DevicesProvider/AudioInputProvider.tsx
@@ -28,11 +28,27 @@ const AudioInputProvider: React.FC = ({ children }) => {
   );
   const selectedInputRef = useRef(selectedAudioInputDevice);
   selectedInputRef.current = selectedAudioInputDevice;
+  const [selectAudioInputDeviceError, setSelectAudioInputDeviceError] = useState(
+    meetingManager.selectAudioInputDeviceError
+  );
+
+  useEffect(() => {
+    const callback = (selectAudioInputDeviceError: Error | null): void => {
+      setSelectAudioInputDeviceError(selectAudioInputDeviceError);
+    };
+
+    meetingManager.subscribeToSelectAudioInputDeviceError(callback);
+
+    return (): void => {
+      meetingManager.unsubscribeFromSelectAudioInputDeviceError(callback);
+    };
+  }, []);
 
   useEffect(() => {
     const callback = (updatedAudioInputDevice: string | null): void => {
       setSelectedAudioInputDevice(updatedAudioInputDevice);
     };
+
     meetingManager.subscribeToSelectedAudioInputDevice(callback);
 
     return (): void => {
@@ -100,8 +116,9 @@ const AudioInputProvider: React.FC = ({ children }) => {
     () => ({
       devices: audioInputs,
       selectedDevice: selectedAudioInputDevice,
+      selectDeviceError: selectAudioInputDeviceError,
     }),
-    [audioInputs, selectedAudioInputDevice]
+    [audioInputs, selectedAudioInputDevice, selectAudioInputDeviceError]
   );
 
   return <Context.Provider value={contextValue}>{children}</Context.Provider>;
@@ -117,7 +134,8 @@ const useAudioInputs = (props?: DeviceConfig): DeviceTypeContext => {
 
   let { devices } = context;
   const { selectedDevice } = context;
-
+  const { selectDeviceError } = context;
+  
   if (needAdditionalIO) {
     const additionalAudioInputs = getFormattedDropdownDeviceOptions(
       AUDIO_INPUT
@@ -127,7 +145,7 @@ const useAudioInputs = (props?: DeviceConfig): DeviceTypeContext => {
     }
   }
 
-  return { devices, selectedDevice };
+  return { devices, selectedDevice, selectDeviceError };
 };
 
 export { AudioInputProvider, useAudioInputs };

--- a/src/providers/DevicesProvider/VideoInputProvider.tsx
+++ b/src/providers/DevicesProvider/VideoInputProvider.tsx
@@ -25,6 +25,21 @@ const VideoInputProvider: React.FC = ({ children }) => {
   const [selectedVideoInputDevice, setSelectedVideoInputDevice] = useState(
     meetingManager.selectedVideoInputDevice
   );
+  const [selectVideoInputDeviceError, setSelectVideoInputDeviceError] = useState(
+    meetingManager.selectVideoInputDeviceError
+  );
+
+  useEffect(() => {
+    const callback = (selectVideoInputDeviceError: Error | null): void => {
+      setSelectVideoInputDeviceError(selectVideoInputDeviceError);
+    };
+
+    meetingManager.subscribeToSelectVideoInputDeviceError(callback);
+
+    return (): void => {
+      meetingManager.unsubscribeFromSelectVideoInputDeviceError(callback);
+    };
+  }, []);
 
   useEffect(() => {
     const callback = (updatedVideoInputDevice: string | null): void => {
@@ -42,9 +57,9 @@ const VideoInputProvider: React.FC = ({ children }) => {
     let isMounted = true;
 
     const observer: DeviceChangeObserver = {
-      videoInputsChanged: (newvideoInputs: MediaDeviceInfo[]) => {
+      videoInputsChanged: (newVideoInputs: MediaDeviceInfo[]) => {
         console.log('VideoInputProvider - video inputs updated');
-        setVideoInputs(newvideoInputs);
+        setVideoInputs(newVideoInputs);
       },
     };
 
@@ -73,8 +88,9 @@ const VideoInputProvider: React.FC = ({ children }) => {
     () => ({
       devices: videoInputs,
       selectedDevice: selectedVideoInputDevice,
+      selectDeviceError: selectVideoInputDeviceError,
     }),
-    [videoInputs, selectedVideoInputDevice]
+    [videoInputs, selectedVideoInputDevice, selectVideoInputDeviceError]
   );
 
   return <Context.Provider value={contextValue}>{children}</Context.Provider>;
@@ -91,7 +107,8 @@ const useVideoInputs = (props?: DeviceConfig): DeviceTypeContext => {
 
   let { devices } = context;
   const { selectedDevice } = context;
-
+  const { selectDeviceError } = context;
+  
   if (needAdditionalIO) {
     const additionalVideoInputs = getFormattedDropdownDeviceOptions(
       additionalIOJSON
@@ -100,7 +117,7 @@ const useVideoInputs = (props?: DeviceConfig): DeviceTypeContext => {
       devices = [...devices, ...additionalVideoInputs];
     }
   }
-  return { devices, selectedDevice };
+  return { devices, selectedDevice, selectDeviceError };
 };
 
 export { VideoInputProvider, useVideoInputs };

--- a/src/providers/DevicesProvider/docs/AudioInputProvider.stories.mdx
+++ b/src/providers/DevicesProvider/docs/AudioInputProvider.stories.mdx
@@ -2,7 +2,7 @@
 
 # AudioInputProvider
 
-The `AudioInputProvider` provides a list of the user's available `audio-input` devices and the currently selected device.
+The `AudioInputProvider` provides a list of the user's available `audio-input` devices, the currently selected device, and the error if device selection fails.
 
 ## State
 
@@ -15,6 +15,9 @@ The `AudioInputProvider` provides a list of the user's available `audio-input` d
 
   // The device ID of the currently selected device
   selectedDevice: string | null
+
+  // The error if device selection fails
+  selectDeviceError?: Error | null
 }
 
 ```
@@ -45,7 +48,7 @@ const App = () => (
 );
 
 const MyChild = () => {
-  const { devices, selectedDevice } = useAudioInputs();
+  const { devices, selectedDevice, selectDeviceError } = useAudioInputs();
   const items = devices.map(device => (
     <li key={device.deviceId}>{device.label}</li>
   ));
@@ -55,6 +58,7 @@ const MyChild = () => {
       <p>Current Selected DeviceId: {selectedDevice}</p>
       <p>Devices</p>
       <ul>{items}</ul>
+      {selectDeviceError && (<p>{selectDeviceError.message}<p/>)}
     </div>
   );
 };

--- a/src/providers/DevicesProvider/docs/VideoInputProvider.stories.mdx
+++ b/src/providers/DevicesProvider/docs/VideoInputProvider.stories.mdx
@@ -2,7 +2,7 @@
 
 # VideoInputProvider
 
-Provides a list of the user's available `video-input` devices and the currently selected device.
+Provides a list of the user's available `video-input` devices, the currently selected device, and the error if device selection fails.
 
 ## State
 
@@ -15,6 +15,9 @@ Provides a list of the user's available `video-input` devices and the currently 
 
   // The device ID of the currently selected device
   selectedDevice: string | null
+  
+  // The error if device selection fails
+  selectDeviceError?: Error | null
 }
 
 ```
@@ -33,7 +36,10 @@ If you are using `MeetingProvider`, `VideoInputProvider` is rendered by default.
 
 ```jsx
 import React from 'react';
-import { MeetingProvider, useVideoInputs } from 'amazon-chime-sdk-component-library-react';
+import { 
+  MeetingProvider,
+  useVideoInputs 
+} from 'amazon-chime-sdk-component-library-react';
 
 const App = () => (
   <MeetingProvider>
@@ -42,19 +48,20 @@ const App = () => (
 );
 
 const MyChild = () => {
-  const { devices, selectedDevice } = useVideoInputs();
-  const items = devices.map((device) => <li key={device.deviceId}>{device.label}</li>)
+  const { devices, selectedDevice, selectDeviceError } = useVideoInputs();
+  const items = devices.map(device => (
+    <li key={device.deviceId}>{device.label}</li>
+  ));
 
   return (
     <div>
       <p>Current Selected DeviceId: {selectedDevice}</p>
       <p>Devices</p>
-      <ul>
-        {items}
-      </ul>
+      <ul>{items}</ul>
+      {selectDeviceError && (<p>{selectDeviceError.message}<p/>)}
     </div>
   );
-}
+};
 ```
 
 ### Dependencies

--- a/src/providers/DevicesProvider/docs/useAudioInputs.stories.mdx
+++ b/src/providers/DevicesProvider/docs/useAudioInputs.stories.mdx
@@ -5,7 +5,7 @@ import { useAudioInputs } from '../';
 
 # useAudioInputs
 
-The `useAudioInputs` hook returns a list of the user's available `audio-input` devices and the currently selected device.
+The `useAudioInputs` hook returns a list of the user's available `audio-input` devices, the currently selected device, and the error if device selection fails.
 
 ## Return Value
 
@@ -18,6 +18,9 @@ The `useAudioInputs` hook returns a list of the user's available `audio-input` d
 
   // The device ID of the currently selected device
   selectedDevice: string | null
+
+  // The error if device selection fails
+  selectDeviceError?: Error | null
 }
 
 ```
@@ -46,12 +49,19 @@ const App = () => (
 );
 
 const MyChild = () => {
-  const { devices } = useAudioInputs();
+  const { devices, selectedDevice, selectDeviceError } = useAudioInputs();
   const items = devices.map(device => (
     <li key={device.deviceId}>{device.label}</li>
   ));
 
-  return <ul>{items}</ul>;
+  return (
+    <div>
+      <p>Current Selected DeviceId: {selectedDevice}</p>
+      <p>Devices</p>
+      <ul>{items}</ul>
+      {selectDeviceError && (<p>{selectDeviceError.message}<p/>)}
+    </div>
+  );
 };
 ```
 

--- a/src/providers/DevicesProvider/docs/useVideoInputs.stories.mdx
+++ b/src/providers/DevicesProvider/docs/useVideoInputs.stories.mdx
@@ -5,7 +5,7 @@ import { useVideoInputs } from '../';
 
 # useVideoInputs
 
-The `useVideoInputs` hook returns a list of the user's available `video-input` devices and the currently selected device.
+The `useVideoInputs` hook returns a list of the user's available `video-input` devices, the currently selected device, and the error if device selection fails.
 
 ## Return Value
 
@@ -18,6 +18,9 @@ The `useVideoInputs` hook returns a list of the user's available `video-input` d
 
   // The device ID of the currently selected device
   selectedDevice: string | null
+
+  // The error if device selection fails
+  selectDeviceError?: Error | null
 }
 
 ```
@@ -46,12 +49,19 @@ const App = () => (
 );
 
 const MyChild = () => {
-  const { devices } = useVideoInputs();
+  const { devices, selectedDevice, selectDeviceError } = useVideoInputs();
   const items = devices.map(device => (
     <li key={device.deviceId}>{device.label}</li>
   ));
 
-  return <ul>{items}</ul>;
+  return (
+    <div>
+      <p>Current Selected DeviceId: {selectedDevice}</p>
+      <p>Devices</p>
+      <ul>{items}</ul>
+      {selectDeviceError && (<p>{selectDeviceError.message}<p/>)}
+    </div>
+  );
 };
 ```
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,7 @@ export type SelectedDeviceId = string | null;
 export type DeviceTypeContext = {
   devices: DeviceType[];
   selectedDevice: SelectedDeviceId;
+  selectDeviceError?: Error | null;
 };
 
 export type DeviceConfig = {


### PR DESCRIPTION
**Issue #433 :** 

**Description of changes:**
Fix several typos. 
Add observer to `selectAudioInputDeviceError` and `selectVideoInputDeviceError` to deliver the error from SDK level to client application level.

When calling the `meetingManager.selectVideoInputDevice()/selectAudioInputDevice()`
* If there is an error, assign the error to `selectVideoInputDeviceError`/`selectAudioInputDeviceError`, and publish it
* If there is no error, set the `selectVideoInputDeviceError`/`selectAudioInputDeviceError` to `null`, and publish it

Error can be accessed through `useVideoInput`/`useAudioInput` hook. 

**Testing**
1. Have you successfully run `npm run build:release` locally?
    Yes

2. How did you test these changes?
    Mock a non-existent device for both `VideoInputProvider` and `AudioInputProvider`, and let `CameraSelection` and `MicSelection` display the `selectDeviceError` if not `null`, hide it if `null`.
    Run the meeting demo, on the "Device" page, for both video input device and audio input device:
    * Select the mocked device, and then the error appears
    * Choose the correct device, the error disappears
 
    Test on Safari, Chrome, Firefox.
3. If you made changes to the component library, have you provided corresponding documentation changes?
Yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
