### PR TITLE
Improve README of integration test

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -109,15 +109,15 @@ To enable the entire testing process:
 
 To change the browser on which the test is run, simply change the host property in `/utils/config.js` file.
 
-```json
+```js
 // By default is to run tests locally with Chrome
-host: process.env.HOST || 'chrome',
+host: process.env.HOST || 'chrome'
 
 // To run tests locally with Firefox
-host: process.env.HOST || 'firefox',
+host: process.env.HOST || 'firefox'
 
 // To run tests locally with Safari
-host: process.env.HOST || 'safari',
+host: process.env.HOST || 'safari'
 ```
 
 ### Run Test Suites on Sauce Labs
@@ -132,18 +132,18 @@ npm run start
 
 Then, you need to update the `host` property in `/utils/config.js` file.
 
-```json
+```js
 // By default is to run tests locally with Chrome
-host: process.env.HOST || 'chrome',
+host: process.env.HOST || 'chrome'
 
 // To Run tests on Sauce Labs with Chrome
-host: process.env.HOST || 'sauce-chrome',
+host: process.env.HOST || 'sauce-chrome'
 
 // To Run tests on Sauce Labs with Firefox
-host: process.env.HOST || 'sauce-firefox',
+host: process.env.HOST || 'sauce-firefox'
 
 // To Run tests on Sauce Labs with Safari
-host: process.env.HOST || 'sauce-safari',
+host: process.env.HOST || 'sauce-safari'
 ```
 
 Last, you need to [setup the Sauce Connect Proxy](https://docs.saucelabs.com/secure-connections/sauce-connect/setup-configuration/basic-setup/) manually to allow Sauce Labs accessing the test demo running on your local machine.


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Fix the typo in README of integration test.
* Change the name from `READEME.md` to `README.md`

Change the language of two markdown sections to fix the display issue.

* Before:
  ![image](https://user-images.githubusercontent.com/20471438/150876573-a7cd7745-15dd-4445-bebd-1fd133182ce3.png)

* After:
  ![image](https://user-images.githubusercontent.com/20471438/150876548-347eed3b-1087-42e4-b8d4-987ca8ac5869.png)


**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
N/A

3. If you made changes to the component library, have you provided corresponding documentation changes?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
