### PR TITLE
Export useVoiceFocus hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,7 @@ export { useApplyVideoObjectFit } from './hooks/useApplyVideoObjectFit';
 export { useElementAspectRatio } from './hooks/useElementAspectRatio';
 
 export { useMeetingManager } from './providers/MeetingProvider';
-export { VoiceFocusProvider } from './providers/VoiceFocusProvider';
+export { VoiceFocusProvider, useVoiceFocus } from './providers/VoiceFocusProvider';
 export { useAudioVideo } from './providers/AudioVideoProvider';
 export { useRosterState } from './providers/RosterProvider';
 export { useRemoteVideoTileState } from './providers/RemoteVideoTileProvider';
@@ -170,6 +170,7 @@ export { lightTheme, darkTheme, GlobalStyles, StyledReset } from './theme';
 
 // Types
 export { VideoQuality } from './hooks/sdk/useSelectVideoQuality';
+export { RosterAttendeeType, RosterType } from './types';
 
 // enums
 export {
@@ -177,7 +178,7 @@ export {
   DevicePermissionStatus,
   DeviceLabels,
   DeviceLabelTrigger,
-} from './types/index';
+} from './types';
 export { Severity, ActionType } from './providers/NotificationProvider';
 
 // Class


### PR DESCRIPTION
**Issue #:** [#601](https://github.com/aws/amazon-chime-sdk-component-library-react/issues/601)

**Description of changes:**
Export `useVoiceFocus` hook, type `RosterAttendeeType` and `RosterType`.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes? Run `npm run build` and pack the component as a tar file, then install the tar file in the meeting demo. Import the `useVoiceFocus` from React library,  it works as expected.

3. If you made changes to the component library, have you provided corresponding documentation changes? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
