### PR TITLE
Update publish script to publish the tag instead of head of master br…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout Package
         uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.release.tag_name }}
       - name: Setup Node environment
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
change the publish workflow to checkout the tag that was created as part of the release.

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes?
Tested in a personal public repo:
    1. Create a new branch called 'hotfix'
    2. Create a Github Release and specify the hotfix branch and create a new tag
    3.  Verify that the github action checks out the ref commit, which is the tagged commit

3. If you made changes to the component library, have you provided corresponding documentation changes?
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
