### PR TITLE
[Demo] Add stack name to kms alias in serverless demo

### DIFF
--- a/demo/meeting/serverless/template.yaml
+++ b/demo/meeting/serverless/template.yaml
@@ -117,13 +117,13 @@ Resources:
   ChimeKMSAlias:
     Type: AWS::KMS::Alias
     Properties:
-      AliasName: alias/ChimeKMS
+      AliasName: !Sub alias/ChimeKMS-${AWS::StackName}
       TargetKeyId:
         Ref: ChimeKMSKey
   MeetingNotificationsQueue:
     Type: AWS::SQS::Queue
     Properties:
-      KmsMasterKeyId: alias/ChimeKMS
+      KmsMasterKeyId: !Sub alias/ChimeKMS-${AWS::StackName}
   ChimeSdkIndexLambda:
     Type: AWS::Serverless::Function
     Properties:


### PR DESCRIPTION
**Description of changes:**
Add the stack name to the kms alias in serverless template to make sure its unique for each stack.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes?
Manually deployed another stack in the same aws account and verified that it worked.

3. If you made changes to the component library, have you provided corresponding documentation changes? No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
