### PR TITLE
Add MeetingStatus Terminal State

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add more details in the `AudioInputProvider` on storybook.
 - Add `MeetingStatus.Left` and set it when explicitly leaving the meeting
 - Publish `MeetingStatus.Failed` when `audioVideoDidStop` gets triggered with one of the Failure types of `MeetingSessionStatus` 
+- Add `Terminal Failure` Meeting Status
 
 ### Changed
 - Remove the audio video observers in the `audioVideoDidStop()` function instead of `leave()` function in the `MeetingManager`.

--- a/src/hooks/sdk/docs/useMeetingStatus.stories.mdx
+++ b/src/hooks/sdk/docs/useMeetingStatus.stories.mdx
@@ -10,8 +10,9 @@ enum MeetingStatus {
   Succeeded,
   Failed,
   Ended,
+  JoinedFromAnotherDevice,
   Left,
-  JoinedFromAnotherDevice
+  TerminalFailure
 }
 ```
 

--- a/src/hooks/sdk/useMeetingStatus.tsx
+++ b/src/hooks/sdk/useMeetingStatus.tsx
@@ -24,3 +24,5 @@ export const useMeetingStatus = () => {
 
   return meetingStatus;
 };
+
+export default useMeetingStatus;

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -349,6 +349,9 @@ export class MeetingManager implements AudioVideoObserver {
         if (sessionStatus.isFailure()) {
           this.meetingStatus = MeetingStatus.Failed;
           this.publishMeetingStatus();
+        } else if (sessionStatus.isTerminal()) {
+          this.meetingStatus = MeetingStatus.TerminalFailure;
+          this.publishMeetingStatus();
         }
         console.log('[MeetingManager audioVideoDidStop] session stopped with code ${sessionStatusCode}');
         this.leave();

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -323,23 +323,21 @@ export class MeetingManager implements AudioVideoObserver {
 
   audioVideoDidStop = (sessionStatus: MeetingSessionStatus) => {
     const sessionStatusCode = sessionStatus.statusCode();
-
-
     switch (sessionStatusCode) {
       case MeetingSessionStatusCode.AudioCallEnded: 
-        console.log('[MeetingManager audioVideoDidStop] Meeting ended for all');
+        console.log(`[MeetingManager audioVideoDidStop] Meeting ended for all: ${sessionStatusCode}`);
         this.meetingStatus = MeetingStatus.Ended;
         this.publishMeetingStatus();
         this.leave();
         break;
       case MeetingSessionStatusCode.Left:
-        console.log('[MeetingManager audioVideoDidStop] Left the meeting');
+        console.log(`[MeetingManager audioVideoDidStop] Left the meeting: ${sessionStatusCode}`);
         this.meetingStatus = MeetingStatus.Left;
         this.publishMeetingStatus();
-        // No need to call leave() here, since we already called meetingManager.leave() to get here
+        this.leave();
         break;
       case MeetingSessionStatusCode.AudioJoinedFromAnotherDevice:
-        console.log('[MeetingManager audioVideoDidStop] Meeting joined from another device');
+        console.log(`[MeetingManager audioVideoDidStop] Meeting joined from another device: ${sessionStatusCode}`);
         this.meetingStatus = MeetingStatus.JoinedFromAnotherDevice;
         this.publishMeetingStatus();
         this.leave();
@@ -347,13 +345,15 @@ export class MeetingManager implements AudioVideoObserver {
       default:
         // The following status codes are Failures according to MeetingSessionStatus
         if (sessionStatus.isFailure()) {
+          console.log(`[MeetingManager audioVideoDidStop] Non-Terminal failure occured: ${sessionStatusCode}`);
           this.meetingStatus = MeetingStatus.Failed;
           this.publishMeetingStatus();
         } else if (sessionStatus.isTerminal()) {
+          console.log(`[MeetingManager audioVideoDidStop] Terminal failure occured: ${sessionStatusCode}`);
           this.meetingStatus = MeetingStatus.TerminalFailure;
           this.publishMeetingStatus();
         }
-        console.log('[MeetingManager audioVideoDidStop] session stopped with code ${sessionStatusCode}');
+        console.log(`[MeetingManager audioVideoDidStop] session stopped with code ${sessionStatusCode}`);
         this.leave();
     }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -44,8 +44,9 @@ export enum MeetingStatus {
   Succeeded,
   Failed,
   Ended,
-  Left,
   JoinedFromAnotherDevice,
+  Left,
+  TerminalFailure
 };
 
 export type RosterAttendeeType = {


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Introduce a Terminal state to MeetingStatus - this will receive any meeting statuses from the Amazon Chime SDK for Javascript and bubble them up into the React Library's concept of Meeting Status. 

**Testing**
1. Have you successfully run `npm run build:release` locally?
yes

2. How did you test these changes?
From the demo app, disconnect from meeting to trigger terminal failure. 

3. If you made changes to the component library, have you provided corresponding documentation changes?
Yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
