### PR TITLE
Remove the year in the copy right checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 # Changelog
 
@@ -6,6 +6,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+### Added
+
+### Changed
+
+- Remove the year in the copy right checker.
+
+### Removed
 
 ## [2.9.0] - 2021-08-28
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 amazon-chime-sdk-component-library-react
-Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -136,4 +136,4 @@ If you have more questions, or require support for your business, you can reach 
 
 This project is licensed under the Apache-2.0 License.
 
-Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/scripts/check-codestyle.js
+++ b/scripts/check-codestyle.js
@@ -51,36 +51,6 @@ let allFiles = function() {
   return srcFiles.concat(tests());
 };
 
-let joinYears = function(years) {
-  let prevYear = null;
-  let rangeEnd = null;
-  let out = '';
-  for (const year of years) {
-    if (parseInt(prevYear) + 1 === parseInt(year)) {
-      rangeEnd = year;
-    } else {
-      if (rangeEnd) {
-        out += `-${rangeEnd}`;
-        rangeEnd = null;
-      }
-      if (out !== '') {
-        out += ', ';
-      }
-      out += year;
-    }
-    prevYear = year;
-  }
-  if (rangeEnd) {
-    out += `-${rangeEnd}`;
-    rangeEnd = null;
-  }
-  return out;
-};
-
-let unique = function(value, index, self) {
-  return self.indexOf(value) === index;
-};
-
 tests().forEach(file => {
   if (
     file.includes(`.DS_Store`) ||
@@ -119,24 +89,8 @@ allFiles().forEach(file => {
   if (file.endsWith('.d.ts') || file.includes('.DS_Store')) {
     return;
   }
-  let yearsForFileInGitHistory = [];
-  const stdout = exec(`git log --pretty=format:'%ad' --date=short ${file}`);
 
-  const dates = [];
-  for (const line of stdout
-    .toString()
-    .trim()
-    .split('\n')) {
-    const year = line.replace(/[-].*/, '').replace(`'`, '');
-    dates.push(year);
-    allYears.push(year);
-  }
-
-  yearsForFileInGitHistory = dates.sort().filter(unique);
-
-  const copyright = `// Copyright ${joinYears(
-    yearsForFileInGitHistory
-  )} Amazon.com, Inc. or its affiliates. All Rights Reserved.`;
+  const copyright = `// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.`;
   const fileLines = fs
     .readFileSync(file)
     .toString()
@@ -185,9 +139,7 @@ allFiles().forEach(file => {
   }
 });
 
-const footerCopyright = `\nCopyright ${joinYears(
-  allYears.sort().filter(unique)
-)} Amazon.com, Inc. or its affiliates. All Rights Reserved.\n`;
+const footerCopyright = `\nCopyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\n`;
 
 for (const file of ['README.md', 'NOTICE']) {
   if (

--- a/src/components/sdk/Base/index.tsx
+++ b/src/components/sdk/Base/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 export interface BaseSdkProps {

--- a/src/components/sdk/ContentShare/index.tsx
+++ b/src/components/sdk/ContentShare/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useEffect, useRef } from 'react';

--- a/src/components/sdk/DeviceSelection/CameraSelection/QualitySelection.tsx
+++ b/src/components/sdk/DeviceSelection/CameraSelection/QualitySelection.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState, ChangeEvent } from 'react';

--- a/src/components/sdk/DeviceSelection/CameraSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/CameraSelection/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/sdk/DeviceSelection/DeviceInput.tsx
+++ b/src/components/sdk/DeviceSelection/DeviceInput.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ChangeEvent } from 'react';

--- a/src/components/sdk/DeviceSelection/MicSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/MicSelection/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/sdk/DeviceSelection/SpeakerSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/SpeakerSelection/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/sdk/DeviceSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import SpeakerSelection from './SpeakerSelection';

--- a/src/components/sdk/FeaturedRemoteVideos/index.tsx
+++ b/src/components/sdk/FeaturedRemoteVideos/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { memo, FC, HTMLAttributes } from 'react';

--- a/src/components/sdk/LocalVideo/index.tsx
+++ b/src/components/sdk/LocalVideo/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useEffect, useRef } from 'react';

--- a/src/components/sdk/MeetingControls/AudioInputControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioInputControl.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/sdk/MeetingControls/AudioInputVFControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioInputVFControl.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useEffect, useState, ReactNode } from 'react';

--- a/src/components/sdk/MeetingControls/AudioOutputControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioOutputControl.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/sdk/MeetingControls/ContentShareControl.tsx
+++ b/src/components/sdk/MeetingControls/ContentShareControl.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/sdk/MeetingControls/VideoInputControl.tsx
+++ b/src/components/sdk/MeetingControls/VideoInputControl.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/sdk/MeetingControls/index.tsx
+++ b/src/components/sdk/MeetingControls/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import AudioInputControl from './AudioInputControl';

--- a/src/components/sdk/MicrophoneActivity/index.tsx
+++ b/src/components/sdk/MicrophoneActivity/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useEffect, useRef } from 'react';

--- a/src/components/sdk/PreviewVideo/index.tsx
+++ b/src/components/sdk/PreviewVideo/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useRef, useEffect } from 'react';

--- a/src/components/sdk/RemoteVideo/index.tsx
+++ b/src/components/sdk/RemoteVideo/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useRef, useEffect, HTMLAttributes } from 'react';

--- a/src/components/sdk/RemoteVideos/index.tsx
+++ b/src/components/sdk/RemoteVideos/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { memo } from 'react';

--- a/src/components/sdk/RosterAttendee/index.tsx
+++ b/src/components/sdk/RosterAttendee/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/sdk/VideoTileGrid/index.tsx
+++ b/src/components/sdk/VideoTileGrid/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Badge/Badge.stories.tsx
+++ b/src/components/ui/Badge/Badge.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Badge/Styled.tsx
+++ b/src/components/ui/Badge/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/Badge/index.tsx
+++ b/src/components/ui/Badge/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC } from 'react';

--- a/src/components/ui/Base/index.ts
+++ b/src/components/ui/Base/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { SpaceProps } from 'styled-system';

