### PR TITLE
Add additionalDevices as a prop instead of hardcoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `activeSpeakerPolicy` and `videoUplinkBandwidthPolicy` to `MeetingProvider` props.
 
 ### Changed
+- Change `additionalDevices` to a prop in `AudioInputControl`, `VideoInputControl`, `AudioInputVFControl`, `MicSelection`, and `CameraSelection` components to allow option to turn off that configuration.
 
 ### Removed
 

--- a/src/components/sdk/DeviceSelection/CameraSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/CameraSelection/index.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import { useVideoInputs } from '../../../../providers/DevicesProvider';
 import { useMeetingManager } from '../../../../providers/MeetingProvider';
+import { DeviceConfig } from '../../../../types';
 import DeviceInput from '../DeviceInput';
 
 interface Props {
@@ -12,14 +13,20 @@ interface Props {
   notFoundMsg?: string;
   /** The label that will be shown for camera selection, it defaults to "Camera source". */
   label?: string;
+  /** A boolean that determines whether or not to include additional sample video devices, such as "None", "Blue", "SMTP Color Bars". Defaults to true. This will be deprecated in the next major version. */
+  appendSampleDevices?: boolean;
 }
 
 export const CameraSelection: React.FC<Props> = ({
   notFoundMsg = 'No camera devices found',
   label = 'Camera source',
+  appendSampleDevices = true,
 }) => {
   const meetingManager = useMeetingManager();
-  const { devices, selectedDevice } = useVideoInputs();
+  const videoInputConfig: DeviceConfig = {
+    additionalDevices: appendSampleDevices,
+  };
+  const { devices, selectedDevice } = useVideoInputs(videoInputConfig);
 
   async function selectVideoInput(deviceId: string) {
     meetingManager.selectVideoInputDevice(deviceId);

--- a/src/components/sdk/DeviceSelection/MicSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/MicSelection/index.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import { useSelectAudioInputDevice } from '../../../../hooks/sdk/useSelectAudioInputDevice';
 import { useAudioInputs } from '../../../../providers/DevicesProvider';
+import { DeviceConfig } from '../../../../types';
 import DeviceInput from '../DeviceInput';
 
 interface Props {
@@ -12,14 +13,20 @@ interface Props {
   notFoundMsg?: string;
   /** The label that will be shown for microphone selection, it defaults to `Microphone source`. */
   label?: string;
+  /** A boolean that determines whether or not to include additional sample audio input devices, such as "None", "440 Hz". Defaults to true. This will be deprecated in the next major version. */
+  appendSampleDevices?: boolean;
 }
 
 export const MicSelection: React.FC<Props> = ({
   notFoundMsg = 'No microphone devices found',
   label = 'Microphone source',
+  appendSampleDevices = true,
 }) => {
+  const audioInputConfig: DeviceConfig = {
+    additionalDevices: appendSampleDevices,
+  };
   const selectAudioInput = useSelectAudioInputDevice();
-  const { devices, selectedDevice } = useAudioInputs();
+  const { devices, selectedDevice } = useAudioInputs(audioInputConfig);
 
   return (
     <DeviceInput

--- a/src/components/sdk/MeetingControls/AudioInputControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioInputControl.tsx
@@ -17,10 +17,12 @@ interface Props {
   muteLabel?: string;
   /** The label that will be shown when microphone is unmuted, it defaults to `Unmute`. */
   unmuteLabel?: string;
-  /** Title attribute for the icon when muted, it defaults to `Muted microphone` */
+  /** Title attribute for the icon when muted, it defaults to `Muted microphone`. */
   mutedIconTitle?: string;
-  /** Title attribute for the icon when unmuted, it defaults to `Microphone` */
+  /** Title attribute for the icon when unmuted, it defaults to `Microphone`. */
   unmutedIconTitle?: string;
+  /** A boolean that determines whether or not to include additional sample audio input devices, such as "None", "440 Hz". Defaults to true. This will be deprecated in the next major version. */
+  appendSampleDevices?: boolean;
 }
 
 const AudioInputControl: React.FC<Props> = ({
@@ -28,11 +30,12 @@ const AudioInputControl: React.FC<Props> = ({
   unmuteLabel = 'Unmute',
   mutedIconTitle,
   unmutedIconTitle,
+  appendSampleDevices = true,
 }) => {
   const meetingManager = useMeetingManager();
   const { muted, toggleMute } = useToggleLocalMute();
   const audioInputConfig: DeviceConfig = {
-    additionalDevices: true,
+    additionalDevices: appendSampleDevices,
   };
   const { devices, selectedDevice } = useAudioInputs(audioInputConfig);
 

--- a/src/components/sdk/MeetingControls/AudioInputVFControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioInputVFControl.tsx
@@ -38,6 +38,8 @@ interface Props {
   voiceFocusOnLabel?: string;
   /** The label that will be shown when the current input audio is not an Amazon Voice Focus device, it defaults to `Enable Amazon Voice Focus`. */
   voiceFocusOffLabel?: string;
+  /** A boolean that determines whether or not to include additional sample audio input devices, such as "None", "440 Hz". Defaults to true. This will be deprecated in the next major version. */
+  appendSampleDevices?: boolean;
 }
 
 const AudioInputVFControl: React.FC<Props> = ({
@@ -47,6 +49,7 @@ const AudioInputVFControl: React.FC<Props> = ({
   unmutedIconTitle,
   voiceFocusOnLabel = 'Amazon Voice Focus enabled',
   voiceFocusOffLabel = 'Enable Amazon Voice Focus',
+  appendSampleDevices = true,
 }) => {
   const meetingManager = useMeetingManager();
   const [isLoading, setIsLoading] = useState(false);
@@ -63,7 +66,7 @@ const AudioInputVFControl: React.FC<Props> = ({
   );
   const { isVoiceFocusSupported, addVoiceFocus } = useVoiceFocus();
   const audioInputConfig: DeviceConfig = {
-    additionalDevices: true,
+    additionalDevices: appendSampleDevices,
   };
   const { devices, selectedDevice } = useAudioInputs(audioInputConfig);
 

--- a/src/components/sdk/MeetingControls/VideoInputControl.tsx
+++ b/src/components/sdk/MeetingControls/VideoInputControl.tsx
@@ -15,13 +15,17 @@ import { PopOverItemProps } from '../../ui/PopOver/PopOverItem';
 interface Props {
   /** The label that will be shown for video input control, it defaults to `Video`. */
   label?: string;
+  /** A boolean that determines whether or not to include additional sample video devices, such as "None", "Blue", "SMTP Color Bars". Defaults to true. This will be deprecated in the next major version. */
+  appendSampleDevices?: boolean;
 }
 
-const videoInputConfig: DeviceConfig = {
-  additionalDevices: true,
-};
-
-const VideoInputControl: React.FC<Props> = ({ label = 'Video' }) => {
+const VideoInputControl: React.FC<Props> = ({ 
+  label = 'Video',
+  appendSampleDevices = true,
+}) => {
+  const videoInputConfig: DeviceConfig = {
+    additionalDevices: appendSampleDevices,
+  };
   const { devices, selectedDevice } = useVideoInputs(videoInputConfig);
   const { isVideoEnabled, toggleVideo } = useLocalVideo();
   const selectDevice = useSelectVideoInputDevice();


### PR DESCRIPTION
**Issue #:** 
https://github.com/aws/amazon-chime-sdk-component-library-react/issues/629

**Description of changes:**
Make the additionalDevices a prop for the media control components. 

**Testing**
1. Have you successfully run `npm run build:release` locally?
yes
2. How did you test these changes?
Ran it in the meeting demo
3. If you made changes to the component library, have you provided corresponding documentation changes?
yes - I just added a prop with a comment above - they will be picked up by storbybook documentation
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
