### PR TITLE
Add explanation for the limitation of the `useDevicePermissionStatus'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+### Added
+
+- [Doc] Add explanation for the limitation of the `useDevicePermissionStatus` hook in storybook.
+
+### Changed
+
+### Removed
+
 ## [2.6.0] - 2021-06-16
 
 ### Fixed

--- a/src/hooks/sdk/docs/useDevicePermissionStatus.stories.mdx
+++ b/src/hooks/sdk/docs/useDevicePermissionStatus.stories.mdx
@@ -4,6 +4,8 @@
 
 The `useDevicePermissionStatus` hook returns the device permission status from the enum below.
 
+This hook cannot read the device permissions from the browser due to browsers' lack of support of such a querying function. Hence, the `permission` will be always set to `UNSET` when the application starts.
+
 ```javascript
 enum DevicePermissionStatus {
   UNSET = 'UNSET',


### PR DESCRIPTION
**Issue #:** 
The `useDevicePermissionStatus` hook cannot read the device permissions from the browser due to browsers' lack of support of such a querying function.

**Description of changes:**
Add doc in storybook to explain the limitation of the `useDevicePermissionStatus' hook.

**Testing**
1. Have you successfully run `npm run build:release` locally? 
Yes

2. How did you test these changes?
N/A, doc changes

3. If you made changes to the component library, have you provided corresponding documentation changes?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
