### PR TITLE
add tst folder to exclude section in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
     "node_modules",
     "build",
     "demo",
+    "tst",
     "scripts",
     ".storybook",
     "src/internal",


### PR DESCRIPTION
**Issue #:** 
Fix Story Book build Issue in  "Deploy Demo and Storybook" Github Action. This Issue is caused when we removed tst folder from tsconfig.json to apply linting on test files.

**Description of changes:**
To fix the issue added tst folder back in excluded section of tsconfig.json.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes?
Ran npm start to create storybook

3. If you made changes to the component library, have you provided corresponding documentation changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
