### PR TITLE
Add Background Blur Provider and VideoInputBackgroundBlurControl component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Eslint rules to enforce code style and fix issues.
 - Add logs for Amazon Voice Focus components.
 - Add FAQ link on audio outputs not available in FireFox and Safari.
+- Add `BackgroundBlurProvider` which provides a background blur video transform device.
+- Add `VideoInputBackgroundBlurControl` component which includes a checkbox for enabling background blur.
+- Add `unsubscribeFromSelectedVideoInputTranformDevice` which subscribes to changes to selected video devices.
+- Add `subscribeFromSelectedVideoInputTranformDevice`.
+- Add `publishSelectedVideoInputTranformDevice` which publishes a `Device | VideoTransformDevice` depending on what video device was chosen.
 
 ### Changed
 
 - Update `useSelectVideoInputDevice` hook documentation and usage example.
 - Update package.json to include NPM 8.
+- Update `meetingManager.selectVideoInputDevice` to accept `VideoTransformDevice` as a parameter.
 
 ### Removed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
         "add": "^2.0.6",
-        "amazon-chime-sdk-js": "^2.18.0",
+        "amazon-chime-sdk-js": "^2.20.0",
         "babel-loader": "^8.1.0",
         "css-loader": "^2.1.1",
         "eslint": "^7.32.0",
@@ -91,7 +91,7 @@
         "npm": "^6 || ^7 || ^8"
       },
       "peerDependencies": {
-        "amazon-chime-sdk-js": "^2.18.0",
+        "amazon-chime-sdk-js": "^2.20.0",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "styled-components": "^5.0.0",
@@ -5421,9 +5421,9 @@
       "dev": true
     },
     "node_modules/@types/dom-mediacapture-record": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.7.tgz",
-      "integrity": "sha512-ddDIRTO1ajtbxaNo2o7fPJggpN54PZf1ZUJKOjto2ENMJE/9GKUvaw3ZRuQzlS/p0E+PnIcssxfoqYJ4yiXSBw==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.10.tgz",
+      "integrity": "sha512-8O84hHuVhMMLHLybf3y9SQpNcnQSuzVzcJaUNq9+4Ovb7fodS0aQXep4hyMtxd6fe/dyszbHFjFqtyawf4y46A==",
       "dev": true
     },
     "node_modules/@types/estree": {
@@ -6520,9 +6520,9 @@
       "dev": true
     },
     "node_modules/amazon-chime-sdk-js": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.18.0.tgz",
-      "integrity": "sha512-C3f/4NzeKUkZil+GFHdwdSOoU8EdpHcOBwKglSmnMXujitff2R0ZeKvu6HsNWGscIBqmQYO4YYpJtNl8e5cwRg==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.20.0.tgz",
+      "integrity": "sha512-DcfypnhZ5q7ppU0celTWRC9IyyDxAnPX5sImkzGFqM4cSahZV+IFvIbpqStQWi62+pd2SDQlbq6Ducp4/D7zwA==",
       "dev": true,
       "dependencies": {
         "@types/dom-mediacapture-record": "^1.0.7",
@@ -6534,7 +6534,7 @@
       },
       "engines": {
         "node": "^12 || ^14 || ^15 || ^16",
-        "npm": "^6 || ^7"
+        "npm": "^6 || ^7 || ^8"
       }
     },
     "node_modules/ansi-align": {
@@ -10177,9 +10177,9 @@
       }
     },
     "node_modules/detect-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.0.tgz",
-      "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.1.tgz",
+      "integrity": "sha512-eAcRiEPTs7utXWPaAgu/OX1HRJpxW7xSHpw4LTDrGFaeWnJ37HRlqpUkKsDm0AoTbtrvHQhH+5U2Cd87EGhJTg==",
       "dev": true
     },
     "node_modules/detect-file": {
@@ -20786,6 +20786,7 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.9.tgz",
       "integrity": "sha512-j2JlRdUeL/f4Z6x4aU4gj9I2LECglC+5qR2TrWb193Tla1qfdaNQTZ8I27Pt7K0Ajmvjjpft7O3KWTGciz4gpw==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -22272,9 +22273,9 @@
       "dev": true
     },
     "node_modules/resize-observer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resize-observer/-/resize-observer-1.0.0.tgz",
-      "integrity": "sha512-D7UFShDm2TgrEDEyeg+/tTEbvOgPWlvPAfJtxiKp+qutu6HowmcGJKjECgGru0PPDIj3SAucn3ZPpOx54fF7DQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/resize-observer/-/resize-observer-1.0.2.tgz",
+      "integrity": "sha512-X0lHFNsxItpBRIRsdwOTkl/VguTaLGx7Gz9xoTGix9ObBN3jRYq9J/rSIuYDrey8AdU3IkfgIMpCeVSEW1QS0Q==",
       "dev": true
     },
     "node_modules/resize-observer-polyfill": {
@@ -32301,9 +32302,9 @@
       "dev": true
     },
     "@types/dom-mediacapture-record": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.7.tgz",
