### PR TITLE
Add activeSpeakerPolicy and videoUplinkBandwidthPolicy in meeting manager config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build
 coverage
 tst/snapshots/**/__diff_output__
 .out
+.idea
+*.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Added
+- Add `activeSpeakerPolicy` and `videoUplinkBandwidthPolicy` in `MeetingManagerConfig` to allow builders to pass in 
+  custom policies.
+- For more flexibility, allow passing `MeetingManagerConfig` to `meetingManager.join` method. Passing the config here would override config passed through `MeetingProvider` props.
 
 ### Changed
-
 - Remove the audio video observers in the `audioVideoDidStop()` function instead of `leave()` function in the `MeetingManager`.
 
 ### Removed

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,6 +186,7 @@ export { MeetingManager } from './providers/MeetingProvider/MeetingManager';
 
 // Interface
 export { NotificationType, Action } from './providers/NotificationProvider';
+export { MeetingManagerConfig } from './providers/MeetingProvider/types';
 
 // Utilities
 export { Versioning } from './versioning/Versioning';

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -36,7 +36,7 @@ import {
   AttendeeResponse,
   FullDeviceInfoType,
   PostLogConfig,
-  ManagerConfig
+  MeetingManagerConfig
 } from './types';
 
 function noOpDeviceLabelHook(): Promise<MediaStream> {
@@ -114,30 +114,30 @@ export class MeetingManager implements AudioVideoObserver {
   ) => void)[] = [];
 
   // This variable will be deprecated in favor of `meetingManagerConfig`.
-  // Please use `meetingManagerConfig` to use `ManagerConfig` values.
+  // Please use `meetingManagerConfig` to use `MeetingManagerConfig` values.
   logLevel: LogLevel = LogLevel.WARN;
 
   // This variable will be deprecated in favor of `meetingManagerConfig`.
-  // Please use `meetingManagerConfig` to use `ManagerConfig` values.
+  // Please use `meetingManagerConfig` to use `MeetingManagerConfig` values.
   postLoggerConfig: PostLogConfig | null = null;
 
   eventReporter: EventReporter;
 
   // This variable will be deprecated in favor of `meetingManagerConfig`.
-  // Please use `meetingManagerConfig` to use `ManagerConfig` values.
+  // Please use `meetingManagerConfig` to use `MeetingManagerConfig` values.
   simulcastEnabled: boolean = false;
 
   // This variable will be deprecated in favor of `meetingManagerConfig`.
-  // Please use `meetingManagerConfig` to use `ManagerConfig` values.
+  // Please use `meetingManagerConfig` to use `MeetingManagerConfig` values.
   videoDownlinkBandwidthPolicy: VideoDownlinkBandwidthPolicy | undefined;
 
   // This variable will be deprecated in favor of `meetingManagerConfig`.
-  // Please use `meetingManagerConfig` to use `ManagerConfig` values.
+  // Please use `meetingManagerConfig` to use `MeetingManagerConfig` values.
   logger: Logger | undefined;
 
   private meetingEventObserverSet = new Set<(name: EventName, attributes: EventAttributes) => void>();
 
