### PR TITLE
Fix memory leak in LocalVideoProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,23 +10,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Fix the issue that Amazon Voice Focus does not get applied on new devices mid-meeting
-- Fix the issue where we call `meetingManager.leave` an additional time when we call `meetingManager.leave`
+
+- Fix the issue that Amazon Voice Focus does not get applied on new devices mid-meeting.
+- Fix the issue where we call `meetingManager.leave` an additional time when we call `meetingManager.leave`.
+- Remove the observer in `LocalVideoProvider` when it is unmounted to fix memory leak.
 
 ### Added
-- Add `activeSpeakerPolicy` and `videoUplinkBandwidthPolicy` in `MeetingManagerConfig` to allow builders to pass in 
-  custom policies.
+
+- Add `activeSpeakerPolicy` and `videoUplinkBandwidthPolicy` in `MeetingManagerConfig` to allow builders to pass in custom policies.
 - For more flexibility, allow passing `MeetingManagerConfig` to `meetingManager.join` method. Passing the config here would override config passed through `MeetingProvider` props.
 - Add more details in the `AudioInputProvider` on storybook.
-- Add `MeetingStatus.Left` and set it when explicitly leaving the meeting
-- Publish `MeetingStatus.Failed` when `audioVideoDidStop` gets triggered with one of the Failure types of `MeetingSessionStatus` 
-- Add `Terminal Failure` Meeting Status
+- Add `MeetingStatus.Left` and set it when explicitly leaving the meeting.
+- Publish `MeetingStatus.Failed` when `audioVideoDidStop` gets triggered with one of the Failure types of `MeetingSessionStatus`.
+- Add `Terminal Failure` Meeting Status.
 
 ### Changed
+
 - Remove the audio video observers in the `audioVideoDidStop()` function instead of `leave()` function in the `MeetingManager`.
 
 ### Removed
-- Remove setting the `MeetingStatus` to `MeetingStatus.Loading` when we call `meetingManager.leave`
+
+- Remove setting the `MeetingStatus` to `MeetingStatus.Loading` when we call `meetingManager.leave`.
 
 ## [2.9.1] - 2021-09-02
 

--- a/src/providers/LocalVideoProvider/index.tsx
+++ b/src/providers/LocalVideoProvider/index.tsx
@@ -72,6 +72,12 @@ const LocalVideoProvider: React.FC = ({ children }) => {
     audioVideo.addObserver({
       videoTileDidUpdate,
     });
+
+    return () => {
+      audioVideo.removeObserver({
+        videoTileDidUpdate,
+      })
+    }
   }, [audioVideo, tileId]);
 
   const value = useMemo(() => ({ tileId, isVideoEnabled, setIsVideoEnabled, toggleVideo, }), [
@@ -79,7 +85,7 @@ const LocalVideoProvider: React.FC = ({ children }) => {
     isVideoEnabled,
     setIsVideoEnabled,
     toggleVideo,
-    ]);
+  ]);
 
   return <Context.Provider value={value}>{children}</Context.Provider>;
 };


### PR DESCRIPTION
**Issue #626 :** 

**Description of changes:**
Remove the observer in `useEffect` cleanup process in `LocalVideoProvider`.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Tried to reproduce the memory leak issue by creating a new component that use the `useLocalVideo` hook, but failed to reproduce it. So just successfully run `npm run build:release`. Anyway we should remove this observer when the provider is unmounted.
3. If you made changes to the component library, have you provided corresponding documentation changes?
meeting demo
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
