### PR TITLE
Specify to include CHANGELOG and NOTICE

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "lib/index.js",
   "module": "lib/index.esm.js",
   "files": [
-    "lib"
+    "lib",
+    "CHANGELOG.md",
+    "NOTICE"
   ],
   "engines": {
     "node": "^12 || ^14 || ^15 || ^16",


### PR DESCRIPTION
**Issue #:** 
NPM 7 and later no longer auto includes CHANGELOG.md and NOTICE files.
**Description of changes:**
Specify those files in package.json to include in the npm package.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes? `npm pack`

3. If you made changes to the component library, have you provided corresponding documentation changes? No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
