### PR TITLE
Correctly remove event observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix the issue that `AudioVideoObserver` was not removed as expected in `LocalVideoProvider`.
+- Fix `eventDidReceive` observer removal in `MeetingManager`.
 
 ### Added
 


### PR DESCRIPTION
**Issue #:** 
NA

**Description of changes:**
- Fix `eventDidReceive` observer removal.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes.

2. How did you test these changes? Tested by raising this PR: https://github.com/aws-samples/amazon-chime-sdk/pull/67 against the demo app.

3. If you made changes to the component library, have you provided corresponding documentation changes? NA.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