-      "integrity": "sha512-ddDIRTO1ajtbxaNo2o7fPJggpN54PZf1ZUJKOjto2ENMJE/9GKUvaw3ZRuQzlS/p0E+PnIcssxfoqYJ4yiXSBw==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.10.tgz",
+      "integrity": "sha512-8O84hHuVhMMLHLybf3y9SQpNcnQSuzVzcJaUNq9+4Ovb7fodS0aQXep4hyMtxd6fe/dyszbHFjFqtyawf4y46A==",
       "dev": true
     },
     "@types/estree": {
@@ -33265,9 +33266,9 @@
       "dev": true
     },
     "amazon-chime-sdk-js": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.18.0.tgz",
-      "integrity": "sha512-C3f/4NzeKUkZil+GFHdwdSOoU8EdpHcOBwKglSmnMXujitff2R0ZeKvu6HsNWGscIBqmQYO4YYpJtNl8e5cwRg==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.20.0.tgz",
+      "integrity": "sha512-DcfypnhZ5q7ppU0celTWRC9IyyDxAnPX5sImkzGFqM4cSahZV+IFvIbpqStQWi62+pd2SDQlbq6Ducp4/D7zwA==",
       "dev": true,
       "requires": {
         "@types/dom-mediacapture-record": "^1.0.7",
@@ -36339,9 +36340,9 @@
       }
     },
     "detect-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.0.tgz",
-      "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.1.tgz",
+      "integrity": "sha512-eAcRiEPTs7utXWPaAgu/OX1HRJpxW7xSHpw4LTDrGFaeWnJ37HRlqpUkKsDm0AoTbtrvHQhH+5U2Cd87EGhJTg==",
       "dev": true
     },
     "detect-file": {
@@ -46340,9 +46341,9 @@
       "dev": true
     },
     "resize-observer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resize-observer/-/resize-observer-1.0.0.tgz",
-      "integrity": "sha512-D7UFShDm2TgrEDEyeg+/tTEbvOgPWlvPAfJtxiKp+qutu6HowmcGJKjECgGru0PPDIj3SAucn3ZPpOx54fF7DQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/resize-observer/-/resize-observer-1.0.2.tgz",
+      "integrity": "sha512-X0lHFNsxItpBRIRsdwOTkl/VguTaLGx7Gz9xoTGix9ObBN3jRYq9J/rSIuYDrey8AdU3IkfgIMpCeVSEW1QS0Q==",
       "dev": true
     },
     "resize-observer-polyfill": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "add": "^2.0.6",
-    "amazon-chime-sdk-js": "^2.18.0",
+    "amazon-chime-sdk-js": "^2.20.0",
     "babel-loader": "^8.1.0",
     "css-loader": "^2.1.1",
     "eslint": "^7.32.0",
