### PR TITLE
Fix missing key prop in RosterAttendeeWrapper

### DIFF
--- a/demo/meeting/src/components/RosterAttendeeWrapper.tsx
+++ b/demo/meeting/src/components/RosterAttendeeWrapper.tsx
@@ -18,7 +18,6 @@ const RosterAttendeeWrapper: React.FC<Props> = ({ attendeeId }) => {
   const { videoEnabled } = useAttendeeStatus(attendeeId);
   return (
     <RosterAttendee
-      key={attendeeId}
       attendeeId={attendeeId}
       menu={
         videoEnabled ? <VideoStreamMetrics attendeeId={attendeeId} /> : null

--- a/demo/meeting/src/containers/MeetingRoster.tsx
+++ b/demo/meeting/src/containers/MeetingRoster.tsx
@@ -31,7 +31,7 @@ const MeetingRoster = () => {
 
   const attendeeItems = attendees.map((attendee: any) => {
     const { chimeAttendeeId } = attendee || {};
-    return <RosterAttendeeWrapper attendeeId={chimeAttendeeId} />;
+    return <RosterAttendeeWrapper key={chimeAttendeeId} attendeeId={chimeAttendeeId} />;
   });
 
   return (


### PR DESCRIPTION
**Issue #531 :** 

**Description of changes:**
Move the `key` prop from children `RosterAttendee` to parent `RosterAttendeeWrapper`.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Check the meeting demo, it renders correctly and the warning disappears.

3. If you made changes to the component library, have you provided corresponding documentation changes? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
