### PR TITLE
Remove AudioVideoObserver in LocalVideoProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix the issue that `AudioVideoObserver` was not removed as expected in `LocalVideoProvider`.
+
+### Added
+
+### Changed
+
+### Removed
+
 ## [2.10.0] - 2021-09-29
 
 ### Fixed

--- a/src/providers/LocalVideoProvider/index.tsx
+++ b/src/providers/LocalVideoProvider/index.tsx
@@ -9,7 +9,7 @@ import React, {
   useCallback,
   useMemo,
 } from 'react';
-import { VideoTileState } from 'amazon-chime-sdk-js';
+import { AudioVideoObserver, VideoTileState } from 'amazon-chime-sdk-js';
 
 import { useMeetingManager } from '../MeetingProvider';
 import { useAudioVideo } from '../AudioVideoProvider';
@@ -57,27 +57,22 @@ const LocalVideoProvider: React.FC = ({ children }) => {
       return;
     }
 
-    const videoTileDidUpdate = (tileState: VideoTileState) => {
-      if (
-        !tileState.localTile ||
-        !tileState.tileId ||
-        tileId === tileState.tileId
-      ) {
-        return;
-      }
+    const observer: AudioVideoObserver = {
+      videoTileDidUpdate: (tileState: VideoTileState) => {
+        if (
+          !tileState.localTile ||
+          !tileState.tileId ||
+          tileId === tileState.tileId
+        ) {
+          return;
+        }
 
-      setTileId(tileState.tileId);
+        setTileId(tileState.tileId);
+      },
     };
+    audioVideo.addObserver(observer);
 
-    audioVideo.addObserver({
-      videoTileDidUpdate,
-    });
-
-    return () => {
-      audioVideo.removeObserver({
-        videoTileDidUpdate,
-      })
-    }
+    return () => audioVideo.removeObserver(observer);
   }, [audioVideo, tileId]);
 
   const value = useMemo(() => ({ tileId, isVideoEnabled, setIsVideoEnabled, toggleVideo, }), [


### PR DESCRIPTION
**Issue #626:** 

**Description of changes:**
Store the listener in an variable `observer`, add and remove this event listener using the reference to `observer`.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
I can't reproduce the issue in our meeting demo. I use TypeScript play ground to mimc the testing code, and confirm the observer can be added and removed in the `Set`.
3. If you made changes to the component library, have you provided corresponding documentation changes?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
