### PR TITLE
Fix wrong import statement in meeting demo

### DIFF
--- a/demo/meeting/src/containers/DevicePermissionControl/DevicePermissionControl.tsx
+++ b/demo/meeting/src/containers/DevicePermissionControl/DevicePermissionControl.tsx
@@ -1,8 +1,7 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ControlBarButton, Cog, useMeetingManager, Camera, Sound, Dots, } from 'amazon-chime-sdk-component-library-react';
-import { DeviceLabels } from 'amazon-chime-sdk-component-library-react/lib/types';
+import { ControlBarButton, Cog, useMeetingManager, Camera, Sound, Dots, DeviceLabels, } from 'amazon-chime-sdk-component-library-react';
 import React from 'react';
 import DevicePermissionPrompt from '../DevicePermissionPrompt';
 

--- a/demo/meeting/src/containers/DynamicMeetingControls/index.tsx
+++ b/demo/meeting/src/containers/DynamicMeetingControls/index.tsx
@@ -13,13 +13,13 @@ import {
   Dots,
   useDevicePermissionStatus,
   DevicePermissionStatus,
+  DeviceLabels,
 } from 'amazon-chime-sdk-component-library-react';
 
 import EndMeetingControl from '../EndMeetingControl';
 import { useNavigation } from '../../providers/NavigationProvider';
 import { StyledControls } from './Styled';
 import DevicePermissionControl from '../DevicePermissionControl/DevicePermissionControl';
-import { DeviceLabels } from 'amazon-chime-sdk-component-library-react/lib/types';
 
 const DynamicMeetingControls = () => {
   const { toggleNavbar, closeRoster, showRoster } = useNavigation();

--- a/demo/meeting/src/containers/MeetingForm/index.tsx
+++ b/demo/meeting/src/containers/MeetingForm/index.tsx
@@ -13,7 +13,8 @@ import {
   useMeetingManager,
   Modal,
   ModalBody,
-  ModalHeader
+  ModalHeader,
+  DeviceLabels,
 } from 'amazon-chime-sdk-component-library-react';
 
 import { getErrorContext } from '../../providers/ErrorProvider';
@@ -25,7 +26,6 @@ import RegionSelection from './RegionSelection';
 import { fetchMeeting, createGetAttendeeCallback } from '../../utils/api';
 import { useAppState } from '../../providers/AppStateProvider';
 import { MeetingMode } from '../../types';
-import { DeviceLabels } from 'amazon-chime-sdk-component-library-react/lib/types';
 
 const MeetingForm: React.FC = () => {
   const meetingManager = useMeetingManager();


### PR DESCRIPTION
**Issue :** 
Several import statements import enum `DeviceLabels` from a wrong place.

**Description of changes:**
Fix the import statements.

**Testing**
1. Have you successfully run `npm run build:release` locally?
  Yes

2. How did you test these changes?
  Run meeting demo and it renders correctly and functions well.

3. If you made changes to the component library, have you provided corresponding documentation changes?
  N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
