### PR TITLE
Delay device permission request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `sourceId` as an optional parameter in the `toggleContentShare` function to specify which screen to share.
 - [Doc] Add a new page, a "How-tos" section in the story book to show use-cases with sample code.
+- Added optional parameter `deviceLabels: DeviceLabels | DeviceLabelTrigger` in `meetingManager.join()`, and `invokeDeviceProvider(deviceLabels: DeviceLabels)` function to control the device permission request. Builder could pass a `deviceLabels` of type `DeviceLabels` to select the devices from which the browser requests permission when joining the meeting. Builder could also pass a `deviceLabels` of `DeviceLabelTrigger` type, to set their customized `deviceLabelTrigger` which is triggered to get the device info. Builder could call `invokeDeviceProvider(deviceLabels: DeviceLabels)` to trigger the device permission prompts. For example, builder wants to implement a view-only mode and no device permission prompts are triggered during the whole process. Builder could just call `meetingManager.join(DeviceLabels.None)` to join a meeting. Later they trigger the device permission prompts by calling `meetingManager.invokeDeviceProvider(DeviceLabels.AudioAndVideo)` to get the full access to devices.
 
 ### Changed
 
@@ -28,8 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [Doc] Add documentaion in introduction on how to use `MeetingSessionPostLogger` to post
-  Amazon Chime JS SDK logs.
+- [Doc] Add documentation in introduction on how to use `MeetingSessionPostLogger` to post Amazon Chime JS SDK logs.
 - Add `useMediaStreamMetrics` hook to expose audio, video and bandwidth data.
 
 ### Changed
@@ -40,8 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Add or remove event listener only when `el.current` reference is valid
-  in `useFocusIn` and `useMouseMove` hooks.
+- Add or remove event listener only when `el.current` reference is valid in `useFocusIn` and `useMouseMove` hooks.
 - Fix bug related to `PreviewVideo` component not releasing media stream when unmounted.
 - Correct `IconButton` border in dark theme.
 
@@ -54,8 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change `package-lock` to V2 to support NPM 7.
-- Update `engines` field in `package.json` to include Node 16
-- Bump `hosted-git-info` version
+- Update `engines` field in `package.json` to include Node 16.
+- Bump `hosted-git-info` version.
 
 ### Removed
 

--- a/demo/meeting/src/app.tsx
+++ b/demo/meeting/src/app.tsx
@@ -39,7 +39,7 @@ const App: FC = () => (
                   </Route>
                   <Route path={routes.MEETING}>
                     <NoMeetingRedirect>
-                      <Meeting />
+                      <MeetingModeSelector />
                     </NoMeetingRedirect>
                   </Route>
                 </Switch>
@@ -60,6 +60,14 @@ const Theme: React.FC = ({ children }) => {
       <GlobalStyles />
       {children}
     </ThemeProvider>
+  );
+};
+
+const MeetingModeSelector: React.FC = () => {
+  const { meetingMode } = useAppState();
+
+  return (
+    <Meeting mode={meetingMode} />
   );
 };
 

--- a/demo/meeting/src/containers/DevicePermissionControl/DevicePermissionControl.tsx
+++ b/demo/meeting/src/containers/DevicePermissionControl/DevicePermissionControl.tsx
@@ -1,0 +1,35 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ControlBarButton, Cog, useMeetingManager, Camera, Sound, Dots, } from 'amazon-chime-sdk-component-library-react';
+import { DeviceLabels } from 'amazon-chime-sdk-component-library-react/lib/types';
+import React from 'react';
+import DevicePermissionPrompt from '../DevicePermissionPrompt';
+
+const DevicePermissionControl = (props: { deviceLabels: DeviceLabels }) => {
+  const meetingManager = useMeetingManager();
+
+  const handleClick = async () => {
+    await meetingManager.invokeDeviceProvider(props.deviceLabels);
+  }
+
+  const label = props.deviceLabels === DeviceLabels.AudioAndVideo ? "Device" :
+    props.deviceLabels === DeviceLabels.Audio ? "Audio" :
+      props.deviceLabels === DeviceLabels.Video ? "Video" :
+        "None"
+
+  const icon = props.deviceLabels === DeviceLabels.AudioAndVideo ? <Cog /> :
+    props.deviceLabels === DeviceLabels.Audio ? <Sound /> :
+      props.deviceLabels === DeviceLabels.Video ? <Camera /> :
+        <Dots />
+
+  return (
+    props.deviceLabels === DeviceLabels.None ? null :
+      <>
+        <ControlBarButton icon={icon} onClick={handleClick} label={label} />
+        <DevicePermissionPrompt />
+      </>
+  );
+}
+
+export default DevicePermissionControl;

