### PR TITLE
Update CODEOWNERS with newly created dev team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 # amazon-chime-sdk-component-library-react repo.
 # Check below link for more information:
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-* @aws/amazon-chime-sdk
+* @aws/amazon-chime-sdk-js-dev


### PR DESCRIPTION
**Issue #:**
- Restrict the GitHub PR review notifications to just the JS SDK Dev team.

**Description of changes:**
- Update CODEOWNERS with newly created dev team: https://github.com/orgs/aws/teams/amazon-chime-sdk-js-dev

**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes?

3. If you made changes to the component library, have you provided corresponding documentation changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
