### PR TITLE
[Do not merge] Correct icon button border in dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add or remove event listener only when `el.current` reference is valid
   in `useFocusIn` and `useMouseMove` hooks.
 - Fix bug related to `PreviewVideo` component not releasing media stream when unmounted.
+- Correct `IconButton` border in dark theme.
 
 ### Added
 

--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -175,7 +175,7 @@ const buttons = {
     shadow: shadows.none,
     static: {
       bgd: 'transparent',
-      border: `0 solid ${colors.greys.black}`,
+      border: `0.03125rem solid transparent`,
       text: colors.greys.grey20,
       shadow: 'none'
     },


### PR DESCRIPTION
**Issue #:** 
#497 

**Description of changes:**
When `IconButton` is used in dark theme, the static border is set to 0,
while in light theme it is set to 0.03125rem.

On hover, in dark theme, the border is set to 0.03125rem which results
into a jumpy behavior as the dimension changes from 0 to 0.03125rem.

This change sets the border color to be transparent and matches
the border dimension with light theme.


**Testing**
1. Have you successfully run `npm run build:release` locally? Yes.

2. How did you test these changes?
2.1 Run demo/meeting app and join the meeting.
2.2 Before this change if you hover over icon buttons in the roster header (where there is a search icon) the roster header kind of shift a little due to a border changing from 0 to 0.03125rem as explained.
2.3 After this change it should not shift.

3. If you made changes to the component library, have you provided corresponding documentation changes?
NA. UI change only.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
