### PR TITLE
Fix bug regarding setting meetingStatus to Loading when leaving meeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix the issue that Amazon Voice Focus does not get applied on new devices mid-meeting
+- Fix the issue where we call `meetingManager.leave` an additional time when we call `meetingManager.leave`
 
 ### Added
 - Add `activeSpeakerPolicy` and `videoUplinkBandwidthPolicy` in `MeetingManagerConfig` to allow builders to pass in 
   custom policies.
 - For more flexibility, allow passing `MeetingManagerConfig` to `meetingManager.join` method. Passing the config here would override config passed through `MeetingProvider` props.
+- Add `MeetingStatus.Left` and set it when explicitly leaving the meeting
+- Publish `MeetingStatus.Failed` when `audioVideoDidStop` gets triggered with one of the Failure types of `MeetingSessionStatus` 
+
 
 ### Changed
 - Remove the audio video observers in the `audioVideoDidStop()` function instead of `leave()` function in the `MeetingManager`.
 
 ### Removed
+- Remove setting the `MeetingStatus` to `MeetingStatus.Loading` when we call `meetingManager.leave`
 
 ## [2.9.1] - 2021-09-02
 

--- a/src/hooks/sdk/docs/useMeetingStatus.stories.mdx
+++ b/src/hooks/sdk/docs/useMeetingStatus.stories.mdx
@@ -10,6 +10,7 @@ enum MeetingStatus {
   Succeeded,
   Failed,
   Ended,
+  Left,
   JoinedFromAnotherDevice
 }
 ```

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -183,8 +183,6 @@ export class MeetingManager implements AudioVideoObserver {
     this.videoInputDevices = [];
     this.activeSpeakers = [];
     this.activeSpeakerListener = null;
-    this.meetingStatus = MeetingStatus.Loading;
-    this.publishMeetingStatus();
     this.audioVideoObservers = {};
   }
 
@@ -325,23 +323,40 @@ export class MeetingManager implements AudioVideoObserver {
 
   audioVideoDidStop = (sessionStatus: MeetingSessionStatus) => {
     const sessionStatusCode = sessionStatus.statusCode();
-    if (sessionStatusCode === MeetingSessionStatusCode.AudioCallEnded) {
-      console.log('[MeetingManager audioVideoDidStop] Meeting ended for all');
-      this.meetingStatus = MeetingStatus.Ended;
-      this.publishMeetingStatus();
-    } else if (sessionStatusCode === MeetingSessionStatusCode.AudioJoinedFromAnotherDevice) {
-      console.log('[MeetingManager audioVideoDidStop] Meeting joined from another device');
-      this.meetingStatus = MeetingStatus.JoinedFromAnotherDevice;
-      this.publishMeetingStatus();
-    } else {
-      console.log(`[MeetingManager audioVideoDidStop] session stopped with code ${sessionStatusCode}`);
+
+
+    switch (sessionStatusCode) {
+      case MeetingSessionStatusCode.AudioCallEnded: 
+        console.log('[MeetingManager audioVideoDidStop] Meeting ended for all');
+        this.meetingStatus = MeetingStatus.Ended;
+        this.publishMeetingStatus();
+        this.leave();
+        break;
+      case MeetingSessionStatusCode.Left:
+        console.log('[MeetingManager audioVideoDidStop] Left the meeting');
+        this.meetingStatus = MeetingStatus.Left;
+        this.publishMeetingStatus();
+        // No need to call leave() here, since we already called meetingManager.leave() to get here
+        break;
+      case MeetingSessionStatusCode.AudioJoinedFromAnotherDevice:
+        console.log('[MeetingManager audioVideoDidStop] Meeting joined from another device');
+        this.meetingStatus = MeetingStatus.JoinedFromAnotherDevice;
+        this.publishMeetingStatus();
+        this.leave();
+        break;
+      default:
+        // The following status codes are Failures according to MeetingSessionStatus
+        if (sessionStatus.isFailure()) {
+          this.meetingStatus = MeetingStatus.Failed;
+          this.publishMeetingStatus();
+        }
+        console.log('[MeetingManager audioVideoDidStop] session stopped with code ${sessionStatusCode}');
+        this.leave();
     }
 
     if (this.audioVideo) {
       this.audioVideo.removeObserver(this.audioVideoObservers);
     }
-
-    this.leave();
   };
 
   setupAudioVideoObservers() {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -44,6 +44,7 @@ export enum MeetingStatus {
   Succeeded,
   Failed,
   Ended,
+  Left,
   JoinedFromAnotherDevice,
 };
 


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
We don't want to set meetingStatus to Loading - this is the same state we use when we are joining a meeting. It can be confusing for builders if they are listening to this Loading state. 

**Testing**
1. Have you successfully run `npm run build:release` locally?
yes

2. How did you test these changes?
Start a meeting, leave a meeting.

3. If you made changes to the component library, have you provided corresponding documentation changes?
N/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