@@ -117,7 +117,7 @@
     "webpack-cli": "^3.3.2"
   },
   "peerDependencies": {
-    "amazon-chime-sdk-js": "^2.18.0",
+    "amazon-chime-sdk-js": "^2.20.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "styled-components": "^5.0.0",

--- a/src/components/sdk/MeetingControls/VideoInputBackgroundBlurControl.tsx
+++ b/src/components/sdk/MeetingControls/VideoInputBackgroundBlurControl.tsx
@@ -1,0 +1,154 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  DefaultVideoTransformDevice,
+  Device,
+  isVideoTransformDevice,
+  VideoTransformDevice,
+} from 'amazon-chime-sdk-js';
+import React, { ReactNode, useEffect, useState } from 'react';
+import isEqual from 'lodash.isequal';
+
+import { useBackgroundBlur } from '../../../providers/BackgroundBlurProvider';
+import { useVideoInputs } from '../../../providers/DevicesProvider';
+import { useLocalVideo } from '../../../providers/LocalVideoProvider';
+import { useMeetingManager } from '../../../providers/MeetingProvider';
+import {
+  isOptionActive,
+  videoInputSelectionToDevice,
+} from '../../../utils/device-utils';
+import { ControlBarButton } from '../../ui/ControlBar/ControlBarButton';
+import { Camera, Spinner } from '../../ui/icons';
+import PopOverItem from '../../ui/PopOver/PopOverItem';
+import PopOverSeparator from '../../ui/PopOver/PopOverSeparator';
+import { DeviceType } from '../../../types';
+import useMemoCompare from '../../../utils/use-memo-compare';
+
+interface Props {
+  /** The label that will be shown for video input control, it defaults to `Video`. */
+  label?: string;
+  /** The label that will be shown for the background blur button. */
+  backgroundBlurLabel?: string;
+}
+
+const VideoInputBackgroundBlurControl: React.FC<Props> = ({
+  label = 'Video',
+  backgroundBlurLabel = 'Enable Background Blur',
+}) => {
+  const meetingManager = useMeetingManager();
+  const { devices, selectedDevice } = useVideoInputs();
+  const { isVideoEnabled, toggleVideo } = useLocalVideo();
+  const { isBackgroundBlurSupported, createBackgroundBlurDevice } = useBackgroundBlur();
+  const [isVideoTransformChecked, setIsVideoTransformChecked] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [dropdownWithVideoTransformOptions, setDropdownWithVideoTransformOptions] = useState<ReactNode[] | null>(null);
+  const [activeVideoDevice, setDevice] = useState<Device | VideoTransformDevice | null>(meetingManager.selectedVideoInputDevice);
+
+  const videoDevices: DeviceType[] = useMemoCompare(devices, (prev: DeviceType[], next: DeviceType[]): boolean => isEqual(prev, next));
+
+  // TODO: Move this to the Video Input Provider and expose only one selected Video Input device state
+  useEffect(() => {
+    meetingManager.subscribeToSelectedVideoInputTransformDevice(setDevice);
+    return () => {
+      meetingManager.unsubscribeFromSelectedVideoInputTranformDevice(setDevice);
+    };
+  }, []);
+
+  useEffect(() => {
+    const deviceOptions: ReactNode[] = videoDevices.map((option) => (
+      <PopOverItem
+        key={option.deviceId}
+        children={<span>{option.label}</span>}
+        checked={isOptionActive(selectedDevice, option.deviceId)}
+        onClick={async (): Promise<void> => {
+          // If background blur is on, then re-use the same video transform pipeline, but replace the inner device
+          // If background blur is not on, then do a normal video selection
+          if (isVideoTransformDevice(activeVideoDevice) && !isLoading) {
+            setIsLoading(true);
+            const receivedDevice = videoInputSelectionToDevice(option.deviceId);
+            if ('chooseNewInnerDevice' in activeVideoDevice) {
+              // @ts-ignore
+              const transformedDevice = activeVideoDevice.chooseNewInnerDevice(receivedDevice);
+              await meetingManager.selectVideoInputDevice(transformedDevice);
+            } else {
+              meetingManager.logger?.error('Transform device cannot choose new inner device');
+            }
+            setIsLoading(false);
+          } else {
+            await meetingManager.selectVideoInputDevice(option.deviceId);
+          }
+        }}
+      />
+    ));
+    if (isBackgroundBlurSupported) {
+      const videoTransformOptions: ReactNode = (
+        <PopOverItem
+          key="videoinput"
+          children={
+            <>
+              {isLoading && <Spinner width="1.5rem" height="1.5rem" />}
+              {backgroundBlurLabel}
+            </>
+          }
+          checked={isVideoTransformDevice(activeVideoDevice)}
+          disabled={isLoading}
+          onClick={() => {
+            setIsLoading(true);
+            setIsVideoTransformChecked((current) => !current);
+          }}
+        />
+      );
+      deviceOptions.push(<PopOverSeparator key="separator" />);
+      deviceOptions.push(videoTransformOptions);
+    }
+    setDropdownWithVideoTransformOptions(deviceOptions);
+  }, [
+    createBackgroundBlurDevice,
+    activeVideoDevice,
+    videoDevices,
+    isVideoTransformChecked,
+    isLoading,
+    selectedDevice,
+    isBackgroundBlurSupported,
+  ]);
+
+  useEffect(() => {
+    async function onVideoTransformCheckboxChange() {
+      let current = activeVideoDevice;
+      if (isVideoTransformChecked) {
+        // Enable video transform on the non-transformed device
+        if (!isVideoTransformDevice(current)) {
+          current = await createBackgroundBlurDevice(current);
+          meetingManager.logger?.info('Video filter turned on - selecting video transform device: ' + JSON.stringify(current));
+        } else {
+          meetingManager.logger?.info('Video Filter is already on.');
+        }
+      } else {
+        // switch back to the inner device
+        if (isVideoTransformDevice(activeVideoDevice)) {
+          current = await activeVideoDevice.intrinsicDevice();
+          meetingManager.logger?.info('Video filter was turned off - selecting inner device: ' + JSON.stringify(current));
+        } else {
+          meetingManager.logger?.info('Video Filter is already off.');
+        }
+      }
+      // If we're currently using a video transform device, and a non-video transform device is selected
+      // then the video transform device will be stopped automatically
+      await meetingManager.selectVideoInputDevice(current);
+      setIsLoading(false);
+    }
+    onVideoTransformCheckboxChange();
+  }, [isVideoTransformChecked]);
+
+  return (
+    <ControlBarButton
+      icon={<Camera disabled={!isVideoEnabled} />}
+      onClick={toggleVideo}
+      label={label}
+      children={dropdownWithVideoTransformOptions}
+    />
+  );
+};
+
+export default VideoInputBackgroundBlurControl;

