### PR TITLE
Add Amazon Voice Focus to default device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Fix the issue that Amazon Voice Focus does not get applied on new devices in the middle of meeting
+- Fix the issue that Amazon Voice Focus does not get applied on new devices mid-meeting
 
 ### Added
 - Add `activeSpeakerPolicy` and `videoUplinkBandwidthPolicy` in `MeetingManagerConfig` to allow builders to pass in 

--- a/src/providers/DevicesProvider/AudioInputProvider.tsx
+++ b/src/providers/DevicesProvider/AudioInputProvider.tsx
@@ -9,13 +9,20 @@ import React, {
   useMemo,
   useRef,
 } from 'react';
-import { DeviceChangeObserver } from 'amazon-chime-sdk-js';
+
+import { 
+  DeviceChangeObserver, 
+  isAudioTransformDevice, 
+  Device, 
+  VoiceFocusTransformDevice,
+} from 'amazon-chime-sdk-js';
 
 import { useAudioVideo } from '../AudioVideoProvider';
 import { useMeetingManager } from '../MeetingProvider';
 import { getFormattedDropdownDeviceOptions } from '../../utils/device-utils';
 import { DeviceTypeContext, DeviceConfig } from '../../types';
 import { AUDIO_INPUT } from '../../constants/additional-audio-video-devices';
+import { useVoiceFocus } from '../VoiceFocusProvider';
 
 const Context = createContext<DeviceTypeContext | null>(null);
 
@@ -31,6 +38,7 @@ const AudioInputProvider: React.FC = ({ children }) => {
   const [selectAudioInputDeviceError, setSelectAudioInputDeviceError] = useState(
     meetingManager.selectAudioInputDeviceError
   );
+  const { addVoiceFocus } = useVoiceFocus();
 
   useEffect(() => {
     meetingManager.subscribeToSelectAudioInputDeviceError(setSelectAudioInputDeviceError);
@@ -76,7 +84,11 @@ const AudioInputProvider: React.FC = ({ children }) => {
             `Audio devices updated and "default" device is selected. Reselecting input.`
           );
           try {
-            await audioVideo?.chooseAudioInputDevice(selectedInputRef.current);
+            let currentDevice: Device | VoiceFocusTransformDevice   = 'default'
+            if (isAudioTransformDevice(meetingManager.selectedAudioInputTransformDevice)) {
+              currentDevice = await addVoiceFocus(newAudioInputs[0].deviceId);
+            }
+            await audioVideo?.chooseAudioInputDevice(currentDevice);
           } catch (e) {
             console.error(`Error in selecting audio input device - ${e}`);
           }


### PR DESCRIPTION
**Issue #:** Amazon Voice Focus does not get applied on new audio-devices when connected mid-meeting.

**Description of changes:**
Add Amazon Voice Focus to the default device when a new blue tooth device is plugged in during the meeting. 

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes? Open two Chrome tabs, select the default device as audio input and disable speaker in one tab, disable microphone and set built in device as speaker in another tab. Turn on Amazon Voice Focus in the first tab, and apply a new device (AirPods), the current device changes as AirPods. Then make some background noice, we don't hear any noice from the second tab, it shows Amazon Voice Focus is enabled in the first tab.

3. If you made changes to the component library, have you provided corresponding documentation changes? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