--- a/src/components/ui/Button/Button.stories.tsx
+++ b/src/components/ui/Button/Button.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Button/IconButton.tsx
+++ b/src/components/ui/Button/IconButton.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { forwardRef } from 'react';

--- a/src/components/ui/Button/PrimaryButton.tsx
+++ b/src/components/ui/Button/PrimaryButton.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { forwardRef } from 'react';

--- a/src/components/ui/Button/SecondaryButton.tsx
+++ b/src/components/ui/Button/SecondaryButton.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { forwardRef } from 'react';

--- a/src/components/ui/Button/Styled.tsx
+++ b/src/components/ui/Button/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled, { css } from 'styled-components';

--- a/src/components/ui/Button/index.tsx
+++ b/src/components/ui/Button/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { forwardRef, HTMLAttributes } from 'react';

--- a/src/components/ui/Chat/ChannelList/ChannelItem.tsx
+++ b/src/components/ui/Chat/ChannelList/ChannelItem.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, HTMLAttributes, ReactNode } from 'react';

--- a/src/components/ui/Chat/ChannelList/ChannelList.stories.tsx
+++ b/src/components/ui/Chat/ChannelList/ChannelList.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState } from 'react';

--- a/src/components/ui/Chat/ChannelList/Styled.tsx
+++ b/src/components/ui/Chat/ChannelList/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/Chat/ChannelList/index.tsx
+++ b/src/components/ui/Chat/ChannelList/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, HTMLAttributes } from 'react';

--- a/src/components/ui/Chat/ChatBubble/ChatBubble.stories.tsx
+++ b/src/components/ui/Chat/ChatBubble/ChatBubble.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Chat/ChatBubble/ChatBubbleContainer.stories.tsx
+++ b/src/components/ui/Chat/ChatBubble/ChatBubbleContainer.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Chat/ChatBubble/ChatBubbleContainer.tsx
+++ b/src/components/ui/Chat/ChatBubble/ChatBubbleContainer.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, useMemo, HTMLAttributes, ReactNode, Ref } from 'react';

--- a/src/components/ui/Chat/ChatBubble/EditableChatBubble.stories.tsx
+++ b/src/components/ui/Chat/ChatBubble/EditableChatBubble.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Chat/ChatBubble/EditableChatBubble.tsx
+++ b/src/components/ui/Chat/ChatBubble/EditableChatBubble.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, useState, HTMLAttributes, useRef, useEffect } from 'react';

--- a/src/components/ui/Chat/ChatBubble/Styled.tsx
+++ b/src/components/ui/Chat/ChatBubble/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/Chat/ChatBubble/index.tsx
+++ b/src/components/ui/Chat/ChatBubble/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, HTMLAttributes, ReactNode } from 'react';

--- a/src/components/ui/Chat/InfiniteList/InfiniteList.stories.tsx
+++ b/src/components/ui/Chat/InfiniteList/InfiniteList.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState } from 'react';

--- a/src/components/ui/Chat/InfiniteList/Styled.tsx
+++ b/src/components/ui/Chat/InfiniteList/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled, { keyframes } from 'styled-components';

--- a/src/components/ui/Chat/InfiniteList/index.tsx
+++ b/src/components/ui/Chat/InfiniteList/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, {

--- a/src/components/ui/Chat/MessageAttachment/Attachment.stories.tsx
+++ b/src/components/ui/Chat/MessageAttachment/Attachment.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Chat/MessageAttachment/Styled.tsx
+++ b/src/components/ui/Chat/MessageAttachment/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/Chat/MessageAttachment/index.tsx
+++ b/src/components/ui/Chat/MessageAttachment/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, HTMLAttributes } from 'react';

--- a/src/components/ui/Checkbox/Checkbox.stories.tsx
+++ b/src/components/ui/Checkbox/Checkbox.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Checkbox/Styled.tsx
+++ b/src/components/ui/Checkbox/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/Checkbox/index.tsx
+++ b/src/components/ui/Checkbox/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, ChangeEvent, useRef } from 'react';

--- a/src/components/ui/ContentTile/ContentTile.stories.tsx
+++ b/src/components/ui/ContentTile/ContentTile.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/ContentTile/index.tsx
+++ b/src/components/ui/ContentTile/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/ControlBar/ControlBar.stories.tsx
+++ b/src/components/ui/ControlBar/ControlBar.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState } from 'react';

--- a/src/components/ui/ControlBar/ControlBarButton.tsx
+++ b/src/components/ui/ControlBar/ControlBarButton.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, ReactNode, useMemo } from 'react';

--- a/src/components/ui/ControlBar/ControlBarContext.tsx
+++ b/src/components/ui/ControlBar/ControlBarContext.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { createContext, useContext } from 'react';

--- a/src/components/ui/ControlBar/Styled.tsx
+++ b/src/components/ui/ControlBar/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled, { css } from 'styled-components';

--- a/src/components/ui/ControlBar/index.tsx
+++ b/src/components/ui/ControlBar/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, HTMLAttributes } from 'react';

--- a/src/components/ui/Flex/Flex.stories.tsx
+++ b/src/components/ui/Flex/Flex.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Flex/Styled.tsx
+++ b/src/components/ui/Flex/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled, { css } from 'styled-components';

--- a/src/components/ui/Flex/index.tsx
+++ b/src/components/ui/Flex/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC } from 'react';

--- a/src/components/ui/FormField/FormField.stories.tsx
+++ b/src/components/ui/FormField/FormField.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState } from 'react';

--- a/src/components/ui/FormField/Styled.tsx
+++ b/src/components/ui/FormField/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled, { css } from 'styled-components';

--- a/src/components/ui/FormField/index.tsx
+++ b/src/components/ui/FormField/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, forwardRef, Ref, ChangeEvent } from 'react';

--- a/src/components/ui/Grid/Cell.tsx
+++ b/src/components/ui/Grid/Cell.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Grid/Grid.stories.tsx
+++ b/src/components/ui/Grid/Grid.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Grid/Styled.tsx
+++ b/src/components/ui/Grid/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/Grid/index.tsx
+++ b/src/components/ui/Grid/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Heading/Heading.stories.tsx
+++ b/src/components/ui/Heading/Heading.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Heading/Styled.tsx
+++ b/src/components/ui/Heading/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/Heading/index.tsx
+++ b/src/components/ui/Heading/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { forwardRef, ReactNode } from 'react';

