### PR TITLE
Fix the issue isVideoEnabled is not correct after unmounting the PreviewVideo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Doc] Add explanation for the limitation of the `useDevicePermissionStatus` hook in storybook.
 - Add support to override event reporter for client event ingestion once enabled in the Amazon Chime SDK for JavaScript. For more information check the [Client Event Ingestion guide](https://aws.github.io/amazon-chime-sdk-js/modules/clientevent_ingestion.html) in the Amazon Chime SDK for JavaScript.
+- Add new function `setIsVideoEnabled` in `useLocalVideo` hook.
 
 ### Changed
 
-### Removed
+- Set the `isVideoEnabled` to `false` when stopping video preview.
 
+### Removed
 
 ## [2.6.0] - 2021-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [Doc] Add explanation for the limitation of the `useDevicePermissionStatus` hook in storybook.
+- [Doc] Add how-to doc for view-only mode in storybook.
 - Add support to override event reporter for client event ingestion once enabled in the Amazon Chime SDK for JavaScript. For more information check the [Client Event Ingestion guide](https://aws.github.io/amazon-chime-sdk-js/modules/clientevent_ingestion.html) in the Amazon Chime SDK for JavaScript.
 - Add new function `setIsVideoEnabled` in `useLocalVideo` hook.
 

--- a/src/components/sdk/PreviewVideo/PreviewVideo.stories.mdx
+++ b/src/components/sdk/PreviewVideo/PreviewVideo.stories.mdx
@@ -6,9 +6,8 @@ import { PreviewVideo } from './';
 # PreviewVideo
 
 The `PreviewVideo` component renders a preview of the local user's video. If there is no available video input, the video will be blank. 
-When the `PreviewVideo` component is unmounted, it will release the media streams associated with the video element it references.
 
-A `PreviewVideo` is typically used on a pre-meeting view, or a device settings page.
+A `PreviewVideo` is typically used on a pre-meeting view, or a device settings page. The React SDK depends on the Amazon Chime SDK for JavaScript, wherein, a single video stream is attached to a video element at a time. Hence, if `PreviewVideo` and `LocalVideo` component both are rendered on the same page and if both are enabled, stopping the video preview in `PreviewVideo` component will result into disconnecting the video stream for `LocalVideo` as well showing a black screen.
 
 ## Importing
 

--- a/src/components/sdk/PreviewVideo/index.tsx
+++ b/src/components/sdk/PreviewVideo/index.tsx
@@ -9,6 +9,7 @@ import VideoTile from '../../ui/VideoTile';
 import styled from 'styled-components';
 import { BaseSdkProps } from '../Base';
 import { useVideoInputs } from '../../../providers/DevicesProvider';
+import { useLocalVideo } from '../../../providers/LocalVideoProvider';
 
 const StyledPreview = styled(VideoTile)`
   height: auto;
@@ -23,6 +24,7 @@ export const PreviewVideo: React.FC<BaseSdkProps> = (props) => {
   const audioVideo = useAudioVideo();
   const videoEl = useRef<HTMLVideoElement>(null);
   const { selectedDevice } = useVideoInputs();
+  const { isVideoEnabled, setIsVideoEnabled } = useLocalVideo();
 
   useEffect(() => {
     if (!audioVideo || !selectedDevice || !videoEl.current) {
@@ -49,6 +51,7 @@ export const PreviewVideo: React.FC<BaseSdkProps> = (props) => {
 
       if (videoElement) {
         audioVideo.stopVideoPreviewForVideoInput(videoElement);
+        if (isVideoEnabled) setIsVideoEnabled(false);
       }
     };
   }, [audioVideo, selectedDevice]);

--- a/src/providers/LocalVideoProvider/docs/LocalVideoProvider.stories.mdx
+++ b/src/providers/LocalVideoProvider/docs/LocalVideoProvider.stories.mdx
@@ -2,7 +2,12 @@
 
 # LocalVideoProvider
 
-The `LocalVideoProvider` provides the local video status, video tile id associated with the local user's video and a function to toggle their video.
+The `LocalVideoProvider` provides video tile id associated with the local user's video, `isVideoEnabled` specifying the local video status, a function to set the value of `isVideoEnabled` and a function to toggle user's local video. 
+
+The React SDK depends on the Amazon Chime SDK for JavaScript, wherein, a single video stream is attached to a video element at a time. Hence, if `PreviewVideo` and `LocalVideo` component both are rendered on the same page and if both are enabled, stopping the video preview in `PreviewVideo` component will result into disconnecting the video stream for `LocalVideo` as well showing a black screen.
+
+To start/stop a video preview, please check `PreviewVideo` component [documentation](/?path=/story/sdk-components-previewvideo--page).
+To start/stop user's local video, use `toggleVideo` function from the `LocalVideoProvider`.
 
 ## State
 
@@ -12,7 +17,11 @@ The `LocalVideoProvider` provides the local video status, video tile id associat
   tileId: null | number;
 
   // Whether or not the local user has video enabled
+  // This does not tell whether the video preview from PreviewVideo component is enabled or not.
   isVideoEnabled: boolean;
+
+  // A function to set the value of `isVideoEnabled`
+  setIsVideoEnabled: (isEnabled: boolean) => void;
 
   // A function that toggles the local user's video
   toggleVideo: () => Promise<void>;
@@ -39,9 +48,19 @@ const App = () => (
 );
 
 const MyChild = () => {
-  const { isVideoEnabled, toggleVideo } = useLocalVideo();
+  const { tileId, isVideoEnabled, setIsVideoEnabled, toggleVideo } = useLocalVideo();
 
   return (
+    <p>Tile ID: {tileId}</p>
+
+    <p>
+      {setIsVideoEnabled ? 'LocalVideo is enabled' : 'LocalVideo is disabled'}
+    </p>
+
+    <button onClick={() => setIsVideoEnabled(true)}>
+      Set isVidelEnabled to true
+    </button>
+    
     <button onClick={toggleVideo}>
       {isVideoEnabled ? 'Stop your video' : 'Start your video'}
     </button>

--- a/src/providers/LocalVideoProvider/docs/useLocalVideo.stories.mdx
+++ b/src/providers/LocalVideoProvider/docs/useLocalVideo.stories.mdx
@@ -2,7 +2,12 @@
 
 # useLocalVideo
 
-The `useLocalVideo` hook returns the video state of the local user, and a function to toggle their video.
+The `useLocalVideo` hook returns video tile id associated with the local user's video, `isVideoEnabled` specifying the local video status, a function to set the value of `isVideoEnabled` and a function to toggle user's local video.
+
+The React SDK depends on the Amazon Chime SDK for JavaScript, wherein, a single video stream is attached to a video element at a time. Hence, if `PreviewVideo` and `LocalVideo` component both are rendered on the same page and if both are enabled, stopping the video preview in `PreviewVideo` component will result into disconnecting the video stream for `LocalVideo` as well showing a black screen.
+
+To start/stop a video preview, please check `PreviewVideo` component [documentation](/?path=/story/sdk-components-previewvideo--page).
+To start/stop user's local video, use `toggleVideo` function from the `LocalVideoProvider`.
 
 ### Return Value
 
@@ -12,7 +17,11 @@ The `useLocalVideo` hook returns the video state of the local user, and a functi
   tileId: null | number;
 
   // Whether or not the local user has video enabled
+  // This does not tell whether the video preview from `PreviewVideo` component is enabled or not.
   isVideoEnabled: boolean;
+
+  // A function to set the value of `isVideoEnabled`
+  setIsVideoEnabled: (isEnabled: boolean) => void;
 
   // A function that toggles the local user's video
   toggleVideo: () => Promise<void>;
@@ -43,9 +52,19 @@ const App = () => (
 );
 
 const MyChild = () => {
-  const { isVideoEnabled, toggleVideo } = useLocalVideo();
+  const { tileId, isVideoEnabled, setIsVideoEnabled, toggleVideo } = useLocalVideo();
 
   return (
+    <p>Tile ID: {tileId}</p>
+
+    <p>
+      {setIsVideoEnabled ? 'LocalVideo is enabled' : 'LocalVideo is disabled'}
+    </p>
+
+    <button onClick={() => setIsVideoEnabled(true)}>
+      Set isVideoEnabled to true
+    </button>
+    
     <button onClick={toggleVideo}>
       {isVideoEnabled ? 'Stop your video' : 'Start your video'}
     </button>

--- a/src/providers/LocalVideoProvider/index.tsx
+++ b/src/providers/LocalVideoProvider/index.tsx
@@ -74,11 +74,12 @@ const LocalVideoProvider: React.FC = ({ children }) => {
     });
   }, [audioVideo, tileId]);
 
-  const value = useMemo(() => ({ isVideoEnabled, toggleVideo, tileId }), [
-    isVideoEnabled,
-    toggleVideo,
+  const value = useMemo(() => ({ tileId, isVideoEnabled, setIsVideoEnabled, toggleVideo, }), [
     tileId,
-  ]);
+    isVideoEnabled,
+    setIsVideoEnabled,
+    toggleVideo,
+    ]);
 
   return <Context.Provider value={value}>{children}</Context.Provider>;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,7 @@ export type LocalAudioOutputContextType = {
 export type LocalVideoContextType = {
   tileId: null | number;
   isVideoEnabled: boolean;
+  setIsVideoEnabled: (isEnabled: boolean) => void;
   toggleVideo: () => Promise<void>;
 };
 
@@ -44,7 +45,7 @@ export enum MeetingStatus {
   Failed,
   Ended,
   JoinedFromAnotherDevice,
-}
+};
 
 export type RosterAttendeeType = {
   chimeAttendeeId: string;


### PR DESCRIPTION
**Issue #529 :** 
If `PreviewVideo` and `LocalVideo` are used at the same time, unmounting `PreviewVideo` leads to the closing of `LocalVideo` stream, but the `isVideoEnabled` is still `true`, resulting a blank `LocalVideo` tile, and the status of the video button in MeetingControl is still on.

**Description of changes:**
- Add `setIsVideoEnabled` in `useLocalVideo` hook to set the value of the `isVidelEnabled`.
- Set the value of `isVideoEnabled` to `false` after unmounting the `PreviewVideo` to correct its status.

**Testing**
1. Have you successfully run `npm run build:release` locally? 
Yes

2. How did you test these changes?
- Run meeting demo and make sure`LocalVideo` and `PreviewVideo` work well, the states are correct.
- Modify meeting demo to allow opening a dialog for `PreviewVideo` on Meeting Page while `LocalVideo` is enabled, check the states and function are correct.

3. If you made changes to the component library, have you provided corresponding documentation changes?
Yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
