### PR TITLE
Update PreviewVideo to support VideoTransformedDevices, and Add VideoFilterSelection component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add quickstart guide for background blur feature.
+- Add `VideoFilterSelection` component to allow selecting background blur video filter for the `PreviewVideo` component.
 
 ### Changed
+- The `PreviewVideo` component will listen to the `selectedVideoInputTransform` state, which means it can display regular `Device` video streams, along with `VideoTransformDevice` video streams as well. 
 
 ### Removed
 

--- a/src/components/sdk/DeviceSelection/CameraSelection/VideoFilterSelection.tsx
+++ b/src/components/sdk/DeviceSelection/CameraSelection/VideoFilterSelection.tsx
@@ -1,0 +1,77 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  Device,
+  isVideoTransformDevice,
+  VideoTransformDevice,
+} from 'amazon-chime-sdk-js';
+import React, { useEffect, useState } from 'react';
+
+import { useBackgroundBlur } from '../../../../providers/BackgroundBlurProvider';
+import { useMeetingManager } from '../../../../providers/MeetingProvider';
+import { Checkbox } from '../../../ui/Checkbox';
+import { FormField } from '../../../ui/FormField';
+
+interface Props {
+  /** Label shown for video filter selection, by default it is "Blur my background" */
+  label?: string;
+}
+
+export const VideoFilterSelection: React.FC<Props> = ({
+  label = 'Blur my background',
+}) => {
+  const { isBackgroundBlurSupported, createBackgroundBlurDevice } =
+    useBackgroundBlur();
+  const [isLoading, setIsLoading] = useState(false);
+  const meetingManager = useMeetingManager();
+  // TODO: Move this to the Video Input Provider and expose only one selected Video Input device state
+  const [device, setDevice] = useState<Device | VideoTransformDevice | null>(
+    meetingManager.selectedVideoInputTransformDevice
+  );
+
+  // TODO: Move this to the Video Input Provider and expose only one selected Video Input device state
+  useEffect(() => {
+    meetingManager.subscribeToSelectedVideoInputTransformDevice(setDevice);
+    return () => {
+      meetingManager.unsubscribeFromSelectedVideoInputTranformDevice(setDevice);
+    };
+  }, []);
+
+  const toggleBackgroundBlur = async () => {
+    if (isLoading) {
+      return;
+    }
+    if (!isVideoTransformDevice(device)) {
+      setIsLoading(true);
+      if (isBackgroundBlurSupported) {
+        const transformedVideoDevice = await createBackgroundBlurDevice(device);
+        await meetingManager.selectVideoInputDevice(transformedVideoDevice);
+      } else {
+        meetingManager.logger?.warn(
+          'Background blur processor is not supported yet.'
+        );
+      }
+    } else {
+      if ('chooseNewInnerDevice' in device) {
+        setIsLoading(true);
+        // @ts-ignore
+        const deviceId = await device.intrinsicDevice();
+        await meetingManager.selectVideoInputDevice(deviceId);
+      }
+    }
+    setIsLoading(false);
+  };
+
+  return (
+    <FormField
+      field={Checkbox}
+      onChange={toggleBackgroundBlur}
+      value={'Background Blur'}
+      checked={isVideoTransformDevice(device)}
+      label={label}
+    />
+  );
+};
+
+export default VideoFilterSelection;

--- a/src/components/sdk/DeviceSelection/docs/VideoFilterSelection.stories.mdx
+++ b/src/components/sdk/DeviceSelection/docs/VideoFilterSelection.stories.mdx
@@ -1,0 +1,47 @@
+import { Props } from '@storybook/addon-docs/blocks';
+import VideoFilterSelection from '../CameraSelection/VideoFilterSelection';
+
+<Meta title="SDK Components/DeviceSelection/Camera/VideoFilterSelection" />
+
+# VideoFilterSelection
+
+The `VideoFilterSelection` component renders a `Checkbox FormField` to select a background blur device. Currently, the only option is background blur.
+
+The component depends on the `DevicesProvider`. If you are using `MeetingProvider`, `DevicesProvider` is rendered by default.
+
+## Importing
+
+```javascript
+import { VideoFilterSelection } from 'amazon-chime-sdk-component-library-react';
+```
+
+## Usage
+
+```jsx
+import React from 'react';
+import {
+  BackgroundBlurProvider,
+  MeetingProvider,
+  VideoFilterSelection
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => {
+  return (
+    <BackgroundBlurProvider >
+      <MeetingProvider>
+        <VideoFilterSelection />
+      </MeetingProvider>
+    </BackgroundBlurProvider >
+  );
+};
+```
+
+## Props
+
+<Props of={VideoFilterSelection} />
+
+### Dependencies
+
+- `BackgroundBlurProvider`
+- `MeetingProvider`
+- `DevicesProvider`, If you are using `MeetingProvider`, `DevicesProvider` is rendered by default

--- a/src/components/sdk/DeviceSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/index.tsx
@@ -5,5 +5,6 @@ import CameraSelection from './CameraSelection';
 import QualitySelection from './CameraSelection/QualitySelection';
 import MicSelection from './MicSelection';
 import SpeakerSelection from './SpeakerSelection';
+import VideoFilterSelection from './CameraSelection/VideoFilterSelection';
 
-export { SpeakerSelection, MicSelection, CameraSelection, QualitySelection };
+export { SpeakerSelection, MicSelection, CameraSelection, QualitySelection, VideoFilterSelection };

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ export {
   MicSelection,
   SpeakerSelection,
   QualitySelection,
+  VideoFilterSelection,
 } from './components/sdk/DeviceSelection';
 export {
   AudioInputControl,


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Update PreviewVideo to show the `selectedVideoInputTransformDevice` rather than the `selectedVideoInputDevice`. The difference is that the `selectedVideoInputTransformDevice` can be a regular `Device` but also a `VideoTransformDevice` - that means the PreviewVideo can now show video streams that have been transformed.

Next, add a `VideoFilterSelection` component that will simply create a background blur `VideoTransformDevice` and then call `meetingManager.selectVideoInputDevice` to select the background blur video transform device, thus publishing a new `selectedVideoInputTransformDevice`. The PreviewVideo component will listen to any changes on `selectedVideoInputTransformDevice` and update the video element with that video stream. 

Also, fixes a small bug where we were calling `meetingManager.selectVideoInputDevice` on accident in the `VideoInputBackgroundBlurControl` component's useEffect hook. The solution was to take the `meetingManager.selectVideoInputDevice` call out of the useEffect hook so that it wasn't called on mount.

Related demo changes are here: https://github.com/aws-samples/amazon-chime-sdk/pull/86

![image](https://user-images.githubusercontent.com/54328451/139965123-96965195-c657-4542-95d7-1bcee3020509.png)

**Testing**
1. Have you successfully run `npm run build:release` locally?
yes

2. How did you test these changes?
Via the demo app. Changes for the demo app will be posted soon.

3. If you made changes to the component library, have you provided corresponding documentation changes?
Yes, documentation has been updated for `PreviewVideo` and a new doc for `VideoFilterSelection`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
