### PR TITLE
Clone the meeting demo from meeting-dev branch

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -185,10 +185,10 @@ if (release_option === '5') {
 // Checkout the meeting demo
 process.chdir(path.join(__dirname, '../..'));
 if (!fs.existsSync('amazon-chime-sdk')) {
-  spawnOrFail('git', ['clone https://github.com/aws-samples/amazon-chime-sdk.git']);
+  spawnOrFail('git', ['clone --branch meeting-dev https://github.com/aws-samples/amazon-chime-sdk.git']);
 } else {
   spawnOrFail('rm', ['-rf amazon-chime-sdk']);
-  spawnOrFail('git', ['clone https://github.com/aws-samples/amazon-chime-sdk.git']);
+  spawnOrFail('git', ['clone --branch meeting-dev https://github.com/aws-samples/amazon-chime-sdk.git']);
 }
 
 // Udpate the demo to the most up to date version of JS SDK 


### PR DESCRIPTION
**Issue #:** 
NA

**Description of changes:**
- This is to update the release script to use the "meeting-dev" branch instead of the "main" branch to create the next demo for testing of next version release.

**Testing**
1. Have you successfully run `npm run build:release` locally?
NA.

2. How did you test these changes?
Had been tested while creating last release's deployed demo URL.

3. If you made changes to the component library, have you provided corresponding documentation changes?
NA.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