--- a/demo/meeting/src/containers/DevicePermissionControl/Styled.tsx
+++ b/demo/meeting/src/containers/DevicePermissionControl/Styled.tsx
@@ -1,0 +1,8 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import styled from 'styled-components';
+
+export const StyledP = styled.p`
+  padding: 1rem 1rem 1rem 0;
+`;

--- a/demo/meeting/src/containers/DynamicMeetingControls/Styled.ts
+++ b/demo/meeting/src/containers/DynamicMeetingControls/Styled.ts
@@ -1,0 +1,22 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import styled from 'styled-components';
+
+interface StyledProps {
+  active: boolean;
+}
+
+export const StyledControls = styled.div<StyledProps>`
+  opacity: ${props => (props.active ? '1' : '0')};
+  transition: opacity 250ms ease;
+
+  @media screen and (max-width: 768px) {
+    opacity: 1;
+  }
+
+  .controls-menu {
+    width: 100%;
+    position: static;
+  }
+`;

--- a/demo/meeting/src/containers/DynamicMeetingControls/index.tsx
+++ b/demo/meeting/src/containers/DynamicMeetingControls/index.tsx
@@ -1,0 +1,65 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import {
+  ControlBar,
+  AudioInputControl,
+  VideoInputControl,
+  ContentShareControl,
+  AudioOutputControl,
+  ControlBarButton,
+  useUserActivityState,
+  Dots,
+  useDevicePermissionStatus,
+  DevicePermissionStatus,
+} from 'amazon-chime-sdk-component-library-react';
+
+import EndMeetingControl from '../EndMeetingControl';
+import { useNavigation } from '../../providers/NavigationProvider';
+import { StyledControls } from './Styled';
+import DevicePermissionControl from '../DevicePermissionControl/DevicePermissionControl';
+import { DeviceLabels } from 'amazon-chime-sdk-component-library-react/lib/types';
+
+const DynamicMeetingControls = () => {
+  const { toggleNavbar, closeRoster, showRoster } = useNavigation();
+  const { isUserActive } = useUserActivityState();
+  const permission = useDevicePermissionStatus();
+
+  const handleToggle = () => {
+    if (showRoster) {
+      closeRoster();
+    }
+
+    toggleNavbar();
+  };
+
+  return (
+    <StyledControls className="controls" active={!!isUserActive}>
+      <ControlBar
+        className="controls-menu"
+        layout="undocked-horizontal"
+        showLabels
+      >
+        <ControlBarButton
+          className="mobile-toggle"
+          icon={<Dots />}
+          onClick={handleToggle}
+          label="Menu"
+        />
+        {permission === DevicePermissionStatus.GRANTED ?
+          <>
+            <AudioInputControl />
+            <VideoInputControl />
+            <ContentShareControl />
+            <AudioOutputControl />
+          </>
+          : <DevicePermissionControl deviceLabels={DeviceLabels.AudioAndVideo} />}
+
+        <EndMeetingControl />
+      </ControlBar>
+    </StyledControls>
+  );
+};
+
+export default DynamicMeetingControls;

