### PR TITLE
Remove package-lock to fix npm install in GitHub actions

### DIFF
--- a/scripts/update-sdk-version.js
+++ b/scripts/update-sdk-version.js
@@ -7,8 +7,13 @@ const {
   updateDependency
 } = require('./utilities');
 
-// Install the latest version of JS SDK 
+// Install the latest version of JS SDK
 process.chdir(path.join(__dirname, '../amazon-chime-sdk/apps/meeting'));
+
+// Remove package-lock to avoid running into fsevents bad platform issue.
+// https://github.com/fsevents/fsevents/issues/336
+// We use Node 16 and it is not stable which breaks the package installation.
+fs.rmSync('./package-lock.json');
 updateDependency('amazon-chime-sdk-js');
 
 // Get the version of the React library tar file


### PR DESCRIPTION
**Issue #:** 
- NPM install fails in GitHub action as it uses ubuntu machine when installing `fsevents`.
- The `fsevents` has a OS field in `package-lock` which supports `darwin` hence installation fails in `ubuntu` VMs.
- We use node 16 in GA which is not stable, some versions don't break (16.3.0 - 16.8.0) while some do (16.9.0 onwards).

**Description of changes:**
- To avoid above issue, remove `package-lock` to do a fresh installation when GA runs in `ubuntu` VM.

**Testing**
1. Have you successfully run `npm run build:release` locally? Not needed.

2. How did you test these changes? Will test in GA. But verified in Cloud 9 ubuntu VM.

3. If you made changes to the component library, have you provided corresponding documentation changes? NA.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
