### PR TITLE
Fix the issue that Amazon Voice Focus does not get applied on new devices in the middle of meeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Fix the issue that Amazon Voice Focus does not get applied on new devices in the middle of meeting
 
 ### Added
 - Add `activeSpeakerPolicy` and `videoUplinkBandwidthPolicy` in `MeetingManagerConfig` to allow builders to pass in 

--- a/src/components/sdk/MeetingControls/AudioInputVFControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioInputVFControl.tsx
@@ -119,6 +119,7 @@ const AudioInputVFControl: React.FC<Props> = ({
     addVoiceFocus,
     device,
     devices.length,
+    devices[0].label,
     isLoading,
     isVoiceFocusEnabled,
     isVoiceFocusOn,

--- a/src/providers/DevicesProvider/AudioInputProvider.tsx
+++ b/src/providers/DevicesProvider/AudioInputProvider.tsx
@@ -68,6 +68,9 @@ const AudioInputProvider: React.FC = ({ children }) => {
             'Previously selected audio input lost. Selecting a default device.'
           );
           meetingManager.selectAudioInputDevice(newAudioInputs[0].deviceId);
+
+          // Safari and Firefox don't have this "default" as device Id
+          // Only Chrome have this "default" device
         } else if (selectedInputRef.current === 'default') {
           console.log(
             `Audio devices updated and "default" device is selected. Reselecting input.`


### PR DESCRIPTION
**Issue #:** Amazon Voice Focus does not get applied on new audio-devices when connected mid-meeting.

**Description of changes:**
1. This issue only happens in Chrome, since only Chrome have the `default` device. If user selects a specific device or uses other browser such as Safari/FireFox, the current device won't be changed to the new device automatically which is expected.
2. The issue only happens when the new device is AirPods, since only AirPods have two steps to be the current device. When you open the container, AirPods will be shown in the device dropdown list; When you put AirPods on your ears, the current device will be set to AirPods automatically. However, the VF dropdown list only gets updated at the first step, since the length of available devices changes, and it won't be updated at the second step, since no dependencies change in this [useEffect](https://github.com/aws/amazon-chime-sdk-component-library-react/blob/master/src/components/sdk/MeetingControls/AudioInputVFControl.tsx#L119). The `selectedDevice` is still `default`.    

Fix: `devices[0]` stands for the default device in Chrome, so we can add `devices[0].label` as a dependency, since although the `selectedDevice`(`devices[0].deviceId`) keeps the same(`default`), but `devices[0].label` will change when a new device is set to the default device.

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? 1.Join the meeting in Chrome 2.Keep the default device as audio input 3.Enable Amazon Voice Focus 4.Apply a new audio device (AirPods) in the middle of meeting 5.Current audio device switches to AirPods voice focus transform device.

3. If you made changes to the component library, have you provided corresponding documentation changes? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