--- a/demo/meeting/src/containers/MeetingForm/index.tsx
+++ b/demo/meeting/src/containers/MeetingForm/index.tsx
@@ -5,6 +5,7 @@ import React, { useState, useContext, ChangeEvent } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
   Input,
+  Checkbox,
   Flex,
   Heading,
   FormField,
@@ -23,6 +24,8 @@ import DevicePermissionPrompt from '../DevicePermissionPrompt';
 import RegionSelection from './RegionSelection';
 import { fetchMeeting, createGetAttendeeCallback } from '../../utils/api';
 import { useAppState } from '../../providers/AppStateProvider';
+import { MeetingMode } from '../../types';
+import { DeviceLabels } from 'amazon-chime-sdk-component-library-react/lib/types';
 
 const MeetingForm: React.FC = () => {
   const meetingManager = useMeetingManager();
@@ -37,8 +40,10 @@ const MeetingForm: React.FC = () => {
   const [nameErr, setNameErr] = useState(false);
   const [region, setRegion] = useState(appRegion);
   const [isLoading, setIsLoading] = useState(false);
+  const [isSpectatorModeSelected, setIsSpectatorModeSelected] = useState(false)
   const { errorMessage, updateErrorMessage } = useContext(getErrorContext());
   const history = useHistory();
+  const { setMeetingMode } = useAppState();
 
   const handleJoinMeeting = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -66,11 +71,19 @@ const MeetingForm: React.FC = () => {
 
       await meetingManager.join({
         meetingInfo: JoinInfo.Meeting,
-        attendeeInfo: JoinInfo.Attendee
+        attendeeInfo: JoinInfo.Attendee,
+        deviceLabels: isSpectatorModeSelected === true ? DeviceLabels.None : DeviceLabels.AudioAndVideo,
       });
 
       setAppMeetingInfo(id, attendeeName, region);
-      history.push(routes.DEVICE);
+      if (isSpectatorModeSelected === true) {
+        setMeetingMode(MeetingMode.Spectator);
+        await meetingManager.start();
+        history.push(`${routes.MEETING}/${meetingId}`);
+      } else {
+        setMeetingMode(MeetingMode.Attendee);
+        history.push(routes.DEVICE);
+      }
     } catch (error) {
       updateErrorMessage(error.message);
     }
@@ -124,6 +137,15 @@ const MeetingForm: React.FC = () => {
         }}
       />
       <RegionSelection setRegion={setRegion} region={region} />
+      <FormField
+        field={Checkbox}
+        label="Join w/o Audio and Video"
+        value=""
+        checked={isSpectatorModeSelected}
+        onChange={() => (
+          setIsSpectatorModeSelected(!isSpectatorModeSelected)
+        )}
+      />
       <Flex
         container
         layout="fill-space-centered"

--- a/demo/meeting/src/providers/AppStateProvider.tsx
+++ b/demo/meeting/src/providers/AppStateProvider.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useContext, useState, ReactNode } from 'react';
+import { MeetingMode } from '../types';
 
 type Props = {
   children: ReactNode;
@@ -12,8 +13,10 @@ interface AppStateValue {
   localUserName: string;
   theme: string;
   region: string;
+  meetingMode: MeetingMode;
   toggleTheme: () => void;
   setAppMeetingInfo: (meetingId: string, name: string, region: string) => void;
+  setMeetingMode: (meetingMode: MeetingMode) => void;
 }
 
 const AppStateContext = React.createContext<AppStateValue | null>(null);
@@ -33,6 +36,7 @@ const query = new URLSearchParams(location.search);
 export function AppStateProvider({ children }: Props) {
   const [meetingId, setMeeting] = useState(query.get('meetingId') || '');
   const [region, setRegion] = useState(query.get('region') || '');
+  const [meetingMode, setMeetingMode] = useState(MeetingMode.Attendee);
   const [localUserName, setLocalName] = useState('');
   const [theme, setTheme] = useState(() => {
     const storedTheme = localStorage.getItem('theme');
@@ -64,8 +68,10 @@ export function AppStateProvider({ children }: Props) {
     localUserName,
     theme,
     region,
+    meetingMode,
     toggleTheme,
-    setAppMeetingInfo
+    setAppMeetingInfo,
+    setMeetingMode,
   };
 
   return (

--- a/demo/meeting/src/types/index.ts
+++ b/demo/meeting/src/types/index.ts
@@ -34,3 +34,8 @@ export type ContentShareControlContextType = {
   toggleContentShare: () => Promise<void>;
   togglePauseContentShare: () => void;
 };
+
+export enum MeetingMode {
+  Spectator,
+  Attendee,
+};

--- a/demo/meeting/src/views/Meeting/index.tsx
+++ b/demo/meeting/src/views/Meeting/index.tsx
@@ -13,8 +13,10 @@ import { useNavigation } from '../../providers/NavigationProvider';
 import MeetingDetails from '../../containers/MeetingDetails';
 import MeetingControls from '../../containers/MeetingControls';
 import useMeetingEndRedirect from '../../hooks/useMeetingEndRedirect';
+import DynamicMeetingControls from '../../containers/DynamicMeetingControls';
+import { MeetingMode } from '../../types';
 
-const MeetingView = () => {
+const MeetingView = (props: { mode: MeetingMode, }) => {
   useMeetingEndRedirect();
   const { showNavbar, showRoster } = useNavigation();
 
@@ -26,7 +28,10 @@ const MeetingView = () => {
             className="videos"
             noRemoteVideoView={<MeetingDetails />}
           />
-          <MeetingControls />
+          {props.mode === MeetingMode.Spectator ?
+            <DynamicMeetingControls /> :
+            <MeetingControls />
+          }
         </StyledContent>
         <NavigationControl />
       </StyledLayout>

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,7 +168,12 @@ export { lightTheme, darkTheme, GlobalStyles, StyledReset } from './theme';
 export { VideoQuality } from './hooks/sdk/useSelectVideoQuality';
 
 // enums
-export { MeetingStatus, DevicePermissionStatus } from './types/index';
+export {
+  MeetingStatus,
+  DevicePermissionStatus,
+  DeviceLabels,
+  DeviceLabelTrigger,
+} from './types/index';
 export { Severity, ActionType } from './providers/NotificationProvider';
 
 // Class

--- a/src/providers/DevicesProvider/AudioInputProvider.tsx
+++ b/src/providers/DevicesProvider/AudioInputProvider.tsx
@@ -104,11 +104,18 @@ const AudioInputProvider: React.FC = ({ children }) => {
       }
     }
 
+    const callback = (): void => {
+      initAudioInput();
+    };
+
+    meetingManager.subscribeToDeviceLabelTriggerChange(callback);
+
     initAudioInput();
 
     return () => {
       isMounted = false;
       audioVideo?.removeDeviceChangeObserver(observer);
+      meetingManager.unsubscribeFromDeviceLabelTriggerChange(callback);
     };
   }, [audioVideo]);
 
@@ -135,7 +142,7 @@ const useAudioInputs = (props?: DeviceConfig): DeviceTypeContext => {
   let { devices } = context;
   const { selectedDevice } = context;
   const { selectDeviceError } = context;
-  
+
   if (needAdditionalIO) {
     const additionalAudioInputs = getFormattedDropdownDeviceOptions(
       AUDIO_INPUT

--- a/src/providers/DevicesProvider/AudioOutputProvider.tsx
+++ b/src/providers/DevicesProvider/AudioOutputProvider.tsx
@@ -59,11 +59,18 @@ const AudioOutputProvider: React.FC = ({ children }) => {
       }
     }
 
+    const callback = (): void => {
+      initAudioOutput();
+    };
+
+    meetingManager.subscribeToDeviceLabelTriggerChange(callback);
+
     initAudioOutput();
 
     return () => {
       isMounted = false;
       audioVideo?.removeDeviceChangeObserver(observer);
+      meetingManager.unsubscribeFromDeviceLabelTriggerChange(callback);
     };
   }, [audioVideo]);
 

--- a/src/providers/DevicesProvider/VideoInputProvider.tsx
+++ b/src/providers/DevicesProvider/VideoInputProvider.tsx
@@ -76,11 +76,18 @@ const VideoInputProvider: React.FC = ({ children }) => {
       }
     }
 
+    const callback = (): void => {
+      initVideoInput();
+    };
+
+    meetingManager.subscribeToDeviceLabelTriggerChange(callback);
+
     initVideoInput();
 
     return () => {
       isMounted = false;
       audioVideo?.removeDeviceChangeObserver(observer);
+      meetingManager.unsubscribeFromDeviceLabelTriggerChange(callback);
     };
   }, [audioVideo]);
 
@@ -108,7 +115,7 @@ const useVideoInputs = (props?: DeviceConfig): DeviceTypeContext => {
   let { devices } = context;
   const { selectedDevice } = context;
   const { selectDeviceError } = context;
-  
+
   if (needAdditionalIO) {
     const additionalVideoInputs = getFormattedDropdownDeviceOptions(
       additionalIOJSON

--- a/src/providers/MeetingProvider/types.ts
+++ b/src/providers/MeetingProvider/types.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { LogLevel } from 'amazon-chime-sdk-js';
+import { DeviceLabels, DeviceLabelTrigger } from '../../types';
 
 export enum DevicePermissionStatus {
   UNSET = 'UNSET',
@@ -13,6 +14,7 @@ export enum DevicePermissionStatus {
 export interface MeetingJoinData {
   meetingInfo: any;
   attendeeInfo: any;
+  deviceLabels?: DeviceLabels | DeviceLabelTrigger;
 }
 
 export interface AttendeeResponse {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -61,4 +61,13 @@ export enum DevicePermissionStatus {
   IN_PROGRESS = 'IN_PROGRESS',
   GRANTED = 'GRANTED',
   DENIED = 'DENIED',
-}
+};
+
+export enum DeviceLabels {
+  None,
+  Audio,
+  Video,
+  AudioAndVideo,
+};
+
+export type DeviceLabelTrigger = () => Promise<MediaStream>;


### PR DESCRIPTION
**Issue #379 :**

**Description of changes:**
- Add controls to device permission request in `DeviceProvider` and `MeetingManager` to suppress the permission request, and invoke it.
- Add a checkbox in `MeetingForm` to allow use join the meeting  without device preview process.
- Add a `DevicePermissionControl` component, which is used in `MeetingControls`.
- Change the `MeetingControls` to be rendered conditionally based on `devicePermissionStatus`.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
    #### Normal Meeting
    * User joins a meeting without selecting "Join w/o Audio and Video"
    * Device permission prompt pops up for audio and video device
    * Device setup page works as usual and join the meeting
    * Check `MeetingControl` works as usual
    #### View-only Meeting
    * User joins a meeting with selecting "Join w/o Audio and Video"
    * No permission prompt pops up
    * Device setup page is skipped, redirect to Meeting page directly
    * `MeetingControl` display only `DevicePermissionControl` and `EndMeetingControl` like below:
    ![image](https://user-images.githubusercontent.com/20471438/121410705-b8fdbe80-c917-11eb-9c81-74ae8ee9e5f5.png)

    * Click 'Device' button
    * Device permission prompt for audio and video device pops up
    * Click 'Allow' and `MeetingControl` transforms to the original one like below:
    ![image](https://user-images.githubusercontent.com/20471438/121411189-388b8d80-c918-11eb-8b79-39f7ecb06936.png)
    * Check `MeetingControl` works as usual
1. If you made changes to the component library, have you provided corresponding documentation changes?
Yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.