### PR TITLE
Move storybook deploy to when PR merge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    name: Deploy Demo App
+    name: Deploy Demo App and Storybook
     runs-on: ubuntu-latest
     env:
         AWS_DEFAULT_REGION: us-east-1
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node environment
         uses: actions/setup-node@v1
         with:
-          node-version: 15
+          node-version: 16
       - name: Install Yalc
         run: sudo npm i yalc -g
       - name: NPM Install
@@ -38,3 +38,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/demo/meeting/serverless
           node ./deploy.js -r us-east-1 -b chime-sdk-components-demo-canary -s chime-sdk-components-demo-canary -l
+      - name: Publish Storybook Documentation
+        run: npm run deploy-storybook -- --ci
+        env:
+          GH_TOKEN: chime-sdk-component-bot:${{ secrets.GITHUBPAGES}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node environment
         uses: actions/setup-node@v1
         with:
-          node-version: 15
+          node-version: 16
           registry-url: https://registry.npmjs.org/
       - name: NPM Install
         run: npm install
@@ -23,7 +23,3 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-      - name: Publish Storybook Documentation
-        run: npm run deploy-storybook -- --ci
-        env:
-          GH_TOKEN: chime-sdk-component-bot:${{ secrets.GITHUBPAGES}}


### PR DESCRIPTION
**Description of changes:**
Move storybook deploy to when PR merge instead of when publishing to NPM as before.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes? N/A

3. If you made changes to the component library, have you provided corresponding documentation changes? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