--- a/src/components/ui/Input/Input.stories.tsx
+++ b/src/components/ui/Input/Input.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState } from 'react';

--- a/src/components/ui/Input/InputWrapper.tsx
+++ b/src/components/ui/Input/InputWrapper.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { forwardRef, ReactNode, Ref } from 'react';

--- a/src/components/ui/Input/SearchInput.tsx
+++ b/src/components/ui/Input/SearchInput.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { Ref, forwardRef } from 'react';

--- a/src/components/ui/Input/Styled.tsx
+++ b/src/components/ui/Input/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/Input/index.tsx
+++ b/src/components/ui/Input/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, {

--- a/src/components/ui/Label/Label.stories.tsx
+++ b/src/components/ui/Label/Label.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Label/Styled.tsx
+++ b/src/components/ui/Label/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/Label/index.tsx
+++ b/src/components/ui/Label/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { forwardRef, Ref, LabelHTMLAttributes } from 'react';

--- a/src/components/ui/MicVolumeIndicator/Styled.tsx
+++ b/src/components/ui/MicVolumeIndicator/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/MicVolumeIndicator/index.tsx
+++ b/src/components/ui/MicVolumeIndicator/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { HTMLAttributes, Ref, forwardRef } from 'react';

--- a/src/components/ui/Modal/Modal.stories.tsx
+++ b/src/components/ui/Modal/Modal.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState } from 'react';

--- a/src/components/ui/Modal/ModalBody.tsx
+++ b/src/components/ui/Modal/ModalBody.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, HTMLAttributes } from 'react';

--- a/src/components/ui/Modal/ModalButton.tsx
+++ b/src/components/ui/Modal/ModalButton.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Modal/ModalButtonGroup.tsx
+++ b/src/components/ui/Modal/ModalButtonGroup.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, ReactElement } from 'react';

--- a/src/components/ui/Modal/ModalContext.tsx
+++ b/src/components/ui/Modal/ModalContext.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { createContext, useContext } from 'react';

--- a/src/components/ui/Modal/ModalHeader.tsx
+++ b/src/components/ui/Modal/ModalHeader.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, HTMLAttributes } from 'react';

--- a/src/components/ui/Modal/Styled.ts
+++ b/src/components/ui/Modal/Styled.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/Modal/index.tsx
+++ b/src/components/ui/Modal/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, useEffect, useRef, HTMLAttributes } from 'react';

--- a/src/components/ui/Navbar/Navbar.stories.tsx
+++ b/src/components/ui/Navbar/Navbar.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Navbar/NavbarHeader.tsx
+++ b/src/components/ui/Navbar/NavbarHeader.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Navbar/NavbarItem.tsx
+++ b/src/components/ui/Navbar/NavbarItem.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactNode, useMemo } from 'react';

--- a/src/components/ui/Navbar/Styled.tsx
+++ b/src/components/ui/Navbar/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/Navbar/index.tsx
+++ b/src/components/ui/Navbar/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Notification/Notification.stories.tsx
+++ b/src/components/ui/Notification/Notification.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Notification/Styled.tsx
+++ b/src/components/ui/Notification/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/Notification/index.tsx
+++ b/src/components/ui/Notification/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useEffect, HTMLAttributes, ReactNode } from 'react';

--- a/src/components/ui/NotificationGroup/NotificationGroup.stories.tsx
+++ b/src/components/ui/NotificationGroup/NotificationGroup.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/NotificationGroup/Styled.tsx
+++ b/src/components/ui/NotificationGroup/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/NotificationGroup/index.tsx
+++ b/src/components/ui/NotificationGroup/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/PopOver/PopOver.stories.tsx
+++ b/src/components/ui/PopOver/PopOver.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/PopOver/PopOverHeader.tsx
+++ b/src/components/ui/PopOver/PopOverHeader.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, HTMLAttributes, ReactNode } from 'react';

--- a/src/components/ui/PopOver/PopOverItem.tsx
+++ b/src/components/ui/PopOver/PopOverItem.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC } from 'react';

--- a/src/components/ui/PopOver/PopOverSeparator.tsx
+++ b/src/components/ui/PopOver/PopOverSeparator.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, HTMLAttributes } from 'react';

--- a/src/components/ui/PopOver/PopOverSubMenu.tsx
+++ b/src/components/ui/PopOver/PopOverSubMenu.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, HTMLAttributes } from 'react';

--- a/src/components/ui/PopOver/Styled.tsx
+++ b/src/components/ui/PopOver/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/PopOver/index.tsx
+++ b/src/components/ui/PopOver/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, {

--- a/src/components/ui/Portal/index.tsx
+++ b/src/components/ui/Portal/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { FC, useEffect, useState } from 'react';

--- a/src/components/ui/Radio/Radio.stories.tsx
+++ b/src/components/ui/Radio/Radio.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Radio/Styled.tsx
+++ b/src/components/ui/Radio/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/Radio/index.tsx
+++ b/src/components/ui/Radio/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, InputHTMLAttributes, useRef } from 'react';

--- a/src/components/ui/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/ui/RadioGroup/RadioGroup.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/RadioGroup/index.tsx
+++ b/src/components/ui/RadioGroup/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, ChangeEvent, InputHTMLAttributes } from 'react';

--- a/src/components/ui/Roster/PopOverMenu.tsx
+++ b/src/components/ui/Roster/PopOverMenu.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useMemo } from 'react';

--- a/src/components/ui/Roster/Roster.stories.tsx
+++ b/src/components/ui/Roster/Roster.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState } from 'react';

--- a/src/components/ui/Roster/RosterCell/LateMessage.tsx
+++ b/src/components/ui/Roster/RosterCell/LateMessage.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Roster/RosterCell/Styled.tsx
+++ b/src/components/ui/Roster/RosterCell/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/Roster/RosterCell/index.tsx
+++ b/src/components/ui/Roster/RosterCell/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Roster/RosterGroup.tsx
+++ b/src/components/ui/Roster/RosterGroup.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Roster/RosterHeader.tsx
+++ b/src/components/ui/Roster/RosterHeader.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, {

--- a/src/components/ui/Roster/RosterName.tsx
+++ b/src/components/ui/Roster/RosterName.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Roster/Styled.tsx
+++ b/src/components/ui/Roster/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/Roster/index.tsx
+++ b/src/components/ui/Roster/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Select/Select.stories.tsx
+++ b/src/components/ui/Select/Select.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Select/Styled.tsx
+++ b/src/components/ui/Select/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/Select/index.tsx
+++ b/src/components/ui/Select/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, {

--- a/src/components/ui/Textarea/Styled.tsx
+++ b/src/components/ui/Textarea/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/Textarea/Textarea.stories.tsx
+++ b/src/components/ui/Textarea/Textarea.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/Textarea/index.tsx
+++ b/src/components/ui/Textarea/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, ChangeEvent, InputHTMLAttributes, Ref } from 'react';

--- a/src/components/ui/UserActivityManager/Styled.tsx
+++ b/src/components/ui/UserActivityManager/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/UserActivityManager/index.tsx
+++ b/src/components/ui/UserActivityManager/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC } from 'react';

--- a/src/components/ui/Utilities/formatDate.ts
+++ b/src/components/ui/Utilities/formatDate.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import memoize from 'fast-memoize';

--- a/src/components/ui/Utilities/formatTime.ts
+++ b/src/components/ui/Utilities/formatTime.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 export const formatTime = (time: string) => {

--- a/src/components/ui/Utilities/index.ts
+++ b/src/components/ui/Utilities/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 export { formatTime } from './formatTime';

--- a/src/components/ui/VideoGrid/Styled.tsx
+++ b/src/components/ui/VideoGrid/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/VideoGrid/VideoGrid.stories.tsx
+++ b/src/components/ui/VideoGrid/VideoGrid.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/VideoGrid/index.tsx
+++ b/src/components/ui/VideoGrid/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { createRef, useContext, createContext } from 'react';

--- a/src/components/ui/VideoTile/Styled.tsx
+++ b/src/components/ui/VideoTile/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/VideoTile/VideoTile.stories.tsx
+++ b/src/components/ui/VideoTile/VideoTile.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/VideoTile/index.tsx
+++ b/src/components/ui/VideoTile/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { forwardRef, HTMLAttributes } from 'react';

--- a/src/components/ui/WithTooltip/Styled.tsx
+++ b/src/components/ui/WithTooltip/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled, { css } from 'styled-components';

--- a/src/components/ui/WithTooltip/index.tsx
+++ b/src/components/ui/WithTooltip/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useCallback, useEffect, useState } from 'react';

--- a/src/components/ui/icons/Add/Add.stories.tsx
+++ b/src/components/ui/icons/Add/Add.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Add/index.tsx
+++ b/src/components/ui/icons/Add/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/All/All.stories.tsx
+++ b/src/components/ui/icons/All/All.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Arrow/Arrow.stories.tsx
+++ b/src/components/ui/icons/Arrow/Arrow.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Arrow/index.tsx
+++ b/src/components/ui/icons/Arrow/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Attachment/Attachment.stories.tsx
+++ b/src/components/ui/icons/Attachment/Attachment.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Attachment/index.tsx
+++ b/src/components/ui/icons/Attachment/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Attendees/Attendees.stories.tsx
+++ b/src/components/ui/icons/Attendees/Attendees.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Attendees/index.tsx
+++ b/src/components/ui/icons/Attendees/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Camera/Camera.stories.tsx
+++ b/src/components/ui/icons/Camera/Camera.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Camera/index.tsx
+++ b/src/components/ui/icons/Camera/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Caret/Caret.stories.tsx
+++ b/src/components/ui/icons/Caret/Caret.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Caret/index.tsx
+++ b/src/components/ui/icons/Caret/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Caution/Caution.stories.tsx
+++ b/src/components/ui/icons/Caution/Caution.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Caution/index.tsx
+++ b/src/components/ui/icons/Caution/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC } from 'react';

--- a/src/components/ui/icons/Caution/styled.tsx
+++ b/src/components/ui/icons/Caution/styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled, { css } from 'styled-components';

--- a/src/components/ui/icons/Chat/Chat.stories.tsx
+++ b/src/components/ui/icons/Chat/Chat.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Chat/index.tsx
+++ b/src/components/ui/icons/Chat/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Check/Check.stories.tsx
+++ b/src/components/ui/icons/Check/Check.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Check/index.tsx
+++ b/src/components/ui/icons/Check/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/CheckRound/CheckRound.stories.tsx
+++ b/src/components/ui/icons/CheckRound/CheckRound.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/CheckRound/index.tsx
+++ b/src/components/ui/icons/CheckRound/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Clear/Clear.stories.tsx
+++ b/src/components/ui/icons/Clear/Clear.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Clear/index.tsx
+++ b/src/components/ui/icons/Clear/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Clock/Clock.stories.tsx
+++ b/src/components/ui/icons/Clock/Clock.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Clock/index.tsx
+++ b/src/components/ui/icons/Clock/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Cog/Cog.stories.tsx
+++ b/src/components/ui/icons/Cog/Cog.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Cog/index.tsx
+++ b/src/components/ui/icons/Cog/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/ConnectionProblem/ConnectionProblem.stories.tsx
+++ b/src/components/ui/icons/ConnectionProblem/ConnectionProblem.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/ConnectionProblem/index.tsx
+++ b/src/components/ui/icons/ConnectionProblem/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Crown/Crown.stories.tsx
+++ b/src/components/ui/icons/Crown/Crown.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Crown/index.tsx
+++ b/src/components/ui/icons/Crown/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/DeskPhone/DeskPhone.stories.tsx
+++ b/src/components/ui/icons/DeskPhone/DeskPhone.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/DeskPhone/index.tsx
+++ b/src/components/ui/icons/DeskPhone/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Dialer/Dialer.stories.tsx
+++ b/src/components/ui/icons/Dialer/Dialer.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Dialer/index.tsx
+++ b/src/components/ui/icons/Dialer/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Dislike/Dislike.stories.tsx
+++ b/src/components/ui/icons/Dislike/Dislike.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Dislike/index.tsx
+++ b/src/components/ui/icons/Dislike/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Dock/Dock.stories.tsx
+++ b/src/components/ui/icons/Dock/Dock.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Dock/index.tsx
+++ b/src/components/ui/icons/Dock/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Document/Document.stories.tsx
+++ b/src/components/ui/icons/Document/Document.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Document/index.tsx
+++ b/src/components/ui/icons/Document/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Dots/Dots.stories.tsx
+++ b/src/components/ui/icons/Dots/Dots.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Dots/index.tsx
+++ b/src/components/ui/icons/Dots/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/DropToAttach/DropToAttache.stories.tsx
+++ b/src/components/ui/icons/DropToAttach/DropToAttache.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/DropToAttach/index.tsx
+++ b/src/components/ui/icons/DropToAttach/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Echo/Echo.stories.tsx
+++ b/src/components/ui/icons/Echo/Echo.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Echo/index.tsx
+++ b/src/components/ui/icons/Echo/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/EmojiPicker/EmojiPicker.stories.tsx
+++ b/src/components/ui/icons/EmojiPicker/EmojiPicker.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/EmojiPicker/index.tsx
+++ b/src/components/ui/icons/EmojiPicker/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Eye/Eye.stories.tsx
+++ b/src/components/ui/icons/Eye/Eye.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Eye/index.tsx
+++ b/src/components/ui/icons/Eye/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Feedback/Feedback.stories.tsx
+++ b/src/components/ui/icons/Feedback/Feedback.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Feedback/index.tsx
+++ b/src/components/ui/icons/Feedback/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Hamburger/Hamburger.stories.tsx
+++ b/src/components/ui/icons/Hamburger/Hamburger.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Hamburger/index.tsx
+++ b/src/components/ui/icons/Hamburger/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/HandRaise/HandRaise.stories.tsx
+++ b/src/components/ui/icons/HandRaise/HandRaise.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/HandRaise/Styled.tsx
+++ b/src/components/ui/icons/HandRaise/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';

