### PR TITLE
[Demo] Enable sse for SQS in meeting serverless demo

### DIFF
--- a/demo/meeting/serverless/template.yaml
+++ b/demo/meeting/serverless/template.yaml
@@ -93,8 +93,37 @@ Resources:
       KeySchema:
         - AttributeName: "AttendeeId"
           KeyType: HASH
+  ChimeKMSKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: Custom KMS Key with Chime access
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+        - Sid: Allow access for Chime Service
+          Effect: Allow
+          Principal:
+            Service: chime.amazonaws.com
+          Action:
+            - kms:GenerateDataKey
+            - kms:Decrypt
+          Resource: '*'
+        - Sid: Enable IAM User Permissions
+          Effect: Allow
+          Principal:
+            AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+          Action: kms:*
+          Resource: '*'
+  ChimeKMSAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: alias/ChimeKMS
+      TargetKeyId:
+        Ref: ChimeKMSKey
   MeetingNotificationsQueue:
     Type: AWS::SQS::Queue
+    Properties:
+      KmsMasterKeyId: alias/ChimeKMS
   ChimeSdkIndexLambda:
     Type: AWS::Serverless::Function
     Properties:
@@ -189,6 +218,13 @@ Resources:
           Properties:
             Queue: !GetAtt MeetingNotificationsQueue.Arn
             BatchSize: 10
+      Policies:
+        - Statement:
+          - Sid: ChimeSQSQueueLambdaPolicy
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource: '*'
   ChimeEventBridgeLambda:
     Type: AWS::Serverless::Function
     Condition: ShouldUseEventBridge


### PR DESCRIPTION
**Description of changes:**
Enable SSE for SQS queue in serverless demo following these resouces:
- https://docs.aws.amazon.com/chime/latest/dg/mtgs-sdk-notifications.html
- https://docs.amazonaws.cn/en_us/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-lambda-function-trigger.html

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes? 

- Deployed the meeting app with this template change and observed default SSE added to the queue created by the CF template with the custom CMS Key with the correct permissions for chime services.
- Tested joining, re-joining, ending and leaving, video on/off.
- Verify in the lambda cloudwatch log that we received meeting events.


3. If you made changes to the component library, have you provided corresponding documentation changes? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
