### PR TITLE
Add custom styling capabilites to some components and add styling guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [Unreleased]
+### Fixed
 
+### Added
+- Add styling guide documentation for customizing SDK and UI component CSS.
+- Extend and enabled style customizing capabilities on the SDK components.
+### Changed
+
+### Removed
 ## [2.15.0] - 2022-02-03
 ### Fixed
 - Fix a bug in `BackgroundBlurProvider` and `BackgroundReplacementProvider` where the options objects are updated and causing re-rendering and destroying previous processor.
@@ -20,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Removed
-
 ## [2.14.0] - 2022-01-20
 
 

--- a/src/components/sdk/DeviceSelection/CameraSelection/BackgroundBlurCheckbox.tsx
+++ b/src/components/sdk/DeviceSelection/CameraSelection/BackgroundBlurCheckbox.tsx
@@ -12,14 +12,16 @@ import { useBackgroundBlur } from '../../../../providers/BackgroundBlurProvider'
 import { useMeetingManager } from '../../../../providers/MeetingProvider';
 import { Checkbox } from '../../../ui/Checkbox';
 import { FormField } from '../../../ui/FormField';
+import { BaseSdkProps } from '../../Base';
 
-interface Props {
+interface Props extends BaseSdkProps {
   /** Label shown for video filter selection, by default it is "Blur my background" */
   label?: string;
 }
 
 export const BackgroundBlurCheckbox: React.FC<Props> = ({
   label = 'Blur my background',
+  ...rest
 }) => {
   const { isBackgroundBlurSupported, createBackgroundBlurDevice } =
     useBackgroundBlur();
@@ -70,6 +72,7 @@ export const BackgroundBlurCheckbox: React.FC<Props> = ({
       value={'Background Blur'}
       checked={isVideoTransformDevice(device)}
       label={label}
+      {...rest}
     />
   );
 };

--- a/src/components/sdk/DeviceSelection/CameraSelection/QualitySelection.tsx
+++ b/src/components/sdk/DeviceSelection/CameraSelection/QualitySelection.tsx
@@ -10,8 +10,9 @@ import {
 } from '../../../../hooks/sdk/useSelectVideoQuality';
 import { FormField } from '../../../ui/FormField';
 import { Select } from '../../../ui/Select';
+import { BaseSdkProps } from '../../Base';
 
-interface Props {
+interface Props extends BaseSdkProps {
   /** Label shown for video quality selection, by default it is "Video quality" */
   label?: string;
   /** Label shown in the dropdown when no video quality has been selected yet, by default it is "Select video quality" */
@@ -21,6 +22,7 @@ interface Props {
 export const QualitySelection: React.FC<Props> = ({
   label = 'Video quality',
   labelForUnselected = 'Select video quality',
+  ...rest
 }) => {
   const selectVideoQuality = useSelectVideoQuality();
   const [videoQuality, setVideoQuality] = useState('unselected');
@@ -56,6 +58,7 @@ export const QualitySelection: React.FC<Props> = ({
       onChange={selectQuality}
       value={videoQuality}
       label={label}
+      {...rest}
     />
   );
 };

--- a/src/components/sdk/DeviceSelection/CameraSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/CameraSelection/index.tsx
@@ -6,9 +6,10 @@ import React from 'react';
 import { useVideoInputs } from '../../../../providers/DevicesProvider';
 import { useMeetingManager } from '../../../../providers/MeetingProvider';
 import { DeviceConfig } from '../../../../types';
+import { BaseSdkProps } from '../../Base';
 import DeviceInput from '../DeviceInput';
 
-interface Props {
+interface Props extends BaseSdkProps {
   /** The message that will be shown when no camera devices are found. */
   notFoundMsg?: string;
   /** The label that will be shown for camera selection, it defaults to "Camera source". */
@@ -21,6 +22,7 @@ export const CameraSelection: React.FC<Props> = ({
   notFoundMsg = 'No camera devices found',
   label = 'Camera source',
   appendSampleDevices = true,
+  ...rest
 }) => {
   const meetingManager = useMeetingManager();
   const videoInputConfig: DeviceConfig = {
@@ -39,6 +41,7 @@ export const CameraSelection: React.FC<Props> = ({
       devices={devices}
       selectedDeviceId={selectedDevice}
       notFoundMsg={notFoundMsg}
+      {...rest}
     />
   );
 };

--- a/src/components/sdk/DeviceSelection/DeviceInput.tsx
+++ b/src/components/sdk/DeviceSelection/DeviceInput.tsx
@@ -6,8 +6,9 @@ import React, { ChangeEvent } from 'react';
 import { DeviceType, SelectedDeviceId } from '../../../types';
 import { FormField } from '../../ui/FormField';
 import { Select } from '../../ui/Select';
+import { BaseSdkProps } from '../Base';
 
-interface Props {
+interface Props extends BaseSdkProps {
   label: string;
   notFoundMsg: string;
   devices: DeviceType[];
@@ -21,6 +22,7 @@ const DeviceInput: React.FC<Props> = ({
   devices,
   selectedDeviceId,
   notFoundMsg,
+  ...rest
 }) => {
   const outputOptions = devices.map((device) => ({
     value: device.deviceId,
@@ -52,6 +54,7 @@ const DeviceInput: React.FC<Props> = ({
       onChange={selectDevice}
       value={selectedDeviceId || ''}
       label={label}
+      {...rest}
     />
   );
 };

--- a/src/components/sdk/DeviceSelection/MicSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/MicSelection/index.tsx
@@ -6,9 +6,10 @@ import React from 'react';
 import { useSelectAudioInputDevice } from '../../../../hooks/sdk/useSelectAudioInputDevice';
 import { useAudioInputs } from '../../../../providers/DevicesProvider';
 import { DeviceConfig } from '../../../../types';
+import { BaseSdkProps } from '../../Base';
 import DeviceInput from '../DeviceInput';
 
-interface Props {
+interface Props extends BaseSdkProps {
   /** The message that will be shown when no microphone devices are found. */
   notFoundMsg?: string;
   /** The label that will be shown for microphone selection, it defaults to `Microphone source`. */
@@ -21,6 +22,7 @@ export const MicSelection: React.FC<Props> = ({
   notFoundMsg = 'No microphone devices found',
   label = 'Microphone source',
   appendSampleDevices = true,
+  ...rest
 }) => {
   const audioInputConfig: DeviceConfig = {
     additionalDevices: appendSampleDevices,
@@ -35,6 +37,7 @@ export const MicSelection: React.FC<Props> = ({
       devices={devices}
       selectedDeviceId={selectedDevice}
       notFoundMsg={notFoundMsg}
+      {...rest}
     />
   );
 };

--- a/src/components/sdk/DeviceSelection/SpeakerSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/SpeakerSelection/index.tsx
@@ -5,9 +5,10 @@ import React from 'react';
 
 import useSelectAudioOutputDevice from '../../../../hooks/sdk/useSelectAudioOutputDevice';
 import { useAudioOutputs } from '../../../../providers/DevicesProvider';
+import { BaseSdkProps } from '../../Base';
 import DeviceInput from '../DeviceInput';
 
-interface Props {
+interface Props extends BaseSdkProps {
   /** The message that will be shown when no audio output speaker devices are found. */
   notFoundMsg?: string;
   /** The label that will be shown for speaker selection, it defaults to `Speaker source`. */
@@ -20,6 +21,7 @@ export const SpeakerSelection: React.FC<Props> = ({
   notFoundMsg = 'No speaker devices found',
   label = 'Speaker source',
   onChange,
+  ...rest
 }) => {
   const { devices, selectedDevice } = useAudioOutputs();
   const selectAudioOutput = useSelectAudioOutputDevice();
@@ -36,6 +38,7 @@ export const SpeakerSelection: React.FC<Props> = ({
       onChange={selectDevice}
       selectedDeviceId={selectedDevice}
       notFoundMsg={notFoundMsg}
+      {...rest}
     />
   );
 };

--- a/src/components/sdk/MeetingControls/AudioInputControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioInputControl.tsx
@@ -11,8 +11,9 @@ import { isOptionActive } from '../../../utils/device-utils';
 import { ControlBarButton } from '../../ui/ControlBar/ControlBarButton';
 import { Microphone } from '../../ui/icons';
 import { PopOverItemProps } from '../../ui/PopOver/PopOverItem';
+import { BaseSdkProps } from '../Base';
 
-interface Props {
+interface Props extends BaseSdkProps {
   /** The label that will be shown when microphone is muted , it defaults to `Mute`. */
   muteLabel?: string;
   /** The label that will be shown when microphone is unmuted, it defaults to `Unmute`. */
@@ -31,6 +32,7 @@ const AudioInputControl: React.FC<Props> = ({
   mutedIconTitle,
   unmutedIconTitle,
   appendSampleDevices = true,
+  ...rest
 }) => {
   const meetingManager = useMeetingManager();
   const { muted, toggleMute } = useToggleLocalMute();
@@ -58,6 +60,7 @@ const AudioInputControl: React.FC<Props> = ({
       onClick={toggleMute}
       label={muted ? unmuteLabel : muteLabel}
       popOver={dropdownOptions}
+      {...rest}
     />
   );
 };

--- a/src/components/sdk/MeetingControls/AudioInputVFControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioInputVFControl.tsx
@@ -26,8 +26,9 @@ import { ControlBarButton } from '../../ui/ControlBar/ControlBarButton';
 import { Microphone } from '../../ui/icons';
 import { Spinner } from '../../ui/icons';
 import { PopOverItem } from '../../ui/PopOver/PopOverItem';
+import { BaseSdkProps } from '../Base';
 
-interface Props {
+interface Props extends BaseSdkProps {
   /** The label that will be shown when microphone is muted, it defaults to `Mute`. */
   muteLabel?: string;
   /** The label that will be shown when microphone is unmuted, it defaults to `Unmute`. */
@@ -52,6 +53,7 @@ const AudioInputVFControl: React.FC<Props> = ({
   voiceFocusOnLabel = 'Amazon Voice Focus enabled',
   voiceFocusOffLabel = 'Enable Amazon Voice Focus',
   appendSampleDevices = true,
+  ...rest
 }) => {
   const audioVideo = useAudioVideo();
   const meetingManager = useMeetingManager();
@@ -207,6 +209,7 @@ const AudioInputVFControl: React.FC<Props> = ({
       onClick={toggleMute}
       label={muted ? unmuteLabel : muteLabel}
       children={dropdownWithVFOptions}
+      {...rest}
     />
   );
 };

--- a/src/components/sdk/MeetingControls/AudioOutputControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioOutputControl.tsx
@@ -11,13 +11,14 @@ import { isOptionActive, supportsSetSinkId } from '../../../utils/device-utils';
 import { ControlBarButton } from '../../ui/ControlBar/ControlBarButton';
 import { Sound } from '../../ui/icons';
 import { PopOverItemProps } from '../../ui/PopOver/PopOverItem';
+import { BaseSdkProps } from '../Base';
 
-interface Props {
+interface Props extends BaseSdkProps {
   /** The label that will be shown for audio output speaker control, it defaults to `Speaker`. */
   label?: string;
 }
 
-const AudioOutputControl: React.FC<Props> = ({ label = 'Speaker' }) => {
+const AudioOutputControl: React.FC<Props> = ({ label = 'Speaker', ...rest }) => {
   const meetingManager = useMeetingManager();
   const { devices, selectedDevice } = useAudioOutputs();
   const { isAudioOn, toggleAudio } = useLocalAudioOutput();
@@ -42,6 +43,7 @@ const AudioOutputControl: React.FC<Props> = ({ label = 'Speaker' }) => {
         onClick={toggleAudio}
         label={label}
         popOver={dropdownOptions.length ? dropdownOptions : null}
+        {...rest}
       />
     </>
   );

--- a/src/components/sdk/MeetingControls/ContentShareControl.tsx
+++ b/src/components/sdk/MeetingControls/ContentShareControl.tsx
@@ -8,8 +8,9 @@ import { useContentShareControls } from '../../../providers/ContentShareProvider
 import { ControlBarButton } from '../../ui/ControlBar/ControlBarButton';
 import { ScreenShare } from '../../ui/icons';
 import { PopOverItemProps } from '../../ui/PopOver/PopOverItem';
+import { BaseSdkProps } from '../Base';
 
-interface Props {
+interface Props extends BaseSdkProps {
   /** The label that will be shown for content share control, it defaults to `Content`. */
   label?: string;
   /** The label that will be shown for pausing content share button in content share control, it defaults to `Pause`. */
@@ -25,6 +26,7 @@ const ContentShareControl: React.FC<Props> = ({
   pauseLabel = 'Pause',
   unpauseLabel = 'Unpause',
   iconTitle,
+  ...rest
 }) => {
   const { isLocalUserSharing } = useContentShareState();
   const { paused, toggleContentShare, togglePauseContentShare } =
@@ -44,6 +46,7 @@ const ContentShareControl: React.FC<Props> = ({
         onClick={toggleContentShare}
         label={label}
         popOver={isLocalUserSharing ? dropdownOptions : null}
+        {...rest}
       />
     </>
   );

--- a/src/components/sdk/MeetingControls/VideoInputBackgroundBlurControl.tsx
+++ b/src/components/sdk/MeetingControls/VideoInputBackgroundBlurControl.tsx
@@ -23,8 +23,9 @@ import { ControlBarButton } from '../../ui/ControlBar/ControlBarButton';
 import { Camera, Spinner } from '../../ui/icons';
 import PopOverItem from '../../ui/PopOver/PopOverItem';
 import PopOverSeparator from '../../ui/PopOver/PopOverSeparator';
+import { BaseSdkProps } from '../Base';
 
-interface Props {
+interface Props extends BaseSdkProps {
   /** The label that will be shown for video input control, it defaults to `Video`. */
   label?: string;
   /** The label that will be shown for the background blur button. */
@@ -34,6 +35,7 @@ interface Props {
 const VideoInputBackgroundBlurControl: React.FC<Props> = ({
   label = 'Video',
   backgroundBlurLabel = 'Enable Background Blur',
+  ...rest
 }) => {
   const meetingManager = useMeetingManager();
   const { devices, selectedDevice } = useVideoInputs();
@@ -152,6 +154,7 @@ const VideoInputBackgroundBlurControl: React.FC<Props> = ({
       onClick={toggleVideo}
       label={label}
       children={dropdownWithVideoTransformOptions}
+      {...rest}
     />
   );
 };

--- a/src/components/sdk/MeetingControls/VideoInputControl.tsx
+++ b/src/components/sdk/MeetingControls/VideoInputControl.tsx
@@ -11,8 +11,9 @@ import { isOptionActive } from '../../../utils/device-utils';
 import { ControlBarButton } from '../../ui/ControlBar/ControlBarButton';
 import { Camera } from '../../ui/icons';
 import { PopOverItemProps } from '../../ui/PopOver/PopOverItem';
+import { BaseSdkProps } from '../Base';
 
-interface Props {
+interface Props extends BaseSdkProps {
   /** The label that will be shown for video input control, it defaults to `Video`. */
   label?: string;
   /** A boolean that determines whether or not to include additional sample video devices, such as "None", "Blue", "SMTP Color Bars". Defaults to true. This will be deprecated in the next major version. */
@@ -22,6 +23,7 @@ interface Props {
 const VideoInputControl: React.FC<Props> = ({
   label = 'Video',
   appendSampleDevices = true,
+  ...rest
 }) => {
   const videoInputConfig: DeviceConfig = {
     additionalDevices: appendSampleDevices,
@@ -42,6 +44,7 @@ const VideoInputControl: React.FC<Props> = ({
       onClick={toggleVideo}
       label={label}
       popOver={dropdownOptions}
+      {...rest}
     />
   );
 };

--- a/src/components/sdk/RosterAttendee/index.tsx
+++ b/src/components/sdk/RosterAttendee/index.tsx
@@ -6,9 +6,10 @@ import React from 'react';
 import useAttendeeStatus from '../../../hooks/sdk/useAttendeeStatus';
 import { useRosterState } from '../../../providers/RosterProvider';
 import RosterCell, { RosterCellProps } from '../../ui/Roster/RosterCell';
+import { BaseSdkProps } from '../Base';
 import MicrophoneActivity from '../MicrophoneActivity';
 
-export interface RosterAttendeeProps extends Omit<RosterCellProps, 'name'> {
+export interface RosterAttendeeProps extends Omit<RosterCellProps, 'name'>, BaseSdkProps {
   /** The ID of a Chime meeting attendee. */
   attendeeId: string;
 }

--- a/src/components/stylingGuide.stories.mdx
+++ b/src/components/stylingGuide.stories.mdx
@@ -1,0 +1,112 @@
+<Meta title="Styling Guide" />
+
+# Styling Guide
+
+The Amazon Chime SDK React Component Library is comprised of Providers, Hooks, UI Components, and SDK-connected components. 
+Each component has some basic styling applied to it, but you can add or override your own styles to the component by using stylesheets,
+`styled-components` or other styling frameworks. 
+
+The Amazon Chime SDK React Component Library uses [`styled-components`](https://styled-components.com/docs) to attach base styles to all of the components. You must install the peer dependency on `styled-components` to use the library. 
+
+
+# Base Styles
+Every component extends either the [BaseSdkProps](https://github.com/aws/amazon-chime-sdk-component-library-react/blob/61464e15175b0f88d141f968790524c5443ea5d1/src/components/sdk/Base/index.tsx) props or [BaseProps](https://github.com/aws/amazon-chime-sdk-component-library-react/blob/61464e15175b0f88d141f968790524c5443ea5d1/src/components/ui/Base/index.ts), which include the `css` and `className` props. 
+
+# Override base styles on a component
+There are multiple ways to override the base styling applied on SDK or UI components.
+
+Each UI or SDK component contains one or more DOM elements, and in some cases the DOM elements are nested within each other or dynamically rendered.
+In order to select these DOM elements in your stylesheets, you can refer to the individual components' DOM structure. 
+
+## 1. Override styles using the `className` prop
+
+The first method is to use the `className` prop and apply your own classes to the top level DOM element that, in some cases, contain child DOM elements.
+This is the preferred method if you are making more than a couple styling changes to the component.
+
+The base styles were designed to hold a low specificity, however due to [this caveat](https://styled-components.com/docs/advanced#issues-with-specificity) with using `styled-components`, when you select DOM elements in your own stylesheet, you'll need
+to use a higher specificity than just one class selector, otherwise the base styles applied by `styled-components` will override your styles.
+
+```jsx
+import './style.scss'
+
+<Badge className="floating-badge"/>
+```
+Then, in your stylesheet, you need to specify the class name:
+
+```scss
+// ./style.scss
+.floating-badge.floating-badge {
+  // override the base styles in Badge component here
+}
+```
+The reason for having to specify the class selector twice is due to [this caveat](https://styled-components.com/docs/advanced#issues-with-specificity) with `styled-components`. 
+
+## 2. Override styles using `styled-components`
+
+An alternative way you can override base styles is by wrapping an existing component from the `amazon-chime-sdk-component-library-react` library inside of another styled component.
+This is the preferred approach if you are familiar with `styled-components`.
+
+```jsx
+import styled from 'styled-components';
+import { Label } from 'amazon-chime-sdk-component-library-react';
+
+// Create a new styled component based on one of the components from the component library
+let yourStyledLabel = styled(Label)`
+  border: solid 1px black;
+`
+```
+
+## 3. Override styles using the `css` prop
+The last method is by providing the `css` prop to any of the components. This prop is meant to be used
+for minor changes and is not recommended if making more than a couple styling changes for a component.
+
+```jsx
+// CSS prop 
+<Badge css="border: solid 1px black"/>
+```
+
+
+#  Unset styling on a component
+If you want to unset the base styles for a component, you may do the following.
+In some cases, you'll need to use the `*` selector to unstyle components that render nested DOM elements:
+
+## 1. Using `className` prop:
+```jsx
+import './style.scss';
+
+<Label className="my-label"/>
+```
+Example of `./style.scss`:
+```scss
+.my-label.my-label {
+  all: unset;
+  * {
+    all: unset;
+  }
+}
+```
+The reason for having to specify the class selector twice is due to [this caveat](https://styled-components.com/docs/advanced#issues-with-specificity) with `styled-components`. 
+
+## 2. Using `styled-components`
+You can attach the `unset` property to an existing component the same way you'd add any other CSS property to an existing component with `styled-components`:
+
+```jsx
+import styled from 'styled-components';
+import { Label } from 'amazon-chime-sdk-component-library-react';
+
+let yourStyledLabel = styled(Label)`
+  all: unset;
+  * {
+    all: unset;
+  }
+`
+```
+
+## 3. Using `css` prop
+
+You can achieve the same with the `css` prop, but this is most likely not the ideal
+use of this prop, since this prop is meant for only minor changes to the styling:
+
+```jsx
+<Label css="all: unset; * { all: unset }"/>
+```

--- a/src/components/ui/Checkbox/index.tsx
+++ b/src/components/ui/Checkbox/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ChangeEvent, FC, useRef } from 'react';
-
+import { BaseProps } from '../Base';
 import { Check } from '../icons';
 import { HiddenCheckbox, StyledCheckbox } from './Styled';
 
@@ -10,7 +10,7 @@ export interface CheckboxProps
   extends Omit<
     React.InputHTMLAttributes<HTMLInputElement>,
     'onChange' | 'value'
-  > {
+  >, BaseProps {
   /** The callback fired when the state is changed. */
   onChange: (event?: ChangeEvent | string) => void;
   /** The value of the checkbox. */

--- a/src/components/ui/Input/InputWrapper.tsx
+++ b/src/components/ui/Input/InputWrapper.tsx
@@ -2,23 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { forwardRef, ReactNode, Ref } from 'react';
+import { BaseProps } from '../Base';
 
 import { Size } from './';
 import { StyledInputWrapper } from './Styled';
 
-export interface InputWrapperProps {
+export interface InputWrapperProps extends BaseProps {
   leadingIcon?: ReactNode;
   sizing?: Size;
-  className?: string;
   children?: ReactNode | ReactNode[];
 }
 
 export const InputWrapper = forwardRef(
   (props: InputWrapperProps, ref: Ref<HTMLSpanElement>) => {
-    const { leadingIcon, children } = props;
+    const { leadingIcon, children, sizing, ...rest } = props;
 
     return (
-      <StyledInputWrapper ref={ref} {...props} data-testid="input-wrapper">
+      <StyledInputWrapper ref={ref} sizing={sizing} leadingIcon={leadingIcon} {...rest} data-testid="input-wrapper">
         {leadingIcon && <span className="ch-icon">{leadingIcon}</span>}
         {children}
       </StyledInputWrapper>

--- a/src/components/ui/Input/Styled.tsx
+++ b/src/components/ui/Input/Styled.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';
+import { baseSpacing, baseStyles } from '../Base';
 
 import { InputWrapperProps } from './InputWrapper';
 
@@ -72,6 +73,9 @@ export const StyledInput = styled.input`
     width: 0;
     height: 0;
   }
+
+  ${baseSpacing}
+  ${baseStyles}
 `;
 
 interface ClearProps {

--- a/src/components/ui/MicVolumeIndicator/Styled.tsx
+++ b/src/components/ui/MicVolumeIndicator/Styled.tsx
@@ -3,15 +3,13 @@
 
 import styled from 'styled-components';
 
-import { baseStyles } from '../Base';
+import { baseSpacing, baseStyles } from '../Base';
 import { MicVolumeIndicatorProps } from '.';
 
 export const StyledMicVolumeIndicator = styled.div<MicVolumeIndicatorProps>`
   position: relative;
   height: inherit;
   line-height: 0;
-
-  ${baseStyles}
 
   .ch-mic-icon {
     position: relative;
@@ -42,6 +40,9 @@ export const StyledMicVolumeIndicator = styled.div<MicVolumeIndicatorProps>`
         ? props.theme.colors.error.light
         : props.theme.colors.primary.light};
   }
+
+  ${baseSpacing}
+  ${baseStyles}
 `;
 
 export default StyledMicVolumeIndicator;

--- a/src/components/ui/Modal/ModalButtonGroup.tsx
+++ b/src/components/ui/Modal/ModalButtonGroup.tsx
@@ -1,13 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { FC, ReactElement } from 'react';
+import React, { FC, HTMLAttributes, ReactElement } from 'react';
+import { BaseProps } from '../Base';
 
 import { useModalContext } from './ModalContext';
 import { StyledModalButtonGroup } from './Styled';
 
 export interface ModalButtonGroupProps
-  extends React.HTMLAttributes<HTMLDivElement> {
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'css'>, BaseProps {
   /** Defines the primary button(s) in the modal. */
   primaryButtons: ReactElement | ReactElement[];
   /** Defines the secondary button(s) in the modal. */
@@ -17,6 +18,7 @@ export interface ModalButtonGroupProps
 export const ModalButtonGroup: FC<ModalButtonGroupProps> = ({
   primaryButtons,
   secondaryButtons,
+  ...rest
 }) => {
   const context = useModalContext();
 
@@ -49,7 +51,10 @@ export const ModalButtonGroup: FC<ModalButtonGroupProps> = ({
   };
 
   return (
-    <StyledModalButtonGroup data-testid="modal-button-group">
+    <StyledModalButtonGroup
+      data-testid="modal-button-group"
+      {...rest}
+    >
       <div key="primarybuttons">
         {addCloseBehaviorToButtons(primaryButtons)}
       </div>

--- a/src/components/ui/Modal/Styled.ts
+++ b/src/components/ui/Modal/Styled.ts
@@ -4,6 +4,7 @@
 import styled from 'styled-components';
 
 import { fadeAnimation, slideDownAndScaleUp } from '../../../utils/animations';
+import { baseSpacing, baseStyles } from '../Base';
 import { ModalProps } from './';
 
 export const StyledModal = styled.div<ModalProps>`
@@ -50,6 +51,9 @@ export const StyledModal = styled.div<ModalProps>`
       max-height: none;
     }
   }
+
+  ${baseSpacing}
+  ${baseStyles}
 `;
 
 export const StyledModalHeader = styled.header`
@@ -67,6 +71,9 @@ export const StyledModalHeader = styled.header`
     font-size: ${(props) => props.theme.modal.titleSize};
     font-weight: ${(props) => props.theme.modal.titleWeight};
   }
+
+  ${baseSpacing}
+  ${baseStyles}
 `;
 
 export const StyledModalBody = styled.div`
@@ -75,6 +82,9 @@ export const StyledModalBody = styled.div`
   padding: 0 1.5rem;
   flex-grow: 1;
   overflow-y: auto;
+
+  ${baseSpacing}
+  ${baseStyles}
 `;
 
 export const StyledModalButtonGroup = styled.footer`
@@ -110,4 +120,7 @@ export const StyledModalButtonGroup = styled.footer`
       margin: 0.5rem 0 0;
     }
   }
+
+  ${baseSpacing}
+  ${baseStyles}
 `;

--- a/src/components/ui/Select/Styled.tsx
+++ b/src/components/ui/Select/Styled.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import styled from 'styled-components';
+import { baseSpacing, baseStyles } from '../Base';
 
 export const StyledWrapper = styled.div`
   position: relative;
@@ -9,6 +10,9 @@ export const StyledWrapper = styled.div`
   .ch-select-icon {
     pointer-events: none;
   }
+
+  ${baseSpacing}
+  ${baseStyles}
 `;
 
 export const StyledSelectInput = styled.select`
@@ -38,4 +42,7 @@ export const StyledSelectInput = styled.select`
     border: ${(props) => props.theme.inputs.error.border};
     box-shadow: ${(props) => props.theme.inputs.error.shadow};
   }
+
+  ${baseSpacing}
+  ${baseStyles}
 `;


### PR DESCRIPTION
**Issue #:** 

https://github.com/aws/amazon-chime-sdk-component-library-react/issues/712
https://github.com/aws/amazon-chime-sdk-component-library-react/issues/196

**Description of changes:**

Add a styling guide for the component library - this shows builders how to implement custom styling on all of our components.

This should publish a new documentation page on storybook for styling. Ran storybook to confirm that the docs show correctly. Here is a preview: https://github.com/aws/amazon-chime-sdk-component-library-react/blob/db863433b004299ef639ac6242ca7f77647101ab/src/components/stylingGuide.stories.mdx

**Testing**
1. Have you successfully run `npm run build:release` locally?
yes

2. How did you test these changes?
manually added each changed component in the integration test app and changed the `css` and `classname` props to test that the changes are applied accordingly.

3. If you made changes to the component library, have you provided corresponding documentation changes?
Yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
![Screen Shot 2022-01-27 at 8 09 50 PM](https://user-images.githubusercontent.com/54328451/151485909-21a53483-0d40-49e9-b780-613fea4b6f74.png)

