### PR TITLE
Rename theme file so that it properly generates definition file

### DIFF
--- a/src/theme/styled.ts
+++ b/src/theme/styled.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import 'styled-components';

--- a/src/theme/styled.ts
+++ b/src/theme/styled.ts
@@ -1,3 +1,6 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import 'styled-components';
 
 interface TextType {


### PR DESCRIPTION
fixes #588

Renamed `src/theme/styled.d.ts` to `src/theme/styles.ts` so that the build will generate the `styled.d.ts` file for distribution.
Reference: https://betterstack.dev/blog/publishing-type-definitions-with-npm-package/#heading-write-type-definitions-in-ts-files

**Testing**
1. Have you successfully run `npm run build:release` locally?
YES

2. How did you test these changes?
Ran `npm pack` and then imported it into an app to verify transpiling with `tsc`

3. If you made changes to the component library, have you provided corresponding documentation changes?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
