### PR TITLE
Run npm install before running npm audit fixes in prebuild script

### DIFF
--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -94,6 +94,8 @@ When bot submits PR two git context parameters are set.
 
 if (!process.env.GITHUB_ACTIONS) {
   // Pull in npm audit fixes automatically
+  logger.log("Running npm install");
+  spawnOrFail('npm', ['install']);
   logger.log("Running npm audit fix");
   spawnOrFail('npm', ['audit', 'fix']);
   logger.log("Completed npm audit fix");


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Add a step in prebuild script to run npm install before running npm audit fixes. Otherwise the npm audio fixes command will fail with the following error if we bump the SDK version from 2.9.0 to 2.10.0:
```
Command npm failed with exit code 1 signal null
npm ERR! code ELOCKVERIFY
npm ERR! Errors were found in your package-lock.json, run  npm install  to fix them.
npm ERR!     Invalid: lock file's amazon-chime-sdk-js@2.9.0 does not satisfy amazon-chime-sdk-js@^2.10.0
```

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? N/A

3. If you made changes to the component library, have you provided corresponding documentation changes? No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