--- a/src/components/ui/icons/HandRaise/index.tsx
+++ b/src/components/ui/icons/HandRaise/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Information/Information.stories.tsx
+++ b/src/components/ui/icons/Information/Information.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Information/index.tsx
+++ b/src/components/ui/icons/Information/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Laptop/Laptop.stories.tsx
+++ b/src/components/ui/icons/Laptop/Laptop.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Laptop/index.tsx
+++ b/src/components/ui/icons/Laptop/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/LeaveMeeting/LeaveMeeting.stories.tsx
+++ b/src/components/ui/icons/LeaveMeeting/LeaveMeeting.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/LeaveMeeting/index.tsx
+++ b/src/components/ui/icons/LeaveMeeting/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Like/Like.stories.tsx
+++ b/src/components/ui/icons/Like/Like.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Like/index.tsx
+++ b/src/components/ui/icons/Like/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/ListHandRasie/ListHandRaise.stories.tsx
+++ b/src/components/ui/icons/ListHandRasie/ListHandRaise.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/ListHandRasie/index.tsx
+++ b/src/components/ui/icons/ListHandRasie/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Lock/Lock.stories.tsx
+++ b/src/components/ui/icons/Lock/Lock.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Lock/index.tsx
+++ b/src/components/ui/icons/Lock/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Meeting/Meeting.stories.tsx
+++ b/src/components/ui/icons/Meeting/Meeting.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Meeting/index.tsx
+++ b/src/components/ui/icons/Meeting/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Microphone/Microphone.stories.tsx
+++ b/src/components/ui/icons/Microphone/Microphone.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Microphone/Styled.tsx
+++ b/src/components/ui/icons/Microphone/Styled.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Microphone/index.tsx
+++ b/src/components/ui/icons/Microphone/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Pause/Pause.stories.tsx
+++ b/src/components/ui/icons/Pause/Pause.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Pause/index.tsx
+++ b/src/components/ui/icons/Pause/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Phone/Phone.stories.tsx
+++ b/src/components/ui/icons/Phone/Phone.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Phone/index.tsx
+++ b/src/components/ui/icons/Phone/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Pin/Pin.stories.tsx
+++ b/src/components/ui/icons/Pin/Pin.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Pin/index.tsx
+++ b/src/components/ui/icons/Pin/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Play/Play.stories.tsx
+++ b/src/components/ui/icons/Play/Play.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Play/index.tsx
+++ b/src/components/ui/icons/Play/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Presenter/Presenter.stories.tsx
+++ b/src/components/ui/icons/Presenter/Presenter.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Presenter/index.tsx
+++ b/src/components/ui/icons/Presenter/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Record/Record.stories.tsx
+++ b/src/components/ui/icons/Record/Record.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Record/index.tsx
+++ b/src/components/ui/icons/Record/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Remove/Remove.stories.tsx
+++ b/src/components/ui/icons/Remove/Remove.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Remove/index.tsx
+++ b/src/components/ui/icons/Remove/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Rooms/Rooms.stories.tsx
+++ b/src/components/ui/icons/Rooms/Rooms.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Rooms/index.tsx
+++ b/src/components/ui/icons/Rooms/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/ScreenShare/ScreenShare.stories.tsx
+++ b/src/components/ui/icons/ScreenShare/ScreenShare.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/ScreenShare/index.tsx
+++ b/src/components/ui/icons/ScreenShare/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Search/Search.stories.tsx
+++ b/src/components/ui/icons/Search/Search.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Search/index.tsx
+++ b/src/components/ui/icons/Search/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Share/Share.stories.tsx
+++ b/src/components/ui/icons/Share/Share.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Share/index.tsx
+++ b/src/components/ui/icons/Share/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/SignalStrength/SignalStrength.stories.tsx
+++ b/src/components/ui/icons/SignalStrength/SignalStrength.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/SignalStrength/index.tsx
+++ b/src/components/ui/icons/SignalStrength/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Sound/Sound.stories.tsx
+++ b/src/components/ui/icons/Sound/Sound.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Sound/index.tsx
+++ b/src/components/ui/icons/Sound/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Spinner/Spinner.stories.tsx
+++ b/src/components/ui/icons/Spinner/Spinner.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Spinner/index.tsx
+++ b/src/components/ui/icons/Spinner/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/Svg.tsx
+++ b/src/components/ui/icons/Svg.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/UpAndDownCaret/UpAndDownCaret.stories.tsx
+++ b/src/components/ui/icons/UpAndDownCaret/UpAndDownCaret.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/UpAndDownCaret/index.tsx
+++ b/src/components/ui/icons/UpAndDownCaret/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/ZoomIn/ZoomIn.stories.tsx
+++ b/src/components/ui/icons/ZoomIn/ZoomIn.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/ZoomIn/index.tsx
+++ b/src/components/ui/icons/ZoomIn/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/ZoomOut/ZoomOut.stories.tsx
+++ b/src/components/ui/icons/ZoomOut/ZoomOut.stories.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/ZoomOut/index.tsx
+++ b/src/components/ui/icons/ZoomOut/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ui/icons/index.tsx
+++ b/src/components/ui/icons/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 export { default as Add } from './Add';

