### PR TITLE
Add support to customize the downlink policy of the meeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add optional parameter `deviceLabels: DeviceLabels | DeviceLabelTrigger` in `meetingManager.listAndSelectDevices()` to let builder indicate the type of devices they want to select.
-- Add several how-to docs in storybook.
+- Add optional parameter `logger` and `videoDownlinkBandwidthPolicy` in `ManagerConfig` to pass in the `Logger` object and `VideoDownlinkBandwidthPolicy` object that you want to be used in the meeting session.
+- [Doc] Add several how-to docs in storybook.
 
 ### Changed
 

--- a/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
+++ b/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
@@ -34,7 +34,7 @@ const MyApp = () => {
 
 ## Constructor
 
-Accepts a config object of `logLevel`, `postLogConfig`, and `simulcastEnabled` that will be used when initializing a meeting session. See [MeetingProvider](/docs/sdk-providers-meetingprovider--page) documentation for more details.
+Accepts a config object of `logLevel`, `postLogConfig`, `simulcastEnabled`, `logger` and `videoDownlinkBandwidthPolicy` that will be used when initializing a meeting session. See [MeetingProvider](/docs/sdk-providers-meetingprovider--page) documentation for more details.
 
 ## Interface
 
@@ -53,6 +53,10 @@ interface MeetingJoinData {
 
   // The response of calling chime:CreateAttendee from your server.
   attendeeInfo: any;
+
+  // The kind of device for which the browser requests permission.
+  // Or override the default device label trigger in the Amazon Chime SDK for JavaScript.
+  deviceLabels?: DeviceLabels | DeviceLabelTrigger;
 
   // Override the default event reporter in the Amazon Chime SDK for JavaScript.
   eventReporter: EventReporter;

--- a/src/providers/MeetingProvider/docs/MeetingProvider.stories.mdx
+++ b/src/providers/MeetingProvider/docs/MeetingProvider.stories.mdx
@@ -65,6 +65,7 @@ const Root = () => {
 ### Prop values
 
 #### logLevel
+
 The level of logging you want with your meeting session. It is defined by the [LogLevel](https://aws.github.io/amazon-chime-sdk-js/enums/loglevel.html) enum in `amazon-chime-sdk-js`.
 
 ```javascript
@@ -77,7 +78,8 @@ enum LogLevel {
 }
 ```
 
-#### postLogger
+#### postLogConfig
+
 Configuration for setting up a [MeetingSessionPOSTLogger](https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionpostlogger.html).
 
 ```javascript
@@ -91,11 +93,50 @@ interface PostLogConfig = {
 ```
 
 #### simulcastEnabled
+
 To enable simulcast for the meeting pass the `simulcastEnabled` prop with value set to `true`. By default, it is `false`.
 For more information on Simulcast, check Amazon Chime JS SDK [simulcast guide](https://github.com/aws/amazon-chime-sdk-js/blob/master/guides/05_Simulcast.md).
 
+#### logger
+
+The `Logger` object that you want to be used in the meeting session.
+If you pass in a `Logger` object using this parameter, the `MeetingManager` will use this object instead of creating a logger based on `logLevel` and `postLogConfig` to initialize the meeting session.
+
+#### videoDownlinkBandwidthPolicy
+
+The `VideoDownlinkBandwidthPolicy` object that you want to be used in the meeting session.
+For more information on `VideoDownlinkBandwidthPolicy`, check Amazon Chime JS SDK [priority downlink policy guide](https://aws.github.io/amazon-chime-sdk-js/modules/prioritybased_downlink_policy.html).
+
+For example, to use the `VideoPriorityBasedPolicy` in the meeting:
+
+```jsx
+import {
+  LogLevel,
+  ConsoleLogger,
+  VideoPriorityBasedPolicy,
+} from 'amazon-chime-sdk-js';
+import { MeetingProvider } from 'amazon-chime-sdk-component-library-react';
+
+const Root = () => {
+  const logger = new ConsoleLogger('SDK', LogLevel.INFO);
+  const videoDownlinkBandwidthPolicy = new VideoPriorityBasedPolicy(logger);
+
+  const meetingConfig = {
+    logger,
+    videoDownlinkBandwidthPolicy,
+  };
+
+  return (
+    <MeetingProvider {...meetingConfig}>
+      <MyApp />
+    </MeetingProvider>
+  );
+};
+```
+
 #### meetingManager
-There may be use cases to re-use the same `MeetingManager` instance accross multiple different `MeetingProvider`s.
+
+There may be use cases to re-use the same `MeetingManager` instance across multiple different `MeetingProvider`s.
 Hence, you can create a new `MeetingManager` instance and then pass it as a prop to your `MeetingProvider`s. If not passed,
 a new `MeetingManager` instance will be created internally with each `MeetingProvider` when rendered; and, 
 you will get the `MeetingManager` instance associated with that particular `MeetingProvider` when `useMeetingManager` hook is called.

--- a/src/providers/MeetingProvider/index.tsx
+++ b/src/providers/MeetingProvider/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useContext, useState, createContext } from 'react';
-import { LogLevel } from 'amazon-chime-sdk-js';
+import { Logger, LogLevel, VideoDownlinkBandwidthPolicy } from 'amazon-chime-sdk-js';
 
 import MeetingManager from './MeetingManager';
 import { PostLogConfig } from './types';
@@ -22,10 +22,18 @@ interface Props {
   postLogConfig?: PostLogConfig;
   /** Whether or not to enable simulcast for the meeting session */
   simulcastEnabled?: boolean;
+  /** The `Logger` object you want to use in meeting session.
+   * If you pass in a `Logger` object using this parameter, 
+   * the `MeetingManager` will use this object instead of creating a logger 
+   * based on `logLevel` and `postLogConfig` to initialize the meeting session.
+   */
+  logger?: Logger;
+  /** The `VideoDownlinkBandwidthPolicy` object you want to use in meeting session */
+  videoDownlinkBandwidthPolicy?: VideoDownlinkBandwidthPolicy;
   /** Pass a `MeetingManager` instance if you want to share this instance 
    * across multiple different `MeetingProvider`s. This approach has limitations.
    * Check `meetingManager` prop documentation for more information.
-  */
+   */
   meetingManager?: MeetingManager;
 }
 
@@ -35,11 +43,13 @@ export const MeetingProvider: React.FC<Props> = ({
   logLevel = LogLevel.WARN,
   postLogConfig,
   simulcastEnabled = false,
+  logger,
+  videoDownlinkBandwidthPolicy,
   meetingManager: meetingManagerProp,
   children,
 }) => {
   const [meetingManager] = useState(
-    () => meetingManagerProp || new MeetingManager({ logLevel, postLogConfig, simulcastEnabled })
+    () => meetingManagerProp || new MeetingManager({ logLevel, postLogConfig, simulcastEnabled, logger, videoDownlinkBandwidthPolicy })
   );
 
   return (

--- a/src/providers/MeetingProvider/types.ts
+++ b/src/providers/MeetingProvider/types.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { EventReporter, LogLevel } from 'amazon-chime-sdk-js';
+import { EventReporter, LogLevel, VideoDownlinkBandwidthPolicy, Logger } from 'amazon-chime-sdk-js';
 import { DeviceLabels, DeviceLabelTrigger } from '../../types';
 
 export enum DevicePermissionStatus {
@@ -44,4 +44,6 @@ export interface ManagerConfig {
   logLevel: LogLevel;
   postLogConfig?: PostLogConfig;
   simulcastEnabled?: boolean;
+  logger?: Logger;
+  videoDownlinkBandwidthPolicy?: VideoDownlinkBandwidthPolicy;
 }


### PR DESCRIPTION
**Issue #:** 

User wants to set the `Logger` and `VideoDownlinkBandwidthPolicy` for the meeting session.

**Description of changes:**
* Add an option parameter in `MeetingConfig` to pass in a `VideoDownlinkBandwidthPolicy` instance to customize the downlink policy of the meeting
* Add an option parameter in `MeetingConfig` to pass in a `Logger` instance to customize the `Logger` of the meeting

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Check the console logger and downlink policy is set correctly.

3. If you made changes to the component library, have you provided corresponding documentation changes?
Yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
