### PR TITLE
Initialize the VideoInputBackgrounBlurControl component with selectedVideoInputTransformDevice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The `PreviewVideo` component will listen to the `selectedVideoInputTransform` state, which means it can display regular `Device` video streams, along with `VideoTransformDevice` video streams as well.
+- `VideoInputBackgroundBlurControl` component is initialized with the `selectedVideoInputTransformDevice`.
 
 ### Removed
 

--- a/src/components/sdk/MeetingControls/VideoInputBackgroundBlurControl.tsx
+++ b/src/components/sdk/MeetingControls/VideoInputBackgroundBlurControl.tsx
@@ -41,7 +41,7 @@ const VideoInputBackgroundBlurControl: React.FC<Props> = ({
   const { isBackgroundBlurSupported, createBackgroundBlurDevice } = useBackgroundBlur();
   const [isLoading, setIsLoading] = useState(false);
   const [dropdownWithVideoTransformOptions, setDropdownWithVideoTransformOptions] = useState<ReactNode[] | null>(null);
-  const [activeVideoDevice, setDevice] = useState<Device | VideoTransformDevice | null>(meetingManager.selectedVideoInputDevice);
+  const [activeVideoDevice, setDevice] = useState<Device | VideoTransformDevice | null>(meetingManager.selectedVideoInputTransformDevice);
 
   const videoDevices: DeviceType[] = useMemoCompare(devices, (prev: DeviceType[], next: DeviceType[]): boolean => isEqual(prev, next));
 


### PR DESCRIPTION
**Issue #:** 
Fixes a bug where the enable bg blur control is not initially checked when the meeting is started with a video transform device.

**Description of changes:**
Need to initialize the Video Input Background Blur control component with selectedVideoInputTransformDevice because the selectedVideoInputTransformDevice can be a Device or a VideoTransformDevice.

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? running the react meeting demo

3. If you made changes to the component library, have you provided corresponding documentation changes? n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
