### PR TITLE
fix: fix close tag typo in .mdx file

### DIFF
--- a/src/providers/DevicesProvider/docs/AudioInputProvider.stories.mdx
+++ b/src/providers/DevicesProvider/docs/AudioInputProvider.stories.mdx
@@ -58,7 +58,7 @@ const MyChild = () => {
       <p>Current Selected DeviceId: {selectedDevice}</p>
       <p>Devices</p>
       <ul>{items}</ul>
-      {selectDeviceError && (<p>{selectDeviceError.message}<p/>)}
+      {selectDeviceError && (<p>{selectDeviceError.message}</p>)}
     </div>
   );
 };

--- a/src/providers/DevicesProvider/docs/VideoInputProvider.stories.mdx
+++ b/src/providers/DevicesProvider/docs/VideoInputProvider.stories.mdx
@@ -58,7 +58,7 @@ const MyChild = () => {
       <p>Current Selected DeviceId: {selectedDevice}</p>
       <p>Devices</p>
       <ul>{items}</ul>
-      {selectDeviceError && (<p>{selectDeviceError.message}<p/>)}
+      {selectDeviceError && (<p>{selectDeviceError.message}</p>)}
     </div>
   );
 };

--- a/src/providers/DevicesProvider/docs/useAudioInputs.stories.mdx
+++ b/src/providers/DevicesProvider/docs/useAudioInputs.stories.mdx
@@ -59,7 +59,7 @@ const MyChild = () => {
       <p>Current Selected DeviceId: {selectedDevice}</p>
       <p>Devices</p>
       <ul>{items}</ul>
-      {selectDeviceError && (<p>{selectDeviceError.message}<p/>)}
+      {selectDeviceError && (<p>{selectDeviceError.message}</p>)}
     </div>
   );
 };

--- a/src/providers/DevicesProvider/docs/useVideoInputs.stories.mdx
+++ b/src/providers/DevicesProvider/docs/useVideoInputs.stories.mdx
@@ -59,7 +59,7 @@ const MyChild = () => {
       <p>Current Selected DeviceId: {selectedDevice}</p>
       <p>Devices</p>
       <ul>{items}</ul>
-      {selectDeviceError && (<p>{selectDeviceError.message}<p/>)}
+      {selectDeviceError && (<p>{selectDeviceError.message}</p>)}
     </div>
   );
 };


### PR DESCRIPTION
**Issue #:** 
Find typo in some .mdx files when using the storybook
**Description of changes:**
Fix with the correct close tags

**Testing**
1. Have you successfully run `npm run build:release` locally?
yes
2. How did you test these changes?
make syntax correct
3. If you made changes to the component library, have you provided corresponding documentation changes?
N/A
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
