### PR TITLE
Improve the way MeetingManager initializes MeetingSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Added
+
 - Add `MeetingEventProvider` and `useMeetingEvent` hook to receive meeting events from `amazon-chime-sdk-js`. Please check [Amazon Chime SDK for JavaScript meeting events guide](https://aws.github.io/amazon-chime-sdk-js/modules/meetingevents.html) for more information on meeting events.
 
 ### Changed
+
+- In `MeetingManager` add a private property `config` to store the `config` object passed in and remove `logLevel`, `postLoggerConfig`, `simulcastEnabled`, `videoDownlinkBandwidthPolicy` and `logger` properties. Use the newly added property `config` instead of the removed properties to initialize the `MeetingSession`.
 
 ### Removed
 


### PR DESCRIPTION
**Issue #:** 

* [Bug] When `leave` method in `MeetingManager` is called, the `logger` and `videoDowlinkBandwidthPolicy` will be set to `undefined` unexpectedly
* The way `MeetingManager` stores input parameter and initializes `MeetingSession` needs to be improved

**Description of changes:**
* In `MeetingManager` add a private property `config` to store the `config` object passed in
* Remove `logLevel`, `postLoggerConfig`, `simulcastEnabled`, `videoDownlinkBandwidthPolicy` and `logger` properties
* Use the newly added property `config` instead of the removed properties to initialize the `MeetingSession`

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
* Run the meeting demo and check that the bug is fixed, the `MeetingManager` initialize `MeetingSession` correctly, and the demo works.

3. If you made changes to the component library, have you provided corresponding documentation changes?
Yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
