### PR TITLE
Update the default version for Safari to latest

### DIFF
--- a/integration/utils/DriverFactory.js
+++ b/integration/utils/DriverFactory.js
@@ -12,7 +12,6 @@ class DriverFactory {
         builder.withCapabilities({
           ...config.firefoxOptions,
           ...config.sauceOptions,
-          browserVersion: process.env.BROWSER_VERSION || 'latest',
         });
         break;
 
@@ -21,7 +20,6 @@ class DriverFactory {
         builder.withCapabilities({
           ...config.chromeOptions,
           ...config.sauceOptions,
-          browserVersion: process.env.BROWSER_VERSION || 'latest',
         });
         break;
 
@@ -30,7 +28,6 @@ class DriverFactory {
         builder.withCapabilities({
           ...config.safariOptions,
           ...config.sauceOptions,
-          browserVersion: process.env.BROWSER_VERSION || '15',
         });
         break;
 

--- a/integration/utils/config.js
+++ b/integration/utils/config.js
@@ -34,6 +34,7 @@ const config = {
   },
   sauceOptions: {
     platformName: process.env.PLATFORM_NAME || 'macOS 12',
+    browserVersion: process.env.BROWSER_VERSION || 'latest',
     'sauce:options': {
       username: process.env.SAUCE_USERNAME,
       accessKey: process.env.SAUCE_ACCESS_KEY,


### PR DESCRIPTION
**Issue #:** 

In the integration test, the default version of the browser is not unified.

**Description of changes:**
Update the default Safari version to latest to make it consistent with Chrome and Safari.

**Testing**
1. Have you successfully run `npm run build:release` locally?
N/A

2. How did you test these changes?
Try to run the roster test on Sauce Labs using Chrome, Firefox and Safari. Confirmed it works..

3. If you made changes to the component library, have you provided corresponding documentation changes?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
