### PR TITLE
Fix the issue that the device is not selected in Firefox

### DIFF
--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -344,15 +344,9 @@ export class MeetingManager implements AudioVideoObserver {
   async listAndSelectDevices(): Promise<void> {
     await this.updateDeviceLists();
 
-    let hasAudioInput = false, hasAudioOutput = false, hasVideoInput = false;
-    const devices = await navigator.mediaDevices.enumerateDevices();
-    for (const device of devices) {
-      if (device.label) {
-        if (device.kind === "audioinput") hasAudioInput = true;
-        if (device.kind === "audiooutput") hasAudioOutput = true;
-        if (device.kind === "videoinput") hasVideoInput = true;
-      }
-    }
+    const hasAudioInput = this.audioInputDevices?.some(value => value.label) || false;
+    const hasAudioOutput = this.audioOutputDevices?.some(value => value.label) || false;
+    const hasVideoInput = this.videoInputDevices?.some(value => value.label) || false;
 
     if (
       hasAudioInput &&


### PR DESCRIPTION
**Issue:**
The device is not selected when user joins a meeting in Firefox. 
#### Cause
* The `enumerateDevices()` in original  line 348 doesn't `await` the `getUserMedia()` call from `updateDeviceLists` and `DeviceProvider`
* So the `hasAudioInput`, `hasAudioOutput` and `hasVideoInput` keep a `false` status 
* After user navigates to `DevicePage`, although the devices are listed there, but none of them is selected. 
* This cause no video preview and no microphone activity in `DevicePage`. 
* After user joins the meeting, the selected device for audio input and video input are 'None'.

**Description of changes:**

Slightly modified the logic of checking the device label in `MeetingManager`.

Replace the
```ts
const devices = await navigator.mediaDevices.enumerateDevices();
```
with 
```ts
this.audioInputDevices, this.audioOutputDevices, this.videoInputDevices
```
These device info are update by `this.updateDevicesLists`, so the status of `hasAudioInput`, `hasAudioOutput` and `hasVideoInput` are consistency with the actual status.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes?
    Test the meeting demo in Chrome, Firefox and Safari, to ensure it functions well.

3. If you made changes to the component library, have you provided corresponding documentation changes? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
