### PR TITLE
Add background replacement changes under [Unreleased] section in CHAN…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+### Added
+- Add `BackgroundReplacementProvider` provider to support background replacement.
+
+### Changed
+
+### Removed
+
 ## [2.13.0] - 2022-01-06
 
 ### Fixed
 
 ### Added
 - Add `activeSpeakerPolicy` and `videoUplinkBandwidthPolicy` to `MeetingProvider` props.
-- Add `BackgroundReplacementProvider`.
 
 ### Changed
 - Change `additionalDevices` to a prop in `AudioInputControl`, `VideoInputControl`, `AudioInputVFControl`, `MicSelection`, and `CameraSelection` components to allow option to turn off that configuration.


### PR DESCRIPTION
…GELOG

**Issue #:** 

**Description of changes:**
Remove "Add BackgroundReplacementProvider." from [2.13] CHANGELOG section and put it under [Unreleased].

**Testing**
1. Have you successfully run `npm run build:release` locally?
yes
=============================== Coverage summary ===============================
Statements   : 89.73% ( 2027/2259 )
Branches     : 64.7% ( 757/1170 )
Functions    : 78.34% ( 492/628 )
Lines        : 91.64% ( 1754/1914 )
================================================================================

Test Suites: 53 passed, 53 total
Tests:       231 passed, 231 total
Snapshots:   0 total
Time:        53.141 s

2. How did you test these changes?
did not change code

3. If you made changes to the component library, have you provided corresponding documentation changes?
did not change code

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
