### PR TITLE
Remove audio video observers in the audioVideoDidStop()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+### Added
+
+### Changed
+
+- Remove the audio video observers in the `audioVideoDidStop()` function instead of `leave()` function in the `MeetingManager`.
+
+### Removed
+
 ## [2.9.1] - 2021-09-02
 
 ### Fixed

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -229,7 +229,6 @@ export class MeetingManager implements AudioVideoObserver {
       }
 
       this.audioVideo.stop();
-      this.audioVideo.removeObserver(this.audioVideoObservers);
     }
     this.initializeMeetingManager();
     this.publishAudioVideo();
@@ -329,6 +328,11 @@ export class MeetingManager implements AudioVideoObserver {
     } else {
       console.log(`[MeetingManager audioVideoDidStop] session stopped with code ${sessionStatusCode}`);
     }
+    
+    if (this.audioVideo) {
+      this.audioVideo.removeObserver(this.audioVideoObservers);
+    }
+    
     this.leave();
   };
 


### PR DESCRIPTION
**Issue #:** [#605](https://github.com/aws/amazon-chime-sdk-component-library-react/issues/605)

**Description of changes:**
The `audioVideoDidStop()` has not been called when attendee leaves/ends the meeting. The root issue is that we remove all observers before the `audioVideoDidStop()` being called in the `audioVideo.stop()`. So remove the audio video observers in the `audioVideoDidStop()` function instead of `leave()` function.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes?
    - Join the meeting
    - Leave meeting
    - `audioVideoDidStop` is called since there is a log `[MeetingManager audioVideoDidStop]` in the develop tool.
    - Join the meeting
    - End the meeting for all
    - `audioVideoDidStop` is called again.
    - Join the meeting again
    - Disconnect the network
    - `audioVideoDidStop` is called after 2 mins

3. If you made changes to the component library, have you provided corresponding documentation changes? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
