### PR TITLE
Fix meeting manager init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Added
-- Add `MeetingEventProvider` and `useMeetingEvent` hook to receive meeting events from `amazon-chime-sdk-js`. Please check [Amazon Chime SDK for JavaScript meeting events guide](https://aws.github.io/amazon-chime-sdk-js/modules/meetingevents.html) for more information on meeting events.
+- Add [MeetingEventProvider](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/story/sdk-providers-meetingeventprovider--page) and [useMeetingEvent](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/story/sdk-hooks-usemeetingevent--page) hook to receive meeting events from `amazon-chime-sdk-js`. Please check [Amazon Chime SDK for JavaScript meeting events guide](https://aws.github.io/amazon-chime-sdk-js/modules/meetingevents.html) for more information on meeting events.
 
 ### Changed
+- Add `meetingManagerConfig: ManagerConfig` object to `MeetingManager` and use it in `initializeMeetingSession` method. We will use values from `meetingManagerConfig: ManagerConfig` directly instead of class level variables.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Added
-
 - Add `MeetingEventProvider` and `useMeetingEvent` hook to receive meeting events from `amazon-chime-sdk-js`. Please check [Amazon Chime SDK for JavaScript meeting events guide](https://aws.github.io/amazon-chime-sdk-js/modules/meetingevents.html) for more information on meeting events.
 
 ### Changed
-
-- In `MeetingManager` add a private property `config` to store the `config` object passed in and remove `logLevel`, `postLoggerConfig`, `simulcastEnabled`, `videoDownlinkBandwidthPolicy` and `logger` properties. Use the newly added property `config` instead of the removed properties to initialize the `MeetingSession`.
 
 ### Removed
 

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -6,6 +6,7 @@ import {
   ConsoleLogger,
   DefaultDeviceController,
   DefaultMeetingSession,
+  LogLevel,
   MeetingSessionConfiguration,
   DefaultActiveSpeakerPolicy,
   MeetingSessionStatus,
@@ -14,6 +15,8 @@ import {
   MultiLogger,
   MeetingSessionPOSTLogger,
   EventReporter,
+  VideoDownlinkBandwidthPolicy,
+  Logger,
   EventName,
   EventAttributes,
 } from 'amazon-chime-sdk-js';
@@ -29,6 +32,7 @@ import {
   MeetingJoinData,
   AttendeeResponse,
   FullDeviceInfoType,
+  PostLogConfig,
   ManagerConfig
 } from './types';
 
@@ -102,11 +106,38 @@ export class MeetingManager implements AudioVideoObserver {
     fullDeviceInfo: FullDeviceInfoType
   ) => void)[] = [];
 
+  logLevel: LogLevel = LogLevel.WARN;
+
+  postLoggerConfig: PostLogConfig | null = null;
+
   eventReporter: EventReporter;
+
+  simulcastEnabled: boolean = false;
+
+  videoDownlinkBandwidthPolicy: VideoDownlinkBandwidthPolicy | undefined;
+
+  logger: Logger | undefined;
 
   private meetingEventObserverSet = new Set<(name: EventName, attributes: EventAttributes) => void>();
 
-  constructor(private config: ManagerConfig) { }
+  constructor(config: ManagerConfig) {
+    if (config.simulcastEnabled) {
+      this.simulcastEnabled = config.simulcastEnabled;
+    }
+
+    if (config.logger) {
+      this.logger = config.logger;
+    } else {
+      this.logLevel = config.logLevel;
+      if (config.postLogConfig) {
+        this.postLoggerConfig = config.postLogConfig;
+      }
+    }
+
+    if (config.videoDownlinkBandwidthPolicy) {
+      this.videoDownlinkBandwidthPolicy = config.videoDownlinkBandwidthPolicy;
+    }
+  }
 
   initializeMeetingManager(): void {
     this.meetingSession = null;
@@ -127,6 +158,8 @@ export class MeetingManager implements AudioVideoObserver {
     this.meetingStatus = MeetingStatus.Loading;
     this.publishMeetingStatus();
     this.audioVideoObservers = {};
+    this.videoDownlinkBandwidthPolicy = undefined;
+    this.logger = undefined;
   }
 
   async join({ meetingInfo, attendeeInfo, deviceLabels = DeviceLabels.AudioAndVideo, eventReporter }: MeetingJoinData) {
@@ -137,6 +170,11 @@ export class MeetingManager implements AudioVideoObserver {
 
     this.meetingRegion = meetingInfo.MediaRegion;
     this.meetingId = this.configuration.meetingId;
+
+    if (this.simulcastEnabled) {
+      this.configuration.enableUnifiedPlanForChromiumBasedBrowsers = true;
+      this.configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
+    };
 
     if (eventReporter) {
       this.eventReporter = eventReporter;
@@ -185,16 +223,10 @@ export class MeetingManager implements AudioVideoObserver {
     configuration: MeetingSessionConfiguration,
     deviceLabels: DeviceLabels | DeviceLabelTrigger = DeviceLabels.AudioAndVideo,
   ): Promise<any> {
-    const { logger: inputLogger, simulcastEnabled, videoDownlinkBandwidthPolicy } = this.config;
-    const logger = inputLogger ? inputLogger : this.createLogger(configuration);
+    const logger = this.logger ? this.logger : this.createLogger(configuration);
 
-    if (simulcastEnabled) {
-      configuration.enableUnifiedPlanForChromiumBasedBrowsers = true;
-      configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
-    };
-
-    if (videoDownlinkBandwidthPolicy) {
-      configuration.videoDownlinkBandwidthPolicy = videoDownlinkBandwidthPolicy;
+    if (this.videoDownlinkBandwidthPolicy) {
+      configuration.videoDownlinkBandwidthPolicy = this.videoDownlinkBandwidthPolicy;
     }
 
     const deviceController = new DefaultDeviceController(logger);
@@ -206,14 +238,14 @@ export class MeetingManager implements AudioVideoObserver {
     );
 
     this.audioVideo = this.meetingSession.audioVideo;
-
+    
     // When an attendee leaves, we remove AudioVideoObservers and nullify AudioVideoFacade and MeetingSession object.
     // This results into missing few meeting events triggered with audioVideoDidStop such as meetingEnded, meetingFailed and meetingStartFailed.
     // We may also loose audioInputUnselected and videoInputUnselected events as we choose null devices when an attendee leaves.
     // When a new AudioVideoFacade object is created remove and re-add the eventDidReceive observer which wont leak.
     this.audioVideo.removeObserver({ eventDidReceive: this.eventDidReceive });
     this.audioVideo.addObserver({ eventDidReceive: this.eventDidReceive });
-
+    
     this.publishAudioVideo();
     this.setupAudioVideoObservers();
     this.setupDeviceLabelTrigger(deviceLabels);
@@ -224,20 +256,19 @@ export class MeetingManager implements AudioVideoObserver {
   }
 
   createLogger(configuration: MeetingSessionConfiguration) {
-    const { logLevel, postLogConfig } = this.config;
-    const consoleLogger = new ConsoleLogger('SDK', logLevel);
+    const consoleLogger = new ConsoleLogger('SDK', this.logLevel);
     let logger: ConsoleLogger | MultiLogger = consoleLogger;
 
-    if (postLogConfig) {
+    if (this.postLoggerConfig) {
       logger = new MultiLogger(
         consoleLogger,
         new MeetingSessionPOSTLogger(
-          postLogConfig.name,
+          this.postLoggerConfig.name,
           configuration,
-          postLogConfig.batchSize,
-          postLogConfig.intervalMs,
-          postLogConfig.url,
-          postLogConfig.logLevel
+          this.postLoggerConfig.batchSize,
+          this.postLoggerConfig.intervalMs,
+          this.postLoggerConfig.url,
+          this.postLoggerConfig.logLevel
         )
       );
     }


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
- Add `ManagerConfig` object to `MeetingManager`.
- Move object creation/initialization from `MeetingManager` constructor to `initializeMeetingSession` method.
- Reverts earlier commit (#586) where I did not checked for backward compatibility.
- This PR addresses the required changes with backward compatability.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
By running, the meeting demo, tested general flow.

3. If you made changes to the component library, have you provided corresponding documentation changes? NA.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
