### PR TITLE
Publish audioVideo update after listing devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Revert back to publishing `audioVideo` update after listing devices. Publishing earlier before listing devices breaks `useAudioInputs`, `useAudioOutputs` and `useVideoInputs` hooks. The reason is device change observers may fail to get added to `audioVideo` based on builders implementation. Hence, falling back to what existed earlier.
+
+### Added
+
+### Changed
+
+### Removed
+
+
 ## [2.11.0] - 2021-10-21
 
 ### Fixed

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -311,7 +311,6 @@ export class MeetingManager implements AudioVideoObserver {
     );
 
     this.audioVideo = this.meetingSession.audioVideo;
-    this.publishAudioVideo();
 
     // When an attendee leaves, we remove AudioVideoObservers and nullify AudioVideoFacade and MeetingSession object.
     // This results into missing few meeting events triggered with audioVideoDidStop such as meetingEnded, meetingFailed and meetingStartFailed.
@@ -323,6 +322,7 @@ export class MeetingManager implements AudioVideoObserver {
     this.setupAudioVideoObservers();
     this.setupDeviceLabelTrigger(deviceLabels);
     await this.listAndSelectDevices(deviceLabels);
+    this.publishAudioVideo();
     this.setupActiveSpeakerDetection();
     this.meetingStatus = MeetingStatus.Loading;
     this.publishMeetingStatus();


### PR DESCRIPTION
**Issue #:** 
- #628 

**Description of changes:**
- Revert back to publishing `audioVideo` update after listing devices. Publishing earlier before listing devices breaks `useAudioInputs`, `useAudioOutputs` and `useVideoInputs` hooks. The reason is device change observers may fail to get added to `audioVideo` based on builders implementation. Hence, falling back to what existed earlier.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes.

2. How did you test these changes? 
Tested sanity checks in meeting demo as well as checked meeting events logging in the meeting demo. 
2.1. Join the meeting demo.
2.2. Verify devices for audioinput, videoinput and audiooutput are listed.
2.3. Start video, change through videoinputs.
2.4. Can speak and test through other attendee if joined.
2.5. Tested mute/unmute.
2.6. Tested meeting events if logged correctly as expected from 'audioInputSelected' to 'meetingEnded'.

3. If you made changes to the component library, have you provided corresponding documentation changes? NA.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
