### PR TITLE
Expose keepLastFrameWhenPaused meeting session configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add `BackgroundReplacementProvider` provider to support background replacement.
+- Add `keepLastFrameWhenPaused` as an optional parameter to allow to keep the last frame of the video when a remote video is paused via the pauseVideoTile.
 
 ### Changed
 

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -281,6 +281,7 @@ export class MeetingManager implements AudioVideoObserver {
       videoUplinkBandwidthPolicy,
       videoDownlinkBandwidthPolicy,
       reconnectTimeoutMs,
+      keepLastFrameWhenPaused,
     } = this.meetingManagerConfig;
 
     // We are assigning the values from the `meetingManagerConfig` to preserve backward compatibility.
@@ -303,6 +304,10 @@ export class MeetingManager implements AudioVideoObserver {
 
     if (reconnectTimeoutMs) {
       configuration.reconnectTimeoutMs = reconnectTimeoutMs;
+    }
+
+    if (keepLastFrameWhenPaused) {
+      configuration.keepLastFrameWhenPaused = keepLastFrameWhenPaused;
     }
 
     const deviceController = new DefaultDeviceController(logger, {

--- a/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
+++ b/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
@@ -35,8 +35,8 @@ const MyApp = () => {
 ## Constructor
 
 Accepts a config object of `logLevel`, `postLogConfig`, `simulcastEnabled`, `enableWebAudio`, `logger`,
-`activeSpeakerPolicy`, `videoUplinkBandwidthPolicy`, `videoDownlinkBandwidthPolicy`, and `reconnectTimeoutMs` that will be used when
-joining a meeting session. See [MeetingProvider](/docs/sdk-providers-meetingprovider--page) documentation for more details.
+`activeSpeakerPolicy`, `videoUplinkBandwidthPolicy`, `videoDownlinkBandwidthPolicy`, `reconnectTimeoutMs`, and
+`keepLastFrameWhenPaused` that will be used when joining a meeting session. See [MeetingProvider](/docs/sdk-providers-meetingprovider--page) documentation for more details.
 
 ## Interface
 

--- a/src/providers/MeetingProvider/docs/MeetingProvider.stories.mdx
+++ b/src/providers/MeetingProvider/docs/MeetingProvider.stories.mdx
@@ -108,10 +108,10 @@ If you pass in a `Logger` object using this parameter, the `MeetingManager` will
 
 #### onDeviceReplacement
 
-When a selected device is disconnected, or when the Operating System (OS) default device is selected and is changed by the OS (e.g., if a Bluetooth headset is disconnected), 
-the `AudioInputProvider` encapsulated by `DevicesProvider` is forced to automatically select a new audio input. This behaves as expected when the selected device is an ordinary device provided by the browser. 
+When a selected device is disconnected, or when the Operating System (OS) default device is selected and is changed by the OS (e.g., if a Bluetooth headset is disconnected),
+the `AudioInputProvider` encapsulated by `DevicesProvider` is forced to automatically select a new audio input. This behaves as expected when the selected device is an ordinary device provided by the browser.
 However, when your application is using a transform device like Amazon Voice Focus, the `AudioInputProvider` needs a way to transform the newly selected device to avoid reverting to a non-transform device.
-This is accomplished by exposing a `onDeviceReplacement` prop on `MeetingProvider` and `DevicesProvider`, allowing your application to customize the behavior of this device reselection step. 
+This is accomplished by exposing a `onDeviceReplacement` prop on `MeetingProvider` and `DevicesProvider`, allowing your application to customize the behavior of this device reselection step.
 Provide a function that accepts a `Device` as input and returns a `Device` or `AudioTransformDevice` of your choice.
 
 #### activeSpeakerPolicy
@@ -190,7 +190,11 @@ For more information on `VideoPriorityBasedPolicy`, check Amazon Chime SDK for J
 
 #### reconnectTimeoutMs
 
-The `reconnectTimeoutMs` specifies the maximum amount of time in milliseconds to allow for reconnecting. Refer to the [JS SDK FAQ](https://aws.github.io/amazon-chime-sdk-js/modules/faqs.html#what-is-the-timeout-for-connect-and-reconnect-and-where-can-i-configure-the-value) for more information. 
+The `reconnectTimeoutMs` specifies the maximum amount of time in milliseconds to allow for reconnecting. Refer to the [JS SDK FAQ](https://aws.github.io/amazon-chime-sdk-js/modules/faqs.html#what-is-the-timeout-for-connect-and-reconnect-and-where-can-i-configure-the-value) for more information.
+
+#### keepLastFrameWhenPaused
+
+The `keepLastFrameWhenPaused` keeps the last frame of the video when a remote video is paused via the pauseVideoTile.
 
 #### meetingManager
 

--- a/src/providers/MeetingProvider/index.tsx
+++ b/src/providers/MeetingProvider/index.tsx
@@ -63,6 +63,10 @@ interface Props {
    * Maximum amount of time in milliseconds to allow for reconnecting. Default is 120 seconds. [Refer to the documentation.](https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html#reconnecttimeoutms)
    */
   reconnectTimeoutMs?: number;
+  /**
+   * Keep the last frame of the video when a remote video is paused via the pauseVideoTile API.
+   */
+  keepLastFrameWhenPaused?: boolean;
   /** Pass a `MeetingManager` instance if you want to share this instance
    * across multiple different `MeetingProvider`s. This approach has limitations.
    * Check `meetingManager` prop documentation for more information.
@@ -83,6 +87,7 @@ export const MeetingProvider: React.FC<Props> = ({
   videoUplinkBandwidthPolicy,
   reconnectTimeoutMs,
   activeSpeakerPolicy,
+  keepLastFrameWhenPaused,
   meetingManager: meetingManagerProp,
   children,
 }) => {
@@ -98,6 +103,7 @@ export const MeetingProvider: React.FC<Props> = ({
         videoDownlinkBandwidthPolicy,
         videoUplinkBandwidthPolicy,
         reconnectTimeoutMs,
+        keepLastFrameWhenPaused,
         activeSpeakerPolicy,
       })
   );

--- a/src/providers/MeetingProvider/types.ts
+++ b/src/providers/MeetingProvider/types.ts
@@ -59,4 +59,5 @@ export interface MeetingManagerConfig {
   videoUplinkBandwidthPolicy?: VideoUplinkBandwidthPolicy;
   videoDownlinkBandwidthPolicy?: VideoDownlinkBandwidthPolicy;
   reconnectTimeoutMs?: number;
+  keepLastFrameWhenPaused?: boolean;
 }


### PR DESCRIPTION
**Description of changes:**
Expose the `keepLastFrameWhenPaused` meeting session configuration in React SDK (See https://github.com/aws/amazon-chime-sdk-js/pull/1872 for JS SDK change).

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes? 
    1. Join a meeting with priority based policy and ``keepLastFrameWhenPaused` selected.
    2. Throttle the network and make sure that remote videos are paused with last frame.

3. If you made changes to the component library, have you provided corresponding documentation changes? Yes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
