### PR TITLE
Fix CHANGELOG check script

### DIFF
--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -82,12 +82,14 @@ When bot submits PR two git context parameters are set.
   labels.filter(lbl => lbl.name === 'dependencies').length === 1
 ) {
   logger.log('Skipping CHANGELOG.md verification.');
-} else if (!commit_files.includes('./src')) {
+} else {
+  if (commit_files.filter(file => file.includes('src/')).length) {
+    logger.error(
+      `Error: Does not contain CHANGELOG.md in the commit ${commits[0]}\nPlease add CHANGELOG for library src changes.
+    `);
+    return process.exit(1);
+  }
   // Only require a changelog change for changes to the component library
   logger.log('Skipping CHANGELOG.md verification.');
-} else {
-  logger.error(
-    `Error: Does not contain CHANGELOG.md in the commit ${commits[0]}`
-  );
-  return process.exit(1);
+  return process.exit(0);
 }


### PR DESCRIPTION
**Issue #:** 
- The changelog checking is broken and the `npm run build:release` will succeed even if you change something in `src` directory and do not include CHANGELOG for it.
- This PR fixes it.

**Description of changes:**
- Running `npm run build:release` runs `prebuild.js` which checks for `src/` changes and needs a `CHANGELOG` update for those changes.
- The commit files is an array and we do not check for each file in the array hence the check is broken and results into a success even if we change files in `src` directory.
- I just updated the check to go through all files.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes.

2. How did you test these changes?
2.1. Changed `src/providers/MeetingProvider/MeetingManagar.ts` but did not add changelog for it.
2.2. Commit it and run `npm run build:release` or just `node scripts/prebuild.js` to test and checked it that it should fail.

3. If you made changes to the component library, have you provided corresponding documentation changes? NA.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
