### PR TITLE
Add Amazon Voice Focus to default device in VF provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Fix the issue that Amazon Voice Focus does not get applied on new devices mid-meeting.
 
 ### Added
 

--- a/src/providers/DevicesProvider/index.tsx
+++ b/src/providers/DevicesProvider/index.tsx
@@ -2,13 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
+import type { Device, AudioTransformDevice } from 'amazon-chime-sdk-js';
 
 import { AudioInputProvider, useAudioInputs } from './AudioInputProvider';
 import { AudioOutputProvider, useAudioOutputs } from './AudioOutputProvider';
 import { useVideoInputs, VideoInputProvider } from './VideoInputProvider';
 
-const DevicesProvider: React.FC = ({ children }) => (
-  <AudioInputProvider>
+interface Props {
+  onDeviceReplacement?: (
+    nextDevice: string,
+    currentDevice: Device | AudioTransformDevice
+  ) => Promise<Device | AudioTransformDevice>;
+}
+
+const DevicesProvider: React.FC<Props> = ({ children, onDeviceReplacement }) => (
+  <AudioInputProvider onDeviceReplacement={onDeviceReplacement}>
     <AudioOutputProvider>
       <VideoInputProvider>{children}</VideoInputProvider>
     </AudioOutputProvider>

--- a/src/providers/MeetingProvider/docs/MeetingProvider.stories.mdx
+++ b/src/providers/MeetingProvider/docs/MeetingProvider.stories.mdx
@@ -98,12 +98,21 @@ To enable simulcast for the meeting pass the `simulcastEnabled` prop with value 
 For more information on Simulcast, check Amazon Chime JS SDK [simulcast guide](https://github.com/aws/amazon-chime-sdk-js/blob/master/guides/05_Simulcast.md).
 
 #### enableWebAudio
+
 If you want to enable Amazon Voice Focus feature, you should enable Web Audio for the meeting and pass the `enableWebAudio` prop with value set to `true`. By default, it is `false`.
 
 #### logger
 
 The `Logger` object that you want to be used in the meeting session.
 If you pass in a `Logger` object using this parameter, the `MeetingManager` will use this object instead of creating a logger based on `logLevel` and `postLogConfig` to initialize the meeting session.
+
+#### onDeviceReplacement
+
+When a selected device is disconnected, or when the Operating System (OS) default device is selected and is changed by the OS (e.g., if a Bluetooth headset is disconnected), 
+the `AudioInputProvider` encapsulated by `DevicesProvider` is forced to automatically select a new audio input. This behaves as expected when the selected device is an ordinary device provided by the browser. 
+However, when your application is using a transform device like Amazon Voice Focus, the `AudioInputProvider` needs a way to transform the newly selected device to avoid reverting to a non-transform device.
+This is accomplished by exposing a `onDeviceReplacement` prop on `MeetingProvider` and `DevicesProvider`, allowing your application to customize the behavior of this device reselection step. 
+Provide a function that accepts a `Device` as input and returns a `Device` or `AudioTransformDevice` of your choice.
 
 #### activeSpeakerPolicy
 

--- a/src/providers/MeetingProvider/index.tsx
+++ b/src/providers/MeetingProvider/index.tsx
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  AudioTransformDevice,
+  Device,
   Logger,
   LogLevel,
   VideoDownlinkBandwidthPolicy,
@@ -35,6 +37,13 @@ interface Props {
    * based on `logLevel` and `postLogConfig` to initialize the meeting session.
    */
   logger?: Logger;
+  /** Determines how to handle the current audio input device when devices
+   *  change in `AudioInputProvider`.
+   */
+  onDeviceReplacement?: (
+    nextDevice: string,
+    currentDevice: Device | AudioTransformDevice
+  ) => Promise<Device | AudioTransformDevice>;
   /** The `VideoDownlinkBandwidthPolicy` object you want to use in meeting session */
   videoDownlinkBandwidthPolicy?: VideoDownlinkBandwidthPolicy;
   /** Pass a `MeetingManager` instance if you want to share this instance
@@ -52,6 +61,7 @@ export const MeetingProvider: React.FC<Props> = ({
   simulcastEnabled = false,
   enableWebAudio = false,
   logger,
+  onDeviceReplacement,
   videoDownlinkBandwidthPolicy,
   meetingManager: meetingManagerProp,
   children,
@@ -73,7 +83,7 @@ export const MeetingProvider: React.FC<Props> = ({
     <MeetingContext.Provider value={meetingManager}>
       <MeetingEventProvider>
         <AudioVideoProvider>
-          <DevicesProvider>
+          <DevicesProvider onDeviceReplacement={onDeviceReplacement}>
             <RosterProvider>
               <RemoteVideoTileProvider>
                 <LocalVideoProvider>


### PR DESCRIPTION
**Issue #:** Amazon Voice Focus does not get applied on new audio-devices when connected mid-meeting.


**Description of changes:**
Add Amazon Voice Focus to the default device when a new blue tooth device is plugged in during the meeting.
This issue only happens in Chrome and when user selects "default" device as the audio input device. 


**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes?
Should test with the PR of meeting demo: https://github.com/aws-samples/amazon-chime-sdk/pull/70

 * Open two Chrome tabs (no Safari, no FF)
 * Disable speaker in one tab
 * Disable microphone and set built in device as speaker in another tab
 * Turn on Amazon Voice Focus in the first tab
 * Apply a new device (AirPods)
 * The current device changes to AirPods
 * Then make some background noice, you should not hear any noice from the second tab since Amazon Voice Focus is enabled in the first tab.

3. If you made changes to the component library, have you provided corresponding documentation changes? Yes, in the change log

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
