### PR TITLE
Fix device permission doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Add browser flag for node resolve in rollup config.
+- Fix device permission doc to remove reference to meetingStatus
 
 ### Added
 

--- a/src/hooks/sdk/docs/useDevicePermissionStatus.stories.mdx
+++ b/src/hooks/sdk/docs/useDevicePermissionStatus.stories.mdx
@@ -44,9 +44,9 @@ const App = () => (
 );
 
 const MyChild = () => {
-  const meetingStatus = useMeetingStatus();
+  const permission = useDevicePermissionStatus();
 
-  return <p>Meeting Status: {meetingStatus}</p>;
+  return <p>Device Permission Status: {permission}</p>;
 };
 ```
 


### PR DESCRIPTION
**Issue #506 :** 

**Description of changes:**
Update device permission doc to actually use device permission hook instead of meeting status.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes? Just documentation update.

3. If you made changes to the component library, have you provided corresponding documentation changes? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