-  constructor(private meetingManagerConfig: ManagerConfig) {
+  constructor(private meetingManagerConfig: MeetingManagerConfig) {
     const {
       simulcastEnabled,
       logger: configLogger,
@@ -188,7 +188,10 @@ export class MeetingManager implements AudioVideoObserver {
     this.audioVideoObservers = {};
   }
 
-  async join({ meetingInfo, attendeeInfo, deviceLabels = DeviceLabels.AudioAndVideo, eventReporter }: MeetingJoinData) {
+  async join({ meetingInfo, attendeeInfo, deviceLabels = DeviceLabels.AudioAndVideo, eventReporter, meetingManagerConfig }: MeetingJoinData) {
+    if (meetingManagerConfig) {
+      this.meetingManagerConfig = meetingManagerConfig;
+    }
     this.configuration = new MeetingSessionConfiguration(
       meetingInfo,
       attendeeInfo
@@ -247,6 +250,7 @@ export class MeetingManager implements AudioVideoObserver {
       simulcastEnabled,
       enableWebAudio,
       logger: configLogger,
+      videoUplinkBandwidthPolicy,
       videoDownlinkBandwidthPolicy
     } = this.meetingManagerConfig;
 
@@ -257,6 +261,10 @@ export class MeetingManager implements AudioVideoObserver {
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
     }
     const logger = configLogger ? configLogger : this.createLogger(configuration);
+
+    if (videoUplinkBandwidthPolicy) {
+      configuration.videoUplinkBandwidthPolicy = videoUplinkBandwidthPolicy;
+    }
 
     if (videoDownlinkBandwidthPolicy) {
       configuration.videoDownlinkBandwidthPolicy = videoDownlinkBandwidthPolicy;
@@ -328,11 +336,11 @@ export class MeetingManager implements AudioVideoObserver {
     } else {
       console.log(`[MeetingManager audioVideoDidStop] session stopped with code ${sessionStatusCode}`);
     }
-    
+
     if (this.audioVideo) {
       this.audioVideo.removeObserver(this.audioVideoObservers);
     }
-    
+
     this.leave();
   };
 
@@ -409,6 +417,8 @@ export class MeetingManager implements AudioVideoObserver {
   }
 
   setupActiveSpeakerDetection(): void {
+    const activeSpeakerPolicy  = this.meetingManagerConfig.activeSpeakerPolicy;
+
     this.publishActiveSpeaker();
 
     this.activeSpeakerListener = (activeSpeakers: string[]) => {
@@ -417,7 +427,7 @@ export class MeetingManager implements AudioVideoObserver {
     };
 
     this.audioVideo?.subscribeToActiveSpeakerDetector(
-      new DefaultActiveSpeakerPolicy(),
+      activeSpeakerPolicy ? activeSpeakerPolicy : new DefaultActiveSpeakerPolicy(),
       this.activeSpeakerListener
     );
   }

--- a/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
+++ b/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
@@ -34,7 +34,9 @@ const MyApp = () => {
 
 ## Constructor
 
-Accepts a config object of `logLevel`, `postLogConfig`, `simulcastEnabled`, `enableWebAudio`, `logger` and `videoDownlinkBandwidthPolicy` that will be used when initializing a meeting session. See [MeetingProvider](/docs/sdk-providers-meetingprovider--page) documentation for more details.
+Accepts a config object of `logLevel`, `postLogConfig`, `simulcastEnabled`, `enableWebAudio`, `logger`,
+`activeSpeakerPolicy`, `videoUplinkBandwidthPolicy`, and `videoDownlinkBandwidthPolicy` that will be used when
+joining a meeting session. See [MeetingProvider](/docs/sdk-providers-meetingprovider--page) documentation for more details.
 
 ## Interface
 
@@ -44,6 +46,7 @@ Creates a meeting session using the meeting and attendee data passed. It will at
 
 ```typescript
 import { EventReporter } from 'amazon-chime-sdk-js';
+import { MeetingManagerConfig } from 'amazon-chime-sdk-component-library-react';
 
 (data: MeetingJoinData) => Promise<void>
 
@@ -60,6 +63,9 @@ interface MeetingJoinData {
 
   // Override the default event reporter in the Amazon Chime SDK for JavaScript.
   eventReporter: EventReporter;
+
+  // Set the meeting config. This will override the props from MeetingProvider.
+  meetingManagerConfig: MeetingManagerConfig;
 }
 ```
 
@@ -136,7 +142,7 @@ Please make sure your app calls `meetingManager.join()` only once with the same 
 Otherwise,  the previous attendee who joined the meeting will leave the meeting with [AudioJoinedFromAnotherDevice](https://aws.github.io/amazon-chime-sdk-js/enums/meetingsessionstatuscode.html#audiojoinedfromanotherdevice).
 
 You can create a new `MeetingManager` instance and then pass it as a prop to your `MeetingProvider`s. If not passed,
-a new `MeetingManager` instance will be created internally with each `MeetingProvider` when rendered; and, 
+a new `MeetingManager` instance will be created internally with each `MeetingProvider` when rendered; and,
 you will get the `MeetingManager` instance associated with that particular `MeetingProvider` when `useMeetingManager` hook is called.
 
 ```jsx
@@ -144,7 +150,7 @@ import { MeetingProvider, useMeetingManager } from 'amazon-chime-sdk-component-l
 
 const Root = () => {
   const meetingManager = new MeetingManager({ logLevel: LogLevel.INFO });
-  
+
   return (
     <MeetingProvider meetingManager={meetingManager}>
       <MyApp1 />
@@ -153,7 +159,7 @@ const Root = () => {
     <MeetingProvider meetingManager={meetingManager}>
       <MyApp2 />
     <MeetingProvider/>
-  ); 
+  );
 }
 ```
 

--- a/src/providers/MeetingProvider/docs/MeetingProvider.stories.mdx
+++ b/src/providers/MeetingProvider/docs/MeetingProvider.stories.mdx
@@ -45,7 +45,7 @@ import { MeetingProvider, useMeetingManager } from 'amazon-chime-sdk-component-l
 
 const Root = () => {
   const meetingManager = new MeetingManager({ logLevel: LogLevel.INFO });
-  
+
   return (
     <MeetingProvider meetingManager={meetingManager}>
       <MyApp1 />
@@ -54,7 +54,7 @@ const Root = () => {
     <MeetingProvider meetingManager={meetingManager}>
       <MyApp2 />
     <MeetingProvider/>
-  ); 
+  );
 }
 ```
 
@@ -105,10 +105,51 @@ If you want to enable Amazon Voice Focus feature, you should enable Web Audio fo
 The `Logger` object that you want to be used in the meeting session.
 If you pass in a `Logger` object using this parameter, the `MeetingManager` will use this object instead of creating a logger based on `logLevel` and `postLogConfig` to initialize the meeting session.
 
-#### videoDownlinkBandwidthPolicy
+#### activeSpeakerPolicy
 
-The `VideoDownlinkBandwidthPolicy` object that you want to be used in the meeting session.
-For more information on `VideoDownlinkBandwidthPolicy`, check Amazon Chime JS SDK [priority downlink policy guide](https://aws.github.io/amazon-chime-sdk-js/modules/prioritybased_downlink_policy.html).
+The `ActiveSpeakerPolicy` object that you want to be used in the meeting session.
+For more information on `ActiveSpeakerPolicy`, check Amazon Chime JS SDK [ActiveSpeakerPolicy](https://aws.github.io/amazon-chime-sdk-js/interfaces/activespeakerpolicy.html).
+
+For example, if you do not want to prioritize the active speaker during a call you can override the
+`DefaultActiveSpeakerPolicy`:
+```jsx
+import {
+  LogLevel,
+  ConsoleLogger,
+  DefaultActiveSpeakerPolicy,
+  VideoPriorityBasedPolicy,
+} from 'amazon-chime-sdk-js';
+import { MeetingProvider } from 'amazon-chime-sdk-component-library-react';
+
+class MyActiveSpeakerPolicy extends DefaultActiveSpeakerPolicy {
+  prioritizeVideoSendBandwidthForActiveSpeaker() {
+    return false;
+  }
+}
+
+const Root = () => {
+  const logger = new ConsoleLogger('SDK', LogLevel.INFO);
+  const activeSpeakerPolicy = new MyActiveSpeakerPolicy();
+  const meetingConfig = {
+    logger,
+    activeSpeakerPolicy,
+  };
+
+  return (
+    <MeetingProvider {...meetingConfig}>
+      <MyApp />
+    </MeetingProvider>
+  );
+};
+```
+
+#### videoUplinkBandwidthPolicy and videoDownlinkBandwidthPolicy
+
+The `VideoUplinkBandwidthPolicy` and `VideoDownlinkBandwidthPolicy` object that you want to be used in the meeting
+session.
+For more information on `VideoUplinkBandwidthPolicy` and `VideoDownlinkBandwidthPolicy`, check Amazon Chime JS SDK
+[VideoUplinkBandwidthPolicy](https://aws.github.io/amazon-chime-sdk-js/interfaces/videouplinkbandwidthpolicy.html)
+and [VideoDownlinkBandwidthPolicy](https://aws.github.io/amazon-chime-sdk-js/interfaces/videodownlinkbandwidthpolicy.html).
 
 For example, to use the `VideoPriorityBasedPolicy` in the meeting:
 
@@ -136,12 +177,13 @@ const Root = () => {
   );
 };
 ```
+For more information on `VideoPriorityBasedPolicy`, check Amazon Chime JS SDK [priority downlink policy guide](https://aws.github.io/amazon-chime-sdk-js/modules/prioritybased_downlink_policy.html).
 
 #### meetingManager
 
 There may be use cases to re-use the same `MeetingManager` instance across multiple different `MeetingProvider`s.
 Hence, you can create a new `MeetingManager` instance and then pass it as a prop to your `MeetingProvider`s. If not passed,
-a new `MeetingManager` instance will be created internally with each `MeetingProvider` when rendered; and, 
+a new `MeetingManager` instance will be created internally with each `MeetingProvider` when rendered; and,
 you will get the `MeetingManager` instance associated with that particular `MeetingProvider` when `useMeetingManager` hook is called.
 
 This approach has limitations. This should be used only in very specific cases where you want to share the meeting manager instance

--- a/src/providers/MeetingProvider/types.ts
+++ b/src/providers/MeetingProvider/types.ts
@@ -1,7 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { EventReporter, LogLevel, VideoDownlinkBandwidthPolicy, Logger } from 'amazon-chime-sdk-js';
+import {
+  EventReporter,
+  LogLevel,
+  VideoDownlinkBandwidthPolicy,
+  Logger,
+  ActiveSpeakerPolicy,
+  VideoUplinkBandwidthPolicy
+} from 'amazon-chime-sdk-js';
 import { DeviceLabels, DeviceLabelTrigger } from '../../types';
 
 export enum DevicePermissionStatus {
@@ -16,6 +23,7 @@ export interface MeetingJoinData {
   attendeeInfo: any;
   deviceLabels?: DeviceLabels | DeviceLabelTrigger;
   eventReporter?: EventReporter;
+  meetingManagerConfig?: MeetingManagerConfig;
 }
 
 export interface AttendeeResponse {
@@ -40,11 +48,13 @@ export interface PostLogConfig {
   logLevel: LogLevel;
 }
 
-export interface ManagerConfig {
+export interface MeetingManagerConfig {
   logLevel: LogLevel;
   postLogConfig?: PostLogConfig;
   simulcastEnabled?: boolean;
   enableWebAudio?: boolean;
   logger?: Logger;
+  activeSpeakerPolicy?: ActiveSpeakerPolicy;
+  videoUplinkBandwidthPolicy?: VideoUplinkBandwidthPolicy;
   videoDownlinkBandwidthPolicy?: VideoDownlinkBandwidthPolicy;
 }


### PR DESCRIPTION
**Description of changes:**
- Add `activeSpeakerPolicy` and `videoUplinkBandwidthPolicy` in meeting manager config to allow builders to pass in 
  custom policies.
- Allow passing in config in `meetingManager.join` to allow more flexibility.
- Export MeetingManagerConfig object.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes? 
- Verified passing custom active speaker policy and video uplink bandwidth policy to the React meeting demo.

3. If you made changes to the component library, have you provided corresponding documentation changes? Yes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
