### PR TITLE
Add 'reconnectTimeoutMs' as an optional param when joining a meeting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,6 +34,7 @@
     "no-unused-vars": ["error", { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }],
     "prefer-const" : "error",
     "no-eval": "error",
+    "max-len": ["error", { "code": 120 }],
     "semi": ["error", "always"],
     "eqeqeq": ["error", "always"],
     "indent": ["error", 2, { "SwitchCase": 1 }],

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -73,7 +73,7 @@ module.exports = ({ config }) => {
           options: { 
             parser: 'typescript',
             prettierConfig: {
-              printWidth: 100,
+              printWidth: 120,
               tabWidth: 2,
               bracketSpacing: true,
               trailingComma: 'es5',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Change `additionalDevices` to a prop in `AudioInputControl`, `VideoInputControl`, `AudioInputVFControl`, `MicSelection`, and `CameraSelection` components to allow option to turn off that configuration.
+- Add `reconnectTimeoutMs` as an optional parameter to `MeetingManagerConfig` to manage the timeout for reconnection.
 
 ### Removed
 

--- a/src/components/sdk/DeviceSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/index.tsx
@@ -2,9 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import CameraSelection from './CameraSelection';
+import BackgroundBlurCheckbox from './CameraSelection/BackgroundBlurCheckbox';
 import QualitySelection from './CameraSelection/QualitySelection';
 import MicSelection from './MicSelection';
 import SpeakerSelection from './SpeakerSelection';
-import BackgroundBlurCheckbox from './CameraSelection/BackgroundBlurCheckbox';
 
-export { SpeakerSelection, MicSelection, CameraSelection, QualitySelection, BackgroundBlurCheckbox };
+export {
+  SpeakerSelection,
+  MicSelection,
+  CameraSelection,
+  QualitySelection,
+  BackgroundBlurCheckbox,
+};

--- a/src/components/sdk/MeetingControls/VideoInputBackgroundBlurControl.tsx
+++ b/src/components/sdk/MeetingControls/VideoInputBackgroundBlurControl.tsx
@@ -6,23 +6,23 @@ import {
   isVideoTransformDevice,
   VideoTransformDevice,
 } from 'amazon-chime-sdk-js';
-import React, { ReactNode, useEffect, useState } from 'react';
 import isEqual from 'lodash.isequal';
+import React, { ReactNode, useEffect, useState } from 'react';
 
 import { useBackgroundBlur } from '../../../providers/BackgroundBlurProvider';
 import { useVideoInputs } from '../../../providers/DevicesProvider';
 import { useLocalVideo } from '../../../providers/LocalVideoProvider';
 import { useMeetingManager } from '../../../providers/MeetingProvider';
+import { DeviceType } from '../../../types';
 import {
   isOptionActive,
   videoInputSelectionToDevice,
 } from '../../../utils/device-utils';
+import useMemoCompare from '../../../utils/use-memo-compare';
 import { ControlBarButton } from '../../ui/ControlBar/ControlBarButton';
 import { Camera, Spinner } from '../../ui/icons';
 import PopOverItem from '../../ui/PopOver/PopOverItem';
 import PopOverSeparator from '../../ui/PopOver/PopOverSeparator';
-import { DeviceType } from '../../../types';
-import useMemoCompare from '../../../utils/use-memo-compare';
 
 interface Props {
   /** The label that will be shown for video input control, it defaults to `Video`. */
@@ -38,12 +38,21 @@ const VideoInputBackgroundBlurControl: React.FC<Props> = ({
   const meetingManager = useMeetingManager();
   const { devices, selectedDevice } = useVideoInputs();
   const { isVideoEnabled, toggleVideo } = useLocalVideo();
-  const { isBackgroundBlurSupported, createBackgroundBlurDevice } = useBackgroundBlur();
+  const { isBackgroundBlurSupported, createBackgroundBlurDevice } =
+    useBackgroundBlur();
   const [isLoading, setIsLoading] = useState(false);
-  const [dropdownWithVideoTransformOptions, setDropdownWithVideoTransformOptions] = useState<ReactNode[] | null>(null);
-  const [activeVideoDevice, setDevice] = useState<Device | VideoTransformDevice | null>(meetingManager.selectedVideoInputTransformDevice);
+  const [
+    dropdownWithVideoTransformOptions,
+    setDropdownWithVideoTransformOptions,
+  ] = useState<ReactNode[] | null>(null);
+  const [activeVideoDevice, setDevice] = useState<
+    Device | VideoTransformDevice | null
+  >(meetingManager.selectedVideoInputTransformDevice);
 
-  const videoDevices: DeviceType[] = useMemoCompare(devices, (prev: DeviceType[], next: DeviceType[]): boolean => isEqual(prev, next));
+  const videoDevices: DeviceType[] = useMemoCompare(
+    devices,
+    (prev: DeviceType[], next: DeviceType[]): boolean => isEqual(prev, next)
+  );
 
   // TODO: Move this to the Video Input Provider and expose only one selected Video Input device state
   useEffect(() => {
@@ -62,11 +71,17 @@ const VideoInputBackgroundBlurControl: React.FC<Props> = ({
     if (!isVideoTransformDevice(current)) {
       // Enable video transform on the non-transformed device
       current = await createBackgroundBlurDevice(current);
-      meetingManager.logger?.info('Video filter turned on - selecting video transform device: ' + JSON.stringify(current));
+      meetingManager.logger?.info(
+        'Video filter turned on - selecting video transform device: ' +
+          JSON.stringify(current)
+      );
     } else {
       // switch back to the inner device
       current = await current.intrinsicDevice();
-      meetingManager.logger?.info('Video filter was turned off - selecting inner device: ' + JSON.stringify(current));
+      meetingManager.logger?.info(
+        'Video filter was turned off - selecting inner device: ' +
+          JSON.stringify(current)
+      );
     }
     // If we're currently using a video transform device, and a non-video transform device is selected
     // then the video transform device will be stopped automatically
@@ -87,11 +102,14 @@ const VideoInputBackgroundBlurControl: React.FC<Props> = ({
             setIsLoading(true);
             const receivedDevice = videoInputSelectionToDevice(option.deviceId);
             if ('chooseNewInnerDevice' in activeVideoDevice) {
-              // @ts-ignore
-              const transformedDevice = activeVideoDevice.chooseNewInnerDevice(receivedDevice);
+              const transformedDevice =
+                // @ts-ignore
+                activeVideoDevice.chooseNewInnerDevice(receivedDevice);
               await meetingManager.selectVideoInputDevice(transformedDevice);
             } else {
-              meetingManager.logger?.error('Transform device cannot choose new inner device');
+              meetingManager.logger?.error(
+                'Transform device cannot choose new inner device'
+              );
             }
             setIsLoading(false);
           } else {

--- a/src/components/sdk/MeetingControls/VideoInputControl.tsx
+++ b/src/components/sdk/MeetingControls/VideoInputControl.tsx
@@ -19,7 +19,7 @@ interface Props {
   appendSampleDevices?: boolean;
 }
 
-const VideoInputControl: React.FC<Props> = ({ 
+const VideoInputControl: React.FC<Props> = ({
   label = 'Video',
   appendSampleDevices = true,
 }) => {

--- a/src/providers/BackgroundBlurProvider/index.tsx
+++ b/src/providers/BackgroundBlurProvider/index.tsx
@@ -36,11 +36,14 @@ interface BackgroundBlurProviderState {
   isBackgroundBlurSupported: boolean | undefined;
 }
 
-const BackgroundBlurProviderContext =
-  createContext<BackgroundBlurProviderState | undefined>(undefined);
+const BackgroundBlurProviderContext = createContext<
+  BackgroundBlurProviderState | undefined
+>(undefined);
 
 const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
-  const [isBackgroundBlurSupported, setIsBackgroundBlurSupported] = useState<boolean | undefined>(undefined);
+  const [isBackgroundBlurSupported, setIsBackgroundBlurSupported] = useState<
+    boolean | undefined
+  >(undefined);
   const [processor, setProcessor] = useState<VideoFrameProcessor | undefined>();
 
   useEffect(() => {
@@ -60,12 +63,19 @@ const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
           setProcessor(undefined);
           setIsBackgroundBlurSupported(false);
         } else {
-          console.log(`Initialized background blur processor: ${JSON.stringify(createdProcessor)}`);
+          console.log(
+            `Initialized background blur processor: ${JSON.stringify(
+              createdProcessor
+            )}`
+          );
           setProcessor(createdProcessor);
           setIsBackgroundBlurSupported(true);
         }
       } catch (error) {
-        console.error(`Error creating a background blur video frame processor device.`, error);
+        console.error(
+          `Error creating a background blur video frame processor device.`,
+          error
+        );
         setProcessor(undefined);
         setIsBackgroundBlurSupported(false);
       }
@@ -80,10 +90,16 @@ const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
   const createBackgroundBlurDevice = async (
     selectedDevice: Device
   ): Promise<DefaultVideoTransformDevice> => {
-    console.log(`Calling createBackgroundBlurDevice with device: ${JSON.stringify(selectedDevice)}`);
+    console.log(
+      `Calling createBackgroundBlurDevice with device: ${JSON.stringify(
+        selectedDevice
+      )}`
+    );
     // It takes time for the processor to start - if you call this method before it is finished initializing, throw an error
     if (!isBackgroundBlurSupported) {
-      throw new Error('Background blur is not supported. The processor may not be initialized yet.');
+      throw new Error(
+        'Background blur is not supported. The processor may not be initialized yet.'
+      );
     }
     try {
       const logger = options?.logger
@@ -95,7 +111,13 @@ const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
           selectedDevice,
           [processor]
         );
-        console.log(`Created video transform device ${JSON.stringify(chosenVideoTransformDevice, null, 2)}`);
+        console.log(
+          `Created video transform device ${JSON.stringify(
+            chosenVideoTransformDevice,
+            null,
+            2
+          )}`
+        );
         return chosenVideoTransformDevice;
       } else {
         throw new Error('Processor has not been created.');

--- a/src/providers/DevicesProvider/AudioInputProvider.tsx
+++ b/src/providers/DevicesProvider/AudioInputProvider.tsx
@@ -1,6 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type {
+  AudioTransformDevice,
+  Device,
+  DeviceChangeObserver,
+} from 'amazon-chime-sdk-js';
 import React, {
   createContext,
   useContext,
@@ -9,7 +14,6 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import type { Device, AudioTransformDevice, DeviceChangeObserver } from 'amazon-chime-sdk-js';
 
 import { AUDIO_INPUT } from '../../constants/additional-audio-video-devices';
 import { DeviceConfig, DeviceTypeContext } from '../../types';
@@ -26,7 +30,10 @@ interface Props {
 
 const Context = createContext<DeviceTypeContext | null>(null);
 
-const AudioInputProvider: React.FC<Props> = ({ children, onDeviceReplacement }) => {
+const AudioInputProvider: React.FC<Props> = ({
+  children,
+  onDeviceReplacement,
+}) => {
   const meetingManager = useMeetingManager();
   const audioVideo = useAudioVideo();
   const [audioInputs, setAudioInputs] = useState<MediaDeviceInfo[]>([]);
@@ -38,7 +45,9 @@ const AudioInputProvider: React.FC<Props> = ({ children, onDeviceReplacement }) 
   const [selectAudioInputDeviceError, setSelectAudioInputDeviceError] =
     useState(meetingManager.selectAudioInputDeviceError);
 
-  const replaceDevice = async (device: string): Promise<Device | AudioTransformDevice> => {
+  const replaceDevice = async (
+    device: string
+  ): Promise<Device | AudioTransformDevice> => {
     if (onDeviceReplacement) {
       return onDeviceReplacement(
         device,

--- a/src/providers/DevicesProvider/index.tsx
+++ b/src/providers/DevicesProvider/index.tsx
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { AudioTransformDevice, Device } from 'amazon-chime-sdk-js';
 import React from 'react';
-import type { Device, AudioTransformDevice } from 'amazon-chime-sdk-js';
 
 import { AudioInputProvider, useAudioInputs } from './AudioInputProvider';
 import { AudioOutputProvider, useAudioOutputs } from './AudioOutputProvider';
@@ -15,7 +15,10 @@ interface Props {
   ) => Promise<Device | AudioTransformDevice>;
 }
 
-const DevicesProvider: React.FC<Props> = ({ children, onDeviceReplacement }) => (
+const DevicesProvider: React.FC<Props> = ({
+  children,
+  onDeviceReplacement,
+}) => (
   <AudioInputProvider onDeviceReplacement={onDeviceReplacement}>
     <AudioOutputProvider>
       <VideoInputProvider>{children}</VideoInputProvider>

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -280,6 +280,7 @@ export class MeetingManager implements AudioVideoObserver {
       logger: configLogger,
       videoUplinkBandwidthPolicy,
       videoDownlinkBandwidthPolicy,
+      reconnectTimeoutMs,
     } = this.meetingManagerConfig;
 
     // We are assigning the values from the `meetingManagerConfig` to preserve backward compatibility.
@@ -298,6 +299,10 @@ export class MeetingManager implements AudioVideoObserver {
 
     if (videoDownlinkBandwidthPolicy) {
       configuration.videoDownlinkBandwidthPolicy = videoDownlinkBandwidthPolicy;
+    }
+
+    if (reconnectTimeoutMs) {
+      configuration.reconnectTimeoutMs = reconnectTimeoutMs;
     }
 
     const deviceController = new DefaultDeviceController(logger, {

--- a/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
+++ b/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
@@ -35,7 +35,7 @@ const MyApp = () => {
 ## Constructor
 
 Accepts a config object of `logLevel`, `postLogConfig`, `simulcastEnabled`, `enableWebAudio`, `logger`,
-`activeSpeakerPolicy`, `videoUplinkBandwidthPolicy`, and `videoDownlinkBandwidthPolicy` that will be used when
+`activeSpeakerPolicy`, `videoUplinkBandwidthPolicy`, `videoDownlinkBandwidthPolicy`, and `reconnectTimeoutMs` that will be used when
 joining a meeting session. See [MeetingProvider](/docs/sdk-providers-meetingprovider--page) documentation for more details.
 
 ## Interface

--- a/src/providers/MeetingProvider/docs/MeetingProvider.stories.mdx
+++ b/src/providers/MeetingProvider/docs/MeetingProvider.stories.mdx
@@ -188,6 +188,10 @@ const Root = () => {
 ```
 For more information on `VideoPriorityBasedPolicy`, check Amazon Chime JS SDK [priority downlink policy guide](https://aws.github.io/amazon-chime-sdk-js/modules/prioritybased_downlink_policy.html).
 
+#### reconnectTimeoutMs
+
+The `reconnectTimeoutMs` specifies the maximum amount of time in milliseconds to allow for reconnecting. Refer to the [JS SDK FAQ](https://aws.github.io/amazon-chime-sdk-js/modules/faqs.html#what-is-the-timeout-for-connect-and-reconnect-and-where-can-i-configure-the-value) for more information. 
+
 #### meetingManager
 
 There may be use cases to re-use the same `MeetingManager` instance across multiple different `MeetingProvider`s.

--- a/src/providers/MeetingProvider/index.tsx
+++ b/src/providers/MeetingProvider/index.tsx
@@ -59,6 +59,10 @@ interface Props {
    * The [ActiveSpeakerPolicy](https://aws.github.io/amazon-chime-sdk-js/interfaces/activespeakerpolicy.html) object that you want to use in the meeting session.
    */
   activeSpeakerPolicy?: ActiveSpeakerPolicy;
+  /**
+   * Maximum amount of time in milliseconds to allow for reconnecting. Default is 120 seconds. [Refer to the documentation.](https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html#reconnecttimeoutms)
+   */
+  reconnectTimeoutMs?: number;
   /** Pass a `MeetingManager` instance if you want to share this instance
    * across multiple different `MeetingProvider`s. This approach has limitations.
    * Check `meetingManager` prop documentation for more information.
@@ -77,6 +81,7 @@ export const MeetingProvider: React.FC<Props> = ({
   onDeviceReplacement,
   videoDownlinkBandwidthPolicy,
   videoUplinkBandwidthPolicy,
+  reconnectTimeoutMs,
   activeSpeakerPolicy,
   meetingManager: meetingManagerProp,
   children,
@@ -92,6 +97,7 @@ export const MeetingProvider: React.FC<Props> = ({
         logger,
         videoDownlinkBandwidthPolicy,
         videoUplinkBandwidthPolicy,
+        reconnectTimeoutMs,
         activeSpeakerPolicy,
       })
   );

--- a/src/providers/MeetingProvider/types.ts
+++ b/src/providers/MeetingProvider/types.ts
@@ -58,4 +58,5 @@ export interface MeetingManagerConfig {
   activeSpeakerPolicy?: ActiveSpeakerPolicy;
   videoUplinkBandwidthPolicy?: VideoUplinkBandwidthPolicy;
   videoDownlinkBandwidthPolicy?: VideoDownlinkBandwidthPolicy;
+  reconnectTimeoutMs?: number;
 }


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Add the `reconnectTimeoutMs` as part of the join parameters and MeetingProvider props so that builders can modify it before joining a meeting.


**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? 
1. Using the demo app, create a meeting session configuration and pass to the meetingManager.join() function. (timeout = 0sec)
2. Render the MeetingProvider with additional meeting config, including reconnectTimeoutMs (0 sec)

Then, kill the network mid meeting and observe error when reconnect timeout is reached.

3. If you made changes to the component library, have you provided corresponding documentation changes? yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