--- a/src/components/sdk/MeetingControls/docs/AudioInputVFControl.stories.mdx
+++ b/src/components/sdk/MeetingControls/docs/AudioInputVFControl.stories.mdx
@@ -6,7 +6,7 @@ import AudioInputVFControl from '../AudioInputVFControl';
 # AudioInputVFControl
 
 The `AudioInputVFControl` component renders a `ControlBarButton` with pop over menu options to select through multiple audio input options,
-and provides the option of Amazon Voice Focus on the bottom. This component should be used within `VoiceFocusProvider` and `MeetingProvider`.
+and provides the option of Amazon Voice Focus on the bottom. This component must be used within `VoiceFocusProvider` and `MeetingProvider`.
 Make sure you have set `enableWebAudio` as `true` in the meeting config or Amazon Voice Focus feature won't work.
 
 When you click the device button, the local audio input toggles between muted/unmuted state. When you click Amazon Voice Focus button,

--- a/src/components/sdk/MeetingControls/docs/VideoInputBackgroundBlurControl.stories.mdx
+++ b/src/components/sdk/MeetingControls/docs/VideoInputBackgroundBlurControl.stories.mdx
@@ -1,0 +1,62 @@
+import { Props } from '@storybook/addon-docs/blocks';
+import VideoInputBackgroundBlurControl from '../VideoInputBackgroundBlurControl';
+
+<Meta title="SDK Components/MeetingControls/VideoInputBackgroundBlurControl" />
+
+# VideoInputBackgroundBlurControl
+
+The `VideoInputBackgroundBlurControl` component renders a `ControlBarButton` with pop over menu options to select through multiple video input sources.
+These video input sources are provided by the `useVideoInputs` hook.
+The `VideoInputBackgroundBlurControl` component also has a button that will enable or disable background blur on the chosen video input source. A checkmark icon
+next to the background blur button will indicate whether or not background blur is active. If you want to apply background blur to your video input device stream,
+try this `VideoInputBackgroundBlurControl`. If not, `VideoInputControl` is a better choice.
+
+This component must be used within `BackgroundBlurProvider` and `MeetingProvider`.
+
+When you click the button, the local video input toggles between on/off state.
+
+You can use it in the [ControlBar component](/docs/ui-components-controlbar--control-bar) to build the meeting controls bar.
+
+## Importing
+
+```javascript
+import { VideoInputBackgroundBlurControl } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+```jsx
+import React from 'react';
+import {
+  BackgroundBlurProvider,
+  MeetingProvider,
+  VideoInputBackgroundBlurControl,
+  ControlBar,
+  AudioInputControl,
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => {
+  return (
+    <BackgroundBlurProvider>
+      <MeetingProvider>
+        <ControlBar
+          layout="undocked-horizontal"
+          showLabels
+        >
+          <AudioInputControl />
+          <VideoInputBackgroundBlurControl />
+        </ControlBar>
+      </MeetingProvider>
+    </BackgroundBlurProvider>
+  );
+};
+```
+
+## Props
+
+<Props of={VideoInputBackgroundBlurControl} />
+
+### Dependencies
+
+- `MeetingProvider`
+- `BackgroundBlurProvider`

--- a/src/components/sdk/MeetingControls/index.tsx
+++ b/src/components/sdk/MeetingControls/index.tsx
@@ -5,6 +5,7 @@ import AudioInputControl from './AudioInputControl';
 import AudioInputVFControl from './AudioInputVFControl';
 import AudioOutputControl from './AudioOutputControl';
 import ContentShareControl from './ContentShareControl';
+import VideoInputBackgroundBlurControl from './VideoInputBackgroundBlurControl';
 import VideoInputControl from './VideoInputControl';
 
 export {
@@ -12,5 +13,6 @@ export {
   AudioInputVFControl,
   AudioOutputControl,
   VideoInputControl,
+  VideoInputBackgroundBlurControl,
   ContentShareControl,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ export {
   AudioOutputControl,
   ContentShareControl,
   VideoInputControl,
+  VideoInputBackgroundBlurControl,
 } from './components/sdk/MeetingControls';
 export { ContentShare } from './components/sdk/ContentShare';
 export { LocalVideo } from './components/sdk/LocalVideo';
@@ -115,10 +116,8 @@ export { useApplyVideoObjectFit } from './hooks/useApplyVideoObjectFit';
 export { useElementAspectRatio } from './hooks/useElementAspectRatio';
 
 export { useMeetingManager } from './providers/MeetingProvider';
-export {
-  VoiceFocusProvider,
-  useVoiceFocus,
-} from './providers/VoiceFocusProvider';
+export { useVoiceFocus } from './providers/VoiceFocusProvider';
+export { useBackgroundBlur } from './providers/BackgroundBlurProvider';
 export { useAudioVideo } from './providers/AudioVideoProvider';
 export { useRosterState } from './providers/RosterProvider';
 export { useRemoteVideoTileState } from './providers/RemoteVideoTileProvider';
@@ -162,6 +161,9 @@ export { RosterProvider } from './providers/RosterProvider';
 export { DevicesProvider } from './providers/DevicesProvider';
 export { RemoteVideoTileProvider } from './providers/RemoteVideoTileProvider';
 export { FeaturedVideoTileProvider } from './providers/FeaturedVideoTileProvider';
+export { VoiceFocusProvider } from './providers/VoiceFocusProvider';
+export { BackgroundBlurProvider } from './providers/BackgroundBlurProvider';
+
 export {
   UserActivityProvider,
   useUserActivityState,

--- a/src/providers/BackgroundBlurProvider/docs/BackgroundBlurProvider.stories.mdx
+++ b/src/providers/BackgroundBlurProvider/docs/BackgroundBlurProvider.stories.mdx
@@ -1,0 +1,117 @@
+import { Props } from '@storybook/addon-docs/blocks';
+import { BackgroundBlurProvider } from '../';
+
+<Meta title="SDK Providers/BackgroundBlurProvider" />
+
+# BackgroundBlurProvider
+
+The `BackgroundBlurProvider` provides a function transforming a normal video device to a `DefaultVideoTransformDevice`, and also whether or not the background blur feature is supported.
+Background blur related logs can be found in the browser developer tools when the `BackgroundBlurProvider` is used within the app component tree.
+
+This provider is independent from `MeetingProvider`. You can put `BackgroundBlurProvider` wherever you want in the component tree so long as any component that relies on 
+`BackgroundBlurProvider` is nested within `BackgroundBlurProvider`. The `BackgroundBlurProvider` loads the required worker assets
+when mounted, which may impact performance.
+
+## State
+
+```typescript
+{
+  // Whether background blur is supported. The default value is undefined, then changes to true or false.
+  isBackgroundBlurSupported: boolean | undefined;
+
+  // A function to transform a video input device to a DefaultVideoTransformDevice.
+  createBackgroundBlurDevice: (device: Device) => Promise<DefaultVideoTransformDevice>;
+}
+
+```
+
+You should see either "processor is supported" or "processor is not supported" in your browser developer tools based on whether or not
+background blur is supported on your device and browser version. For more information on if background blur is supported, refer
+to [Amazon Chime JS SDK Background Blur Guide](https://github.com/aws/amazon-chime-sdk-js/blob/master/guides/15_Background_Filter_Video_Processor.md#integrating-background-blur-into-your-amazon-chime-sdk-for-javascript-application).
+
+You should check whether or not the processor has been loaded correctly by checking the state of `isBackgroundBlurSupported` before calling `createBackgroundBlurDevice`.
+`createBackgroundBlurDevice` may throw an error if the processor has not been loaded yet. 
+
+You can access the state by using the [useBackgroundBlur](/docs/sdk-hooks-usebackgroundblur--page) hook.
+
+## Props
+
+<Props of={BackgroundBlurProvider} />
+
+## Importing
+
+```javascript
+import { BackgroundBlurProvider } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+```jsx
+import React from 'react';
+import {
+  isVideoTranformDevice,
+  VideoTransformDevice
+} from 'amazon-chime-sdk-js';
+import {
+  MeetingProvider,
+  BackgroundBlurProvider,
+  useMeetingManager,
+  useBackgroundBlur,
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <BackgroundBlurProvider>
+    <MeetingProvider>
+      <MyChild />
+    </MeetingProvider>
+  </BackgroundBlurProvider>
+);
+
+const MyChild = () => {
+  const meetingManager = useMeetingManager();
+  const [isVideoTransformChecked, setIsVideoTransformCheckOn] = useState(false);
+  const [device, setDevice] = useState(meetingManager.selectedVideoInputDevice);
+  const { isBackgroundBlurSupported, createBackgroundBlurDevice } = useBackgroundBlur();
+
+  useEffect(() => {
+    meetingManager.subscribeToSelectedVideoInputTransformDevice(setDevice);
+    return () => {
+      meetingManager.unsubscribeToSelectedVideoInputTransformDevice(setDevice);
+    };
+  }, []);
+
+  useEffect(() => {
+    async function toggleBackgroundBlur() {
+      let current = device;
+      if (isVideoTransformChecked) {
+        current = await createBackgroundBlurDevice(device);
+      } else {
+        if (isVideoTransformDevice(device)) {
+          current = await device.intrinsicDevice();
+        }
+      }
+      await meetingManager.selectVideoInputDevice(current);
+    }
+    
+    toggleBackgroundBlur();
+  }, [isVideoTransformChecked]);
+
+  const onClick = () => {
+    setisVideoTransformCheckOn(current => !current);
+  };
+
+  return (
+    <div>
+      {isBackgroundBlurSupported && (
+        <button onClick={onClick}>
+          {isVideoTranformDevice(device) ? 'Background Blur Enabled' : 'Enable Background Blur'}
+        </button>
+      )}
+    </div>
+  );
+};
+```
+### Dependencies
+
+- `MeetingProvider`
+- `BackgroundBlurProvider`

--- a/src/providers/BackgroundBlurProvider/docs/useBackgroundBlur.stories.mdx
+++ b/src/providers/BackgroundBlurProvider/docs/useBackgroundBlur.stories.mdx
@@ -1,0 +1,105 @@
+import { Props } from '@storybook/addon-docs/blocks';
+import { useBackgroundBlur } from '../';
+
+<Meta title="SDK Hooks/useBackgroundBlur" />
+
+# useBackgroundBlur
+
+The `useBackgroundBlur` hook returns a function transforming a normal video device to a `DefaultVideoTransformDevice`, and also a 
+state called `isBackgroundBlurSupported` which indicates whether or not background blur processor is fully loaded and ready to be used. 
+
+You should check whether or not the processor has been loaded correctly by checking the state of `isBackgroundBlurSupported` before calling `createBackgroundBlurDevice`.
+`createBackgroundBlurDevice` may throw an error if the processor has not been loaded yet. 
+
+Background blur related logs can be found in the browser developer tools when the `BackgroundBlurProvider` is used within the app component tree.
+
+## Return Value
+
+```typescript
+{
+  // Whether background blur is finished loading the processor. The default value is undefined, then changes to true or false.
+  isBackgroundBlurSupported: boolean | undefined;
+
+  // A function to transform a video input device to a DefaultVideoTransformDevice.
+  createBackgroundBlurDevice: (device: Device) => Promise<DefaultVideoTransformDevice>;
+}
+
+```
+
+## Importing
+
+```javascript
+import { useBackgroundBlur } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+The hook depends on the `BackgroundBlurProvider`. You can use it with `MeetingProvider`.
+
+```jsx
+import React from 'react';
+import { VideoTransformDevice } from 'amazon-chime-sdk-js';
+import {
+  MeetingProvider,
+  BackgroundBlurProvider,
+  useMeetingManager,
+  useBackgroundBlur,
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <BackgroundBlurProvider>
+    <MeetingProvider>
+      <MyChild />
+    </MeetingProvider>
+  </BackgroundBlurProvider>
+);
+
+const MyChild = () => {
+  const meetingManager = useMeetingManager();
+  const [isVideoTransformCheckBoxOn, setisVideoTransformCheckBoxOn] = useState(false);
+  const [device, setDevice] = useState(meetingManager.selectedVideoInputDevice);
+  const { isBackgroundBlurSupported, createBackgroundBlurDevice } = useBackgroundBlur();
+
+  useEffect(() => {
+    meetingManager.subscribeToSelectedVideoInputTransformDevice(setDevice);
+    return () => {
+      meetingManager.unsubscribeToSelectedVideoInputTransformDevice(setDevice);
+    };
+  }, []);
+
+  useEffect(() => {
+    async function toggleBackgroundBlur() {
+      let current = device;
+      if (isVideoTransformCheckBoxOn) {
+        current = await createBackgroundBlurDevice(device);
+      } else {
+        if (isVideoTransformDevice(device)) {
+          current = await device.intrinsicDevice();
+        }
+      }
+      await meetingManager.selectVideoInputDevice(current);
+    }
+    
+    toggleBackgroundBlur();
+  }, [isVideoTransformCheckBoxOn]);
+
+  const onClick = () => {
+    setisVideoTransformCheckBoxOn(current => !current);
+  };
+
+  return (
+    <div>
+      {isBackgroundBlurSupported && (
+        <button onClick={onClick}>
+          {isVideoTranformDevice(device) ? 'Background Blur Enabled' : 'Enable Background Blur'}
+        </button>
+      )}
+    </div>
+  );
+};
+```
+
+### Dependencies
+
+- `MeetingProvider`
+- `BackgroundBlurProvider`

--- a/src/providers/BackgroundBlurProvider/index.tsx
+++ b/src/providers/BackgroundBlurProvider/index.tsx
@@ -1,0 +1,133 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  BackgroundBlurOptions,
+  BackgroundBlurVideoFrameProcessor,
+  BackgroundFilterSpec,
+  ConsoleLogger,
+  DefaultVideoTransformDevice,
+  Device,
+  LogLevel,
+  NoOpVideoFrameProcessor,
+  VideoFrameProcessor,
+} from 'amazon-chime-sdk-js';
+import React, {
+  createContext,
+  FC,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+interface Props {
+  /** The spec defines the assets that will be used for adding background blur to a frame. For more information, refer to
+   * [Amazon Chime JS SDK Background Filter Guide](https://github.com/aws/amazon-chime-sdk-js/blob/master/guides/15_Background_Filter_Video_Processor.md#adding-background-blur-to-your-application). */
+  spec?: BackgroundFilterSpec;
+  /** A set of options that can be supplied when creating a background blur video frame processor. For more information, refer to
+   * [Amazon Chime JS SDK Background Filter Guide](https://github.com/aws/amazon-chime-sdk-js/blob/master/guides/15_Background_Filter_Video_Processor.md#adding-background-blur-to-your-application). */
+  options?: BackgroundBlurOptions;
+}
+
+interface BackgroundBlurProviderState {
+  createBackgroundBlurDevice: (
+    device: Device
+  ) => Promise<DefaultVideoTransformDevice>;
+  isBackgroundBlurSupported: boolean | undefined;
+}
+
+const BackgroundBlurProviderContext =
+  createContext<BackgroundBlurProviderState | undefined>(undefined);
+
+const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
+  const [isBackgroundBlurSupported, setIsBackgroundBlurSupported] = useState<boolean | undefined>(undefined);
+  const [processor, setProcessor] = useState<VideoFrameProcessor | undefined>();
+
+  useEffect(() => {
+    async function initializeBackgroundBlur() {
+      try {
+        console.log('Initializing background blur processor.');
+        const createdProcessor = await BackgroundBlurVideoFrameProcessor.create(
+          spec,
+          options
+        );
+        // BackgroundBlurVideoFrameProcessor.create will return a NoOpVideoFrameProcessor
+        // in the case that BackgroundBlurVideoFrameProcessor.isSupported() returns false.
+        // BackgroundBlurVideoFrameProcessor.create() can also throw an error in case loading
+        // the assets are not fetched successfully.
+        if (createdProcessor instanceof NoOpVideoFrameProcessor) {
+          console.warn(`Initialized NoOpVideoFrameProcessor.`);
+          setProcessor(undefined);
+          setIsBackgroundBlurSupported(false);
+        } else {
+          console.log(`Initialized background blur processor: ${JSON.stringify(createdProcessor)}`);
+          setProcessor(createdProcessor);
+          setIsBackgroundBlurSupported(true);
+        }
+      } catch (error) {
+        console.error(`Error creating a background blur video frame processor device.`, error);
+        setProcessor(undefined);
+        setIsBackgroundBlurSupported(false);
+      }
+    }
+    initializeBackgroundBlur();
+    return () => {
+      console.log(`Destroying background blur processor.`);
+      processor?.destroy();
+    };
+  }, []);
+
+  const createBackgroundBlurDevice = async (
+    selectedDevice: Device
+  ): Promise<DefaultVideoTransformDevice> => {
+    console.log(`Calling createBackgroundBlurDevice with device: ${JSON.stringify(selectedDevice)}`);
+    // It takes time for the processor to start - if you call this method before it is finished initializing, throw an error
+    if (!isBackgroundBlurSupported) {
+      throw new Error('Background blur is not supported. The processor may not be initialized yet.');
+    }
+    try {
+      const logger = options?.logger
+        ? options.logger
+        : new ConsoleLogger('BackgroundBlurProvider', LogLevel.INFO);
+      if (processor) {
+        const chosenVideoTransformDevice = new DefaultVideoTransformDevice(
+          logger,
+          selectedDevice,
+          [processor]
+        );
+        console.log(`Created video transform device ${JSON.stringify(chosenVideoTransformDevice, null, 2)}`);
+        return chosenVideoTransformDevice;
+      } else {
+        throw new Error('Processor has not been created.');
+      }
+    } catch (error) {
+      throw new Error(
+        `Failed to create a DefaultVideoTransformDevice: ${error}`
+      );
+    }
+  };
+
+  const value: BackgroundBlurProviderState = {
+    createBackgroundBlurDevice,
+    isBackgroundBlurSupported,
+  };
+
+  return (
+    <BackgroundBlurProviderContext.Provider value={value}>
+      {children}
+    </BackgroundBlurProviderContext.Provider>
+  );
+};
+
+const useBackgroundBlur = (): BackgroundBlurProviderState => {
+  const context = useContext(BackgroundBlurProviderContext);
+
+  if (!context) {
+    throw new Error(
+      'useBackgroundBlur must be used within BackgroundBlurProvider'
+    );
+  }
+  return context;
+};
+
+export { BackgroundBlurProvider, useBackgroundBlur };

--- a/src/providers/LocalVideoProvider/index.tsx
+++ b/src/providers/LocalVideoProvider/index.tsx
@@ -12,7 +12,6 @@ import React, {
 } from 'react';
 
 import { LocalVideoContextType } from '../../types';
-import { videoInputSelectionToDevice } from '../../utils/device-utils';
 import { useAudioVideo } from '../AudioVideoProvider';
 import { useMeetingManager } from '../MeetingProvider';
 
@@ -39,17 +38,21 @@ const LocalVideoProvider: React.FC = ({ children }) => {
   }, [audioVideo]);
 
   const toggleVideo = useCallback(async (): Promise<void> => {
-    if (isVideoEnabled || !meetingManager.selectedVideoInputDevice) {
+    if (isVideoEnabled || !meetingManager.selectedVideoInputTransformDevice) {
       audioVideo?.stopLocalVideoTile();
       setIsVideoEnabled(false);
     } else {
       await audioVideo?.chooseVideoInputDevice(
-        videoInputSelectionToDevice(meetingManager.selectedVideoInputDevice)
+        meetingManager.selectedVideoInputTransformDevice
       );
       audioVideo?.startLocalVideoTile();
       setIsVideoEnabled(true);
     }
-  }, [audioVideo, isVideoEnabled, meetingManager.selectedVideoInputDevice]);
+  }, [
+    audioVideo,
+    isVideoEnabled,
+    meetingManager.selectedVideoInputTransformDevice,
+  ]);
 
   useEffect(() => {
     if (!audioVideo) {

--- a/src/providers/MeetingEventProvider/index.tsx
+++ b/src/providers/MeetingEventProvider/index.tsx
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { EventAttributes,EventName } from 'amazon-chime-sdk-js';
-import React, { createContext, useContext, useEffect,useState } from 'react';
+import { EventAttributes, EventName } from 'amazon-chime-sdk-js';
+import React, { createContext, useContext, useEffect, useState } from 'react';
 
 import { useMeetingManager } from '../MeetingProvider';
 

--- a/src/providers/VoiceFocusProvider/docs/VoiceFocusProvider.stories.mdx
+++ b/src/providers/VoiceFocusProvider/docs/VoiceFocusProvider.stories.mdx
@@ -8,7 +8,8 @@ import { VoiceFocusProvider } from '../';
 The `VoiceFocusProvider` provides a function transforming a normal audio device to an Amazon Voice Focus device, and whether Amazon Voice Focus is supported. 
 Amazon Voice Focus related logs can be found in the browser developer tools when Amazon Voice Focus is enabled.
 
-This provider is independent from `MeetingProvider`. You can put `VoiceFocusProvider` wherever you want in the component tree to control the workflow of Voice Focus.
+This provider is independent from `MeetingProvider`. You can put `VoiceFocusProvider` wherever you want in the component tree to control the workflow of Voice Focus, so long
+as any component which relies on `VoiceFocusProvider` is nested within `VoiceFocusProvider`.
 
 ## State
 


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Add the background blur feature to the React Library.

I created one provider - `BackgroundBlurProvider`and one sample component- `VideoInputBackgroundBlurControl`.

I modified `meetingManager.selectVideoInputDevice` to accept `VideoTransformDevice` along with `Device`.

There was also a small fix to initialize `selectedAudioInputTransformDevice` when the meeting is first started. We need to initialize that so that any subscribers get the correct initial value for `selectedAudioInputTransformDevice`
**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Locally ran tests
1. Join meeting, turn on video. 
2. Enable background blur
3. Disable BG Blur
4. Enable BG Blur and turn off video, turn on video
5. Switch between video inputs while BG BLur is on

3. If you made changes to the component library, have you provided corresponding documentation changes?
Yes, added storybook documentation for useBackgroundBlur, BackgroundBlurProvider, and VideoInputBackgroundBlurControl.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
