### PR TITLE
Update chime js sdk to v2.21.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
         "add": "^2.0.6",
-        "amazon-chime-sdk-js": "^2.20.0",
+        "amazon-chime-sdk-js": "^2.21.1",
         "babel-loader": "^8.1.0",
         "css-loader": "^2.1.1",
         "eslint": "^7.32.0",
@@ -91,7 +91,7 @@
         "npm": "^6 || ^7 || ^8"
       },
       "peerDependencies": {
-        "amazon-chime-sdk-js": "^2.20.0",
+        "amazon-chime-sdk-js": "^2.21.1",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "styled-components": "^5.0.0",
@@ -6520,9 +6520,9 @@
       "dev": true
     },
     "node_modules/amazon-chime-sdk-js": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.20.0.tgz",
-      "integrity": "sha512-DcfypnhZ5q7ppU0celTWRC9IyyDxAnPX5sImkzGFqM4cSahZV+IFvIbpqStQWi62+pd2SDQlbq6Ducp4/D7zwA==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.21.1.tgz",
+      "integrity": "sha512-Y8/qabhzIMMvicu/4RAYezFJzBAV0fs4yOD9fCmwdTmNIbq35/X6rpgI8AmpqRNhob1Xv7X/5+elKPYgxhiTfg==",
       "dev": true,
       "dependencies": {
         "@types/dom-mediacapture-record": "^1.0.7",
@@ -6530,11 +6530,30 @@
         "detect-browser": "^5.2.0",
         "protobufjs": "~6.8.8",
         "resize-observer": "^1.0.0",
-        "ua-parser-js": "^0.7.24"
+        "ua-parser-js": "^1.0.1"
       },
       "engines": {
         "node": "^12 || ^14 || ^15 || ^16",
         "npm": "^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/amazon-chime-sdk-js/node_modules/ua-parser-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
+      "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ansi-align": {
@@ -33266,9 +33285,9 @@
       "dev": true
     },
     "amazon-chime-sdk-js": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.20.0.tgz",
-      "integrity": "sha512-DcfypnhZ5q7ppU0celTWRC9IyyDxAnPX5sImkzGFqM4cSahZV+IFvIbpqStQWi62+pd2SDQlbq6Ducp4/D7zwA==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.21.1.tgz",
+      "integrity": "sha512-Y8/qabhzIMMvicu/4RAYezFJzBAV0fs4yOD9fCmwdTmNIbq35/X6rpgI8AmpqRNhob1Xv7X/5+elKPYgxhiTfg==",
       "dev": true,
       "requires": {
         "@types/dom-mediacapture-record": "^1.0.7",
@@ -33276,7 +33295,15 @@
         "detect-browser": "^5.2.0",
         "protobufjs": "~6.8.8",
         "resize-observer": "^1.0.0",
-        "ua-parser-js": "^0.7.24"
+        "ua-parser-js": "^1.0.1"
+      },
+      "dependencies": {
+        "ua-parser-js": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
+          "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==",
+          "dev": true
+        }
       }
     },
     "ansi-align": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "add": "^2.0.6",
-    "amazon-chime-sdk-js": "^2.20.0",
+    "amazon-chime-sdk-js": "^2.21.1",
     "babel-loader": "^8.1.0",
     "css-loader": "^2.1.1",
     "eslint": "^7.32.0",
@@ -117,7 +117,7 @@
     "webpack-cli": "^3.3.2"
   },
   "peerDependencies": {
-    "amazon-chime-sdk-js": "^2.20.0",
+    "amazon-chime-sdk-js": "^2.21.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "styled-components": "^5.0.0",


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**

Update JS SDK chime revision to include background blur CPU utilization option.
https://github.com/aws/amazon-chime-sdk-js/pull/1746

**Testing**
1. Have you successfully run `npm run build:release` locally?

Yes

2. How did you test these changes?

I have local changes for demo and confirmed with using local build

3. If you made changes to the component library, have you provided corresponding documentation changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
