### PR TITLE
Update VoiceFocusProvider and useVoiceFocus in storybook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Remove the audio video observers in the `audioVideoDidStop()` function instead of `leave()` function in the `MeetingManager`.
+- Update `VoiceFocusProvider` and `useVoiceFocus` documentation in the storybook.
 
 ### Removed
 

--- a/src/providers/VoiceFocusProvider/docs/VoiceFocusProvider.stories.mdx
+++ b/src/providers/VoiceFocusProvider/docs/VoiceFocusProvider.stories.mdx
@@ -1,3 +1,6 @@
+import { Props } from '@storybook/addon-docs/blocks';
+import { VoiceFocusProvider } from '../';
+
 <Meta title="SDK Providers/VoiceFocusProvider" />
 
 # VoiceFocusProvider
@@ -21,6 +24,10 @@ This provider is independent from `MeetingProvider`. You can put `VoiceFocusProv
 
 You can access the state by using the [useVoiceFocus](/docs/sdk-hooks-usevoicefocus--page) hook.
 
+## Props
+
+<Props of={VoiceFocusProvider} />
+
 ## Importing
 
 ```javascript
@@ -31,6 +38,7 @@ import { VoiceFocusProvider } from 'amazon-chime-sdk-component-library-react';
 
 ```jsx
 import React from 'react';
+import { VoiceFocusTransformDevice } from 'amazon-chime-sdk-js';
 import {
   MeetingProvider,
   VoiceFocusProvider,
@@ -50,7 +58,7 @@ const MyChild = () => {
   const meetingManager = useMeetingManager();
   const [isVoiceFocusOn, setIsVoiceFocusOn] = useState(false);
   const [isVoiceFocusEnabled, setIsVoiceFocusEnabled] = useState(false);
-  const [device, setDevice] = useState(meetingManager.selectedAudioInputTransformDevice)
+  const [device, setDevice] = useState(meetingManager.selectedAudioInputDevice);
   const {isVoiceFocusSupported, addVoiceFocus} = useVoiceFocus();
 
   useEffect(() => {
@@ -71,17 +79,22 @@ const MyChild = () => {
   }, [device]);
 
   useEffect(() => {
-    let current = device;
-    if (isVoiceFocusOn) {
-      const currentDevice = audioInputSelectionToDevice(device);
-      current = addVoiceFocus(currentDevice);
-    } else {
-      if (device instanceof VoiceFocusTransformDevice) {
-        current = device.getInnerDevice();
+    async function onVFCheckboxChange() {
+      let current = device;
+      if (isVoiceFocusOn) {
+        if (typeof (device) === 'string') {
+          current = await addVoiceFocus(device);
+        }
+      } else {
+        if (device instanceof VoiceFocusTransformDevice) {
+          current = device.getInnerDevice();
+        }
       }
+      await meetingManager.selectAudioInputDevice(current);
     }
-    meetingManager.selectAudioInputDevice(current);
-  }, [isVoiceFocusOn];
+    
+    onVFCheckboxChange();
+  }, [isVoiceFocusOn]);
 
   const onClick = () => {
     setIsVoiceFocusOn(current => !current);

--- a/src/providers/VoiceFocusProvider/docs/useVoiceFocus.stories.mdx
+++ b/src/providers/VoiceFocusProvider/docs/useVoiceFocus.stories.mdx
@@ -32,6 +32,7 @@ The hook depends on the `VoiceFocusProvider`. You can use it with `MeetingProvid
 
 ```jsx
 import React from 'react';
+import { VoiceFocusTransformDevice } from 'amazon-chime-sdk-js';
 import {
   MeetingProvider,
   VoiceFocusProvider,
@@ -51,7 +52,7 @@ const MyChild = () => {
   const meetingManager = useMeetingManager();
   const [isVoiceFocusOn, setIsVoiceFocusOn] = useState(false);
   const [isVoiceFocusEnabled, setIsVoiceFocusEnabled] = useState(false);
-  const [device, setDevice] = useState(meetingManager.selectedAudioInputTransformDevice)
+  const [device, setDevice] = useState(meetingManager.selectedAudioInputDevice);
   const {isVoiceFocusSupported, addVoiceFocus} = useVoiceFocus();
 
   useEffect(() => {
@@ -72,17 +73,22 @@ const MyChild = () => {
   }, [device]);
 
   useEffect(() => {
-    let current = device;
-    if (isVoiceFocusOn) {
-      const currentDevice = audioInputSelectionToDevice(device);
-      current = addVoiceFocus(currentDevice);
-    } else {
-      if (device instanceof VoiceFocusTransformDevice) {
-        current = device.getInnerDevice();
+    async function onVFCheckboxChange() {
+      let current = device;
+      if (isVoiceFocusOn) {
+        if (typeof (device) === 'string') {
+          current = await addVoiceFocus(device);
+        }
+      } else {
+        if (device instanceof VoiceFocusTransformDevice) {
+          current = device.getInnerDevice();
+        }
       }
+      await meetingManager.selectAudioInputDevice(current);
     }
-    meetingManager.selectAudioInputDevice(current);
-  }, [isVoiceFocusOn];
+    
+    onVFCheckboxChange();
+  }, [isVoiceFocusOn]);
 
   const onClick = () => {
     setIsVoiceFocusOn(current => !current);


### PR DESCRIPTION
**Issue #:** N/A

**Description of changes:**
Update the `VoiceFocusProvider` and `useVoiceFocus` documentation in the storybook. 
* Update the default value of `device`
* Remove `audioInputSelectionToDevice` function since it is not exported from React component library
* Document props, so builders can know how to change `spec`. [Issues 612](https://github.com/aws/amazon-chime-sdk-component-library-react/issues/612)

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? 1. Apply the code in the meeting demo and it works as expected. 2. Run story book locally

3. If you made changes to the component library, have you provided corresponding documentation changes? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
