### PR TITLE
Add observer videoAvailabilityDidChange in LocalVideoProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `BackgroundReplacementProvider` provider to support background replacement.
 - Add `keepLastFrameWhenPaused` as an optional parameter to allow to keep the last frame of the video when a remote video is paused via the pauseVideoTile.
+- Add `videoAvailabilityDidChange` as an audio observer in `LocalVideoProvider` and a new state `isReachVideoLimit` to disable the video button when the video limit is reached.
 
 ### Changed
 

--- a/src/components/quickStarts.stories.mdx
+++ b/src/components/quickStarts.stories.mdx
@@ -411,20 +411,23 @@ You can find examples and usage of the hook from [`useMediaStreamMetrics` storyb
 
 For UI implementation, check the [`LocalMediaStreamMetrics`](https://github.com/aws/amazon-chime-sdk-component-library-react/blob/de22a537d6437073f72d69da30f1703ef4cf40b3/demo/meeting/src/containers/LocalMediaStreamMetrics/index.tsx#L22-L28) and [`VideoStreamMetrics`](https://github.com/aws/amazon-chime-sdk-component-library-react/blob/de22a537d6437073f72d69da30f1703ef4cf40b3/demo/meeting/src/containers/VideoStreamMetrics/index.tsx#L27) components in meeting demo for more details.
 
-## Enable Background Blur
+## Enable Background Blur and Replacement
 
-You can enable background blur on your video stream by using the provider called `BackgroundBlurProvider`. The `BackgroundBlurProvider` provides
-a `createBackgroundBlurDevice` function that takes in a `Device` type and returns a `VideoTransformDevice`. Once you have the `VideoTransformDevice`,
-you may call `meetingManager.selectVideoInputDevice(videoTransformedDevice)` with the `VideoTransformDevice` just as you would with a regular device.
+You can enable background blur and replacement on your video stream by using the providers called `BackgroundBlurProvider` and `BackgroundReplacementProvider`. The `BackgroundBlurProvider` and `BackgroundReplacementProvider` provides
+a `createBackgroundBlurDevice` and `createBackgroundReplacementDevice` functions that takes in a `Device` type and returns a `VideoTransformDevice`. Once you have the `VideoTransformDevice`,
+you may call `meetingManager.selectVideoInputDevice(videoTransformedDevice)` with the `VideoTransformDevice` just as you would with a regular device. Please note that users would also need to call `DefaultVideoTransformDevice.stop` when constructing a new 
+`DefaultVideoTransformDevice` with new video processors. For more information, refer to [Video Processing APIs](https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/10_Video_Processor.md#stopping-videotransformdevice).
 
 Optionally, you may use the `VideoInputBackgroundBlurControl` component - it is similar to the `VideoInputControl` component, except it has an
 additional button to enable background blur. If you'd like to create your own background blur control component, you may look at the [`VideoInputBackgroundBlurControl`](https://github.com/aws/amazon-chime-sdk-component-library-react/blob/main/src/components/sdk/MeetingControls/VideoInputBackgroundBlurControl.tsx)
 as an example.
 
 One thing to note is that calling `meetingManager.selectVideoInputDevice()` with a `Device` type while the current selected video input device is a `VideoTransformDevice`
-will automatically stop any video processor that was previously running.
+will automatically stop any video processor that was previously running. Lastly, make sure to construct a new `DefaultVideoTransformDevice` using `createBackgroundBlurDevice` or `createBackgroundReplacementDevice` if
+the Props of the provider were changed.
 
-You may also refer to the storybook documentation for other examples on how to use [`BackgroundBlurProvider`](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/docs/sdk-providers-backgroundblurprovider--page) and `createBackgroundBlurDevice`.
+You may also refer to the storybook documentation for other examples on how to use [`BackgroundBlurProvider`](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/docs/sdk-providers-backgroundblurprovider--page) 
+and [`BackgroundReplacementProvider`](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/docs/sdk-providers-backgroundreplacementprovider--page).
 
 For more documentation on creating a `VideoTransformDevice`, you can refer to the [Background Filter Video Processor Guide](https://github.com/aws/amazon-chime-sdk-js/blob/master/guides/15_Background_Filter_Video_Processor.md).
 

--- a/src/providers/LocalVideoProvider/docs/LocalVideoProvider.stories.mdx
+++ b/src/providers/LocalVideoProvider/docs/LocalVideoProvider.stories.mdx
@@ -23,6 +23,12 @@ To start/stop user's local video, use `toggleVideo` function from the `LocalVide
   // A function to set the value of `isVideoEnabled`
   setIsVideoEnabled: (isEnabled: boolean) => void;
 
+  // Whether or not video limit is reached, it defaults to false
+  isReachVideoLimit: boolean;
+
+  // A function to set the value of `isReachVideoLimit`
+  setIsReachVideoLimit: (isReachVideoLimit: boolean) => void;
+
   // A function that toggles the local user's video
   toggleVideo: () => Promise<void>;
 }
@@ -48,21 +54,31 @@ const App = () => (
 );
 
 const MyChild = () => {
-  const { tileId, isVideoEnabled, setIsVideoEnabled, toggleVideo } = useLocalVideo();
+  const { tileId, isVideoEnabled, setIsVideoEnabled, 
+  isReachVideoLimit, setIsReachVideoLimit, toggleVideo } = useLocalVideo();
 
   return (
     <p>Tile ID: {tileId}</p>
 
     <p>
-      {setIsVideoEnabled ? 'LocalVideo is enabled' : 'LocalVideo is disabled'}
+      {isVideoEnabled ? 'LocalVideo is enabled' : 'LocalVideo is disabled'}
+    </p>
+
+    <p>
+      {isReachVideoLimit ? 'Video limit is reached' : 'Video limit is not reached'}
     </p>
 
     <button onClick={() => setIsVideoEnabled(true)}>
       Set isVidelEnabled to true
     </button>
+
+    <button onClick={() => setIsReachVideoLimit(true)}>
+      Set isReachVideoLimit to true
+    </button>
     
     <button onClick={toggleVideo}>
-      {isVideoEnabled ? 'Stop your video' : 'Start your video'}
+      {isVideoEnabled ? 'Stop your video' : isReachVideoLimit ? 
+      'Reach the video limit, can not turn on video' : 'Start your video'}
     </button>
   );
 };

--- a/src/providers/LocalVideoProvider/docs/useLocalVideo.stories.mdx
+++ b/src/providers/LocalVideoProvider/docs/useLocalVideo.stories.mdx
@@ -23,6 +23,12 @@ To start/stop user's local video, use `toggleVideo` function from the `LocalVide
   // A function to set the value of `isVideoEnabled`
   setIsVideoEnabled: (isEnabled: boolean) => void;
 
+  // Whether or not video limit is reached, it defaults to false
+  isReachVideoLimit: boolean;
+
+  // A function to set the value of `isReachVideoLimit`
+  setIsReachVideoLimit: (isReachVideoLimit: boolean) => void;
+
   // A function that toggles the local user's video
   toggleVideo: () => Promise<void>;
 }
@@ -52,21 +58,31 @@ const App = () => (
 );
 
 const MyChild = () => {
-  const { tileId, isVideoEnabled, setIsVideoEnabled, toggleVideo } = useLocalVideo();
+  const { tileId, isVideoEnabled, setIsVideoEnabled, 
+  isReachVideoLimit, setIsReachVideoLimit, toggleVideo } = useLocalVideo();
 
   return (
     <p>Tile ID: {tileId}</p>
 
     <p>
-      {setIsVideoEnabled ? 'LocalVideo is enabled' : 'LocalVideo is disabled'}
+      {isVideoEnabled ? 'LocalVideo is enabled' : 'LocalVideo is disabled'}
+    </p>
+
+    <p>
+      {isReachVideoLimit ? 'Video limit is reached' : 'Video limit is not reached'}
     </p>
 
     <button onClick={() => setIsVideoEnabled(true)}>
       Set isVideoEnabled to true
     </button>
+
+    <button onClick={() => setIsReachVideoLimit(true)}>
+      Set isReachVideoLimit to true
+    </button>
     
     <button onClick={toggleVideo}>
-      {isVideoEnabled ? 'Stop your video' : 'Start your video'}
+      {isVideoEnabled ? 'Stop your video' : isReachVideoLimit ? 
+      'Reach the video limit, can not turn on video' : 'Start your video'}
     </button>
   );
 };


### PR DESCRIPTION
**Issue #:** [Handling meeting video share limit](https://github.com/aws/amazon-chime-sdk-component-library-react/issues/720)

**Description of changes:**
Add `videoAvailabilityDidChange` as an audio observer in `LocalVideoProvider` and a new state `isReachVideoLimit`. There will be a warning when the video limit is reached and an error if a user want to turn on the video in this case. The video button will also be disabled in this case.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Change the `joinFrame.maxNumOfVideos` to 2 in [JS SDK](https://github.com/aws/amazon-chime-sdk-js/blob/v2.21.0/src/signalingclient/DefaultSignalingClient.ts#L85), so it will reach the video limit when there are two attendees turning on the video.
* Have 3 attendees join the same meeting
* Turn on the video for two attendees, there is a warning in the console `Reach the number of maximum active videos`
* Then try to turn on the video for the third attendee
* There is an error in the console log and the video button should be disabled 
* Turn off the video for the second attendee
* Try to turn on the video for the third attendee, the video should be available and there is a warning in the console  saying `Reach the number of maximum active videos`

3. If you made changes to the component library, have you provided corresponding documentation changes?
Yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