--- a/src/constants/additional-audio-video-devices.ts
+++ b/src/constants/additional-audio-video-devices.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 export const VIDEO_INPUT = {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 export const KEY_CODES = {

--- a/src/hooks/sdk/useActiveSpeakersState.tsx
+++ b/src/hooks/sdk/useActiveSpeakersState.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useState, useEffect } from 'react';

--- a/src/hooks/sdk/useAttendeeAudioStatus.tsx
+++ b/src/hooks/sdk/useAttendeeAudioStatus.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useState, useEffect } from 'react';

--- a/src/hooks/sdk/useAttendeeStatus.tsx
+++ b/src/hooks/sdk/useAttendeeStatus.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, useState } from 'react';

--- a/src/hooks/sdk/useBandwidthMetrics.tsx
+++ b/src/hooks/sdk/useBandwidthMetrics.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useState, useEffect } from 'react';

--- a/src/hooks/sdk/useDevicePermissionStatus.tsx
+++ b/src/hooks/sdk/useDevicePermissionStatus.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, useState } from 'react';

--- a/src/hooks/sdk/useLocalAudioInputActivity.tsx
+++ b/src/hooks/sdk/useLocalAudioInputActivity.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect } from 'react';

--- a/src/hooks/sdk/useLocalAudioInputActivityPreview.tsx
+++ b/src/hooks/sdk/useLocalAudioInputActivityPreview.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useCallback } from 'react';

--- a/src/hooks/sdk/useMediaStreamMetrics.tsx
+++ b/src/hooks/sdk/useMediaStreamMetrics.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useState, useEffect } from 'react';

--- a/src/hooks/sdk/useMeetingStatus.tsx
+++ b/src/hooks/sdk/useMeetingStatus.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useState, useEffect } from 'react';

--- a/src/hooks/sdk/useSelectAudioInputDevice.tsx
+++ b/src/hooks/sdk/useSelectAudioInputDevice.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useCallback } from 'react';

--- a/src/hooks/sdk/useSelectAudioOutputDevice.tsx
+++ b/src/hooks/sdk/useSelectAudioOutputDevice.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useCallback } from 'react';

--- a/src/hooks/sdk/useSelectVideoInputDevice.tsx
+++ b/src/hooks/sdk/useSelectVideoInputDevice.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useCallback } from 'react';

--- a/src/hooks/sdk/useSelectVideoQuality.tsx
+++ b/src/hooks/sdk/useSelectVideoQuality.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useCallback } from 'react';

--- a/src/hooks/sdk/useToggleLocalMute.tsx
+++ b/src/hooks/sdk/useToggleLocalMute.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, useState, useCallback } from 'react';

--- a/src/hooks/useApplyVideoObjectFit/index.tsx
+++ b/src/hooks/useApplyVideoObjectFit/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, RefObject } from 'react';

--- a/src/hooks/useClickOutside/index.tsx
+++ b/src/hooks/useClickOutside/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, RefObject } from 'react';

--- a/src/hooks/useElementAspectRatio/index.tsx
+++ b/src/hooks/useElementAspectRatio/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useEffect, useLayoutEffect, useState, RefObject } from 'react';

--- a/src/hooks/useFocusIn/index.tsx
+++ b/src/hooks/useFocusIn/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useState, useEffect, useRef, RefObject } from 'react';

--- a/src/hooks/useMouseMove/index.tsx
+++ b/src/hooks/useMouseMove/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useState, useEffect, useRef, RefObject } from 'react';

--- a/src/hooks/useTabOutside/index.tsx
+++ b/src/hooks/useTabOutside/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, RefObject } from 'react';

--- a/src/hooks/useUniqueId/index.tsx
+++ b/src/hooks/useUniqueId/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useState } from 'react';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Components

--- a/src/providers/AudioVideoProvider/index.tsx
+++ b/src/providers/AudioVideoProvider/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { createContext, useState, useContext, useEffect } from 'react';

