### PR TITLE
Exclude the uuid module from the Rollup bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Exclude the uuid module from the Rollup bundle so that the Chime SDK React Components Library uses the uuid module from the builder's node_modules
+
 ### Added
 
 - Add optional parameter `deviceLabels: DeviceLabels | DeviceLabelTrigger` in `meetingManager.listAndSelectDevices()` to let builder indicate the type of devices they want to select.

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,6 +19,7 @@ export default {
       sourcemap: true
     }
   ],
+  external: ['uuid'],
   plugins: [
     peerDepsExternal(),
     resolve({


### PR DESCRIPTION
**Issue #:** 
https://github.com/aws/amazon-chime-sdk-component-library-react/issues/569

**Description of changes:**
We enable the `browser` flag in [@rollup/plugin-node-resolve](https://www.npmjs.com/package/@rollup/plugin-node-resolve), so the Rollup includes the browser version of the `uuid` module in the final output file. 

https://github.com/aws/amazon-chime-sdk-component-library-react/blob/dcc25b6833f79d160056a217e6ad1890958816da/rollup.config.js#L24-L26
 
In this PR, we exclude the `uuid` module from the output file, so the Chime SDK React Components Library uses the `uuid` installed in the customer's `node_modules`.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes. Running the command keeps generating the `package-lock.json` with lockfileVersion 1 (npm 6), so I did not include lock files.

2. How did you test these changes? I tested the change in three sample apps with the following bundles:
    - Webpack 4 (the existing component demo): Webpack 4 includes polyfills for Node.
    - Webpack 5: Webpack 5 does not include polyfills for Node.
    - Razzle (server-side rendering)

3. If you made changes to the component library, have you provided corresponding documentation changes?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
