### PR TITLE
Add Github Environments to enable external contributions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,20 +11,18 @@ jobs:
   build:
     name: Build and Run Unit Tests
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [16.x]
+    environment: 
+      name: CI Workflow
 
     steps:
       - name: Checkout Package
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 16
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 16.x
       - name: Clean Install
         run: npm ci
       - name: Build


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**

Test to incorporate github environments into our repo to enable external contributions. This will impact the flow of contributing:
1. The PR will be submitted
2. Someone from the chime-sdk team will need to review the code, and approve the deployment of the CI Workflow environment. The CI Workflow Github action will execute within the deployment. 
3. Auto merge is not enable yet, but we may enable auto merge so that once the deployment has begun, it will merge automatically once it passes the Github Actions CI Workflow. 

**Testing**
1. Have you successfully run `npm run build:release` locally?
yes
2. How did you test these changes?
n/a

3. If you made changes to the component library, have you provided corresponding documentation changes?
4. n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