--- a/src/providers/ContentShareProvider/index.tsx
+++ b/src/providers/ContentShareProvider/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, {

--- a/src/providers/ContentShareProvider/state.tsx
+++ b/src/providers/ContentShareProvider/state.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { VideoTileState } from 'amazon-chime-sdk-js';

--- a/src/providers/DevicesProvider/AudioInputProvider.tsx
+++ b/src/providers/DevicesProvider/AudioInputProvider.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, {

--- a/src/providers/DevicesProvider/AudioOutputProvider.tsx
+++ b/src/providers/DevicesProvider/AudioOutputProvider.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, {

--- a/src/providers/DevicesProvider/VideoInputProvider.tsx
+++ b/src/providers/DevicesProvider/VideoInputProvider.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, {

--- a/src/providers/DevicesProvider/index.tsx
+++ b/src/providers/DevicesProvider/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/providers/FeaturedVideoTileProvider/index.tsx
+++ b/src/providers/FeaturedVideoTileProvider/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, {

--- a/src/providers/LocalAudioOutputProvider/index.tsx
+++ b/src/providers/LocalAudioOutputProvider/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, {

--- a/src/providers/LocalVideoProvider/index.tsx
+++ b/src/providers/LocalVideoProvider/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, {

--- a/src/providers/MeetingEventProvider/index.tsx
+++ b/src/providers/MeetingEventProvider/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { createContext, useState, useContext, useEffect } from 'react';

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import {

--- a/src/providers/MeetingProvider/index.tsx
+++ b/src/providers/MeetingProvider/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useContext, useState, createContext } from 'react';

--- a/src/providers/MeetingProvider/types.ts
+++ b/src/providers/MeetingProvider/types.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { EventReporter, LogLevel, VideoDownlinkBandwidthPolicy, Logger } from 'amazon-chime-sdk-js';

--- a/src/providers/NotificationProvider/index.tsx
+++ b/src/providers/NotificationProvider/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useReducer, Dispatch, useContext } from 'react';

--- a/src/providers/NotificationProvider/state.ts
+++ b/src/providers/NotificationProvider/state.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { v4 as uuidv4 } from 'uuid';

--- a/src/providers/RemoteVideoTileProvider/index.tsx
+++ b/src/providers/RemoteVideoTileProvider/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useContext, useEffect, useReducer, createContext } from 'react';

--- a/src/providers/RemoteVideoTileProvider/state.tsx
+++ b/src/providers/RemoteVideoTileProvider/state.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 type tileMap = {

--- a/src/providers/RosterProvider/index.tsx
+++ b/src/providers/RosterProvider/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState, useEffect, useRef, useMemo, useContext } from 'react';

--- a/src/providers/UserActivityProvider/index.tsx
+++ b/src/providers/UserActivityProvider/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { createContext, FC, useContext, useMemo, useRef } from 'react';

--- a/src/providers/VoiceFocusProvider/index.tsx
+++ b/src/providers/VoiceFocusProvider/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, {

--- a/src/theme/GlobalStyles.ts
+++ b/src/theme/GlobalStyles.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { createGlobalStyle } from 'styled-components';

--- a/src/theme/StyledReset.ts
+++ b/src/theme/StyledReset.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { css } from 'styled-components';

--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import defaultTheme from './default';

--- a/src/theme/default.ts
+++ b/src/theme/default.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { Breakpoints } from './styled';

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 export { lightTheme } from './light';

--- a/src/theme/light.ts
+++ b/src/theme/light.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import defaultTheme from './default';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 export type Direction = 'up' | 'right' | 'down' | 'left';

--- a/src/utils/animations.ts
+++ b/src/utils/animations.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { keyframes } from 'styled-components'

--- a/src/utils/device-utils.ts
+++ b/src/utils/device-utils.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { DeviceType } from '../types';

--- a/src/utils/style.ts
+++ b/src/utils/style.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { css } from 'styled-components';

--- a/src/utils/trap-focus.ts
+++ b/src/utils/trap-focus.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { KEY_CODES } from '../constants';

--- a/src/utils/use-memo-compare.ts
+++ b/src/utils/use-memo-compare.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, useRef, } from 'react';

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 export class Versioning {

--- a/tst/components/ui/Badge/index.test.tsx
+++ b/tst/components/ui/Badge/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Button/IconButton.test.tsx
+++ b/tst/components/ui/Button/IconButton.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Button/PrimaryButton.test.tsx
+++ b/tst/components/ui/Button/PrimaryButton.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Button/SecondaryButton.test.tsx
+++ b/tst/components/ui/Button/SecondaryButton.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Button/index.test.tsx
+++ b/tst/components/ui/Button/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Chat/ChannelList/ChannelItem.test.tsx
+++ b/tst/components/ui/Chat/ChannelList/ChannelItem.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Chat/ChannelList/index.test.tsx
+++ b/tst/components/ui/Chat/ChannelList/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Chat/ChatBubble/ChatBubbleContainer.test.tsx
+++ b/tst/components/ui/Chat/ChatBubble/ChatBubbleContainer.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Chat/ChatBubble/EditableChatBubble.test.tsx
+++ b/tst/components/ui/Chat/ChatBubble/EditableChatBubble.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Chat/ChatBubble/index.test.tsx
+++ b/tst/components/ui/Chat/ChatBubble/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Chat/InfiniteList/index.test.tsx
+++ b/tst/components/ui/Chat/InfiniteList/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Chat/MessageAttachment/index.test.tsx
+++ b/tst/components/ui/Chat/MessageAttachment/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Checkbox/index.test.tsx
+++ b/tst/components/ui/Checkbox/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/ContentTile/index.test.tsx
+++ b/tst/components/ui/ContentTile/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/ControlBar/ControlBarButton.test.tsx
+++ b/tst/components/ui/ControlBar/ControlBarButton.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/ControlBar/index.test.tsx
+++ b/tst/components/ui/ControlBar/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Flex/index.test.tsx
+++ b/tst/components/ui/Flex/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/FormField/index.test.tsx
+++ b/tst/components/ui/FormField/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Grid/index.test.tsx
+++ b/tst/components/ui/Grid/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Heading/index.test.tsx
+++ b/tst/components/ui/Heading/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Input/InputWrapper.test.tsx
+++ b/tst/components/ui/Input/InputWrapper.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Input/SearchInput.test.tsx
+++ b/tst/components/ui/Input/SearchInput.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Input/index.test.tsx
+++ b/tst/components/ui/Input/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Label/index.test.tsx
+++ b/tst/components/ui/Label/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/MicVolumeIndicator/index.test.tsx
+++ b/tst/components/ui/MicVolumeIndicator/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Modal/ModalBody.test.tsx
+++ b/tst/components/ui/Modal/ModalBody.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Modal/ModalButton.test.tsx
+++ b/tst/components/ui/Modal/ModalButton.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Modal/ModalButtonGroup.test.tsx
+++ b/tst/components/ui/Modal/ModalButtonGroup.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Modal/ModalHeader.test.tsx
+++ b/tst/components/ui/Modal/ModalHeader.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Modal/index.test.tsx
+++ b/tst/components/ui/Modal/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Navbar/NavbarHeader.test.tsx
+++ b/tst/components/ui/Navbar/NavbarHeader.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/tst/components/ui/Navbar/NavbarItem.test.tsx
+++ b/tst/components/ui/Navbar/NavbarItem.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/tst/components/ui/Navbar/index.test.tsx
+++ b/tst/components/ui/Navbar/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/tst/components/ui/Notification/index.test.tsx
+++ b/tst/components/ui/Notification/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/tst/components/ui/NotificationGroup/index.test.tsx
+++ b/tst/components/ui/NotificationGroup/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/tst/components/ui/PopOver/PopOverHeader.test.tsx
+++ b/tst/components/ui/PopOver/PopOverHeader.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/PopOver/PopOverItem.test.tsx
+++ b/tst/components/ui/PopOver/PopOverItem.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/PopOver/PopOverSeparator.test.tsx
+++ b/tst/components/ui/PopOver/PopOverSeparator.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/PopOver/PopOverSubMenu.test.tsx
+++ b/tst/components/ui/PopOver/PopOverSubMenu.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/PopOver/index.test.tsx
+++ b/tst/components/ui/PopOver/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Portal/index.test.tsx
+++ b/tst/components/ui/Portal/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Radio/index.test.tsx
+++ b/tst/components/ui/Radio/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/RadioGroup/index.test.tsx
+++ b/tst/components/ui/RadioGroup/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Roster/RosterGroup.test.tsx
+++ b/tst/components/ui/Roster/RosterGroup.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Roster/RosterHeader.test.tsx
+++ b/tst/components/ui/Roster/RosterHeader.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ChangeEvent } from 'react';

--- a/tst/components/ui/Roster/index.test.tsx
+++ b/tst/components/ui/Roster/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Select/index.test.tsx
+++ b/tst/components/ui/Select/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/Textarea/index.test.tsx
+++ b/tst/components/ui/Textarea/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/UserActivityManager/index.test.tsx
+++ b/tst/components/ui/UserActivityManager/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/VideoGrid/index.test.tsx
+++ b/tst/components/ui/VideoGrid/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/components/ui/VideoTile/index.test.tsx
+++ b/tst/components/ui/VideoTile/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom';

--- a/tst/snapshots/Badge/index.test.tsx
+++ b/tst/snapshots/Badge/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('Badge', () => {

--- a/tst/snapshots/Button/BasicButton/index.test.tsx
+++ b/tst/snapshots/Button/BasicButton/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('Basic Button', () => {

--- a/tst/snapshots/Button/IconButton/index.test.tsx
+++ b/tst/snapshots/Button/IconButton/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('Icon Button', () => {

--- a/tst/snapshots/Button/PrimaryButton/index.test.tsx
+++ b/tst/snapshots/Button/PrimaryButton/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('Primary Button', () => {

--- a/tst/snapshots/Button/SecondaryButton/index.test.tsx
+++ b/tst/snapshots/Button/SecondaryButton/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('Secondary Button', () => {

--- a/tst/snapshots/Chat/ChannelList/index.test.tsx
+++ b/tst/snapshots/Chat/ChannelList/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('ChannelList', () => {

--- a/tst/snapshots/Chat/ChatBubble/index.test.tsx
+++ b/tst/snapshots/Chat/ChatBubble/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('ChatBubble', () => {

--- a/tst/snapshots/Chat/ChatBubbleContainer/index.test.tsx
+++ b/tst/snapshots/Chat/ChatBubbleContainer/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('ChatBubbleContainer', () => {

--- a/tst/snapshots/Chat/EditableChatBubble/index.test.tsx
+++ b/tst/snapshots/Chat/EditableChatBubble/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('EditableChatBubble', () => {

--- a/tst/snapshots/Chat/MessageAttachment/index.test.tsx
+++ b/tst/snapshots/Chat/MessageAttachment/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('MessageAttachment', () => {

--- a/tst/snapshots/Checkbox/index.test.tsx
+++ b/tst/snapshots/Checkbox/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('Checkbox', () => {

--- a/tst/snapshots/ControlBar/index.test.tsx
+++ b/tst/snapshots/ControlBar/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('ControlBar', () => {

--- a/tst/snapshots/Flex/index.test.tsx
+++ b/tst/snapshots/Flex/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('Flex Snapshots', () => {

--- a/tst/snapshots/FormField/index.test.tsx
+++ b/tst/snapshots/FormField/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('FormField', () => {

--- a/tst/snapshots/Grid/index.test.tsx
+++ b/tst/snapshots/Grid/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('Grid Snapshots', () => {

--- a/tst/snapshots/Heading/index.test.tsx
+++ b/tst/snapshots/Heading/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('Heading', () => {

--- a/tst/snapshots/Input/index.test.tsx
+++ b/tst/snapshots/Input/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('Input', () => {

--- a/tst/snapshots/Label/index.test.tsx
+++ b/tst/snapshots/Label/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('Label', () => {

--- a/tst/snapshots/Modal/index.test.tsx
+++ b/tst/snapshots/Modal/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('Modal', () => {

--- a/tst/snapshots/NavBar/index.test.tsx
+++ b/tst/snapshots/NavBar/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('Nav Bar', () => {

--- a/tst/snapshots/RadioGroup/index.test.tsx
+++ b/tst/snapshots/RadioGroup/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('Radio Group', () => {

--- a/tst/snapshots/Select/index.test.tsx
+++ b/tst/snapshots/Select/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('Select', () => {

--- a/tst/snapshots/Textarea/index.test.tsx
+++ b/tst/snapshots/Textarea/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('Textarea', () => {

--- a/tst/snapshots/VideoGrid/index.test.tsx
+++ b/tst/snapshots/VideoGrid/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('VideoGrid', () => {

--- a/tst/snapshots/VideoTile/index.test.tsx
+++ b/tst/snapshots/VideoTile/index.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 describe('VideoTile', () => {

--- a/tst/utils/style.test.tsx
+++ b/tst/utils/style.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import { hexTorgba, isValidCSSHex } from '../../src/utils/style';

--- a/tst/utils/trap-focus.test.tsx
+++ b/tst/utils/trap-focus.test.tsx
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';


### PR DESCRIPTION
**Issue #:** N/A

**Description of changes:**
* Update the `check-codestyle.js`, removing the year in the copy right checker
* Update the header/footer copyright of all files

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes? Run `node scripts/check-codestyle` and success

3. If you made changes to the component library, have you provided corresponding documentation changes? Yes, add details in the Change log.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
