### PR TITLE
Fix BG Blur and BG Replacement bug with options prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- Fix a bug in `BackgroundBlurProvider` and `BackgroundReplacementProvider` where the options objects are updated and causing re-rendering and destroying previous processor.
 
 ### Added
 

--- a/src/components/sdk/MeetingControls/AudioInputVFControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioInputVFControl.tsx
@@ -12,10 +12,10 @@ import React, { ReactNode, useEffect, useState } from 'react';
 
 import { PopOverSeparator } from '../../..';
 import { useToggleLocalMute } from '../../../hooks/sdk/useToggleLocalMute';
+import { useAudioVideo } from '../../../providers/AudioVideoProvider';
 import { useAudioInputs } from '../../../providers/DevicesProvider';
 import { useMeetingManager } from '../../../providers/MeetingProvider';
 import { useVoiceFocus } from '../../../providers/VoiceFocusProvider';
-import { useAudioVideo } from '../../../providers/AudioVideoProvider';
 import { DeviceConfig, DeviceType } from '../../../types';
 import {
   audioInputSelectionToDevice,

--- a/src/providers/BackgroundBlurProvider/docs/BackgroundBlurProvider.stories.mdx
+++ b/src/providers/BackgroundBlurProvider/docs/BackgroundBlurProvider.stories.mdx
@@ -31,8 +31,9 @@ to [Integrating background filters into your Amazon Chime SDK for JavaScript app
 
 You can check whether or not the processor has been loaded correctly by checking the state of `isBackgroundBlurSupported`.
 `createBackgroundBlurDevice` may throw an error if the processor was not loaded. You should check whether or not the processor has been loaded correctly by checking the state of `isBackgroundBlurSupported`
-before calling `createBackgroundBlurDevice`. Calling `createBackgroundBlurDevice` will create a new processor. Users would also need to call `DefaultVideoTransformDevice.stop` when constructing a new 
-`DefaultVideoTransformDevice` with new video processors. For more information, refer to [Video Processing APIs](https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/10_Video_Processor.md#stopping-videotransformdevice).
+before calling `createBackgroundBlurDevice`. Calling `createBackgroundBlurDevice` will create a new `DefaultVideoTransformDevice`. Users would also need to call `DefaultVideoTransformDevice.stop` when constructing a new 
+`DefaultVideoTransformDevice` with `createBackgroundBlurDevice` in order to destroy the processors running previously. Once you call `DefaultVideoTransformDevice.stop`, you should discard the old `DefaultVideoTransformDevice`. 
+For more information, refer to [Video Processing APIs](https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/10_Video_Processor.md#stopping-videotransformdevice).
 
 One thing to note is that calling `meetingManager.selectVideoInputDevice()` with a `Device` type while the current selected video input device is a `VideoTransformDevice`
 will automatically stop any video processor that was previously running. Lastly, make sure to construct a new `DefaultVideoTransformDevice` using `createBackgroundBlurDevice`. 

--- a/src/providers/BackgroundReplacementProvider/docs/BackgroundReplacementProvider.stories.mdx
+++ b/src/providers/BackgroundReplacementProvider/docs/BackgroundReplacementProvider.stories.mdx
@@ -31,11 +31,12 @@ to [Integrating background filters into your Amazon Chime SDK for JavaScript app
 
 You can check whether or not the processor has been loaded correctly by checking the state of `isBackgroundReplacementSupported`.
 `createBackgroundReplacementDevice` may throw an error if the processor was not loaded. You should check whether or not the processor has been loaded correctly by checking the state of `isBackgroundReplacementSupported`
-before calling `createBackgroundReplacementDevice`. Calling `createBackgroundReplacementDevice` will create a new processor. Users would also need to call `DefaultVideoTransformDevice.stop` when constructing a new 
-`DefaultVideoTransformDevice` with new video processors. For more information, refer to [Video Processing APIs](https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/10_Video_Processor.md#stopping-videotransformdevice).
+before calling `createBackgroundReplacementDevice`. Calling `createBackgroundReplacementDevice` will create a `DefaultVideoTransformDevice`. Users would also need to call `DefaultVideoTransformDevice.stop` when constructing a new 
+`DefaultVideoTransformDevice` with `createBackgroundReplacementDevice` in order to destroy the processors running previously. Once you call `DefaultVideoTransformDevice.stop`, you should discard the old `DefaultVideoTransformDevice`. 
+For more information, refer to [Video Processing APIs](https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/10_Video_Processor.md#stopping-videotransformdevice).
 
 One thing to note is that calling `meetingManager.selectVideoInputDevice()` with a `Device` type while the current selected video input device is a `VideoTransformDevice`
-will automatically stop any video processor that was previously running. Lastly, make sure to construct a new `DefaultVideoTransformDevice` using `createBackgroundReplacementDevice`.
+will automatically stop any processors running within a `DefaultVideoTransformDevice` that was previously running. Lastly, make sure to construct a new `DefaultVideoTransformDevice` using `createBackgroundReplacementDevice`.
 if the Props of the provider were changed.
 
 You can access the state by using the [useBackgroundReplacement](/docs/sdk-hooks-useBackgroundReplacement--page) hook.

--- a/src/providers/VoiceFocusProvider/index.tsx
+++ b/src/providers/VoiceFocusProvider/index.tsx
@@ -8,9 +8,9 @@ import {
   VoiceFocusSpec,
   VoiceFocusTransformDevice,
 } from 'amazon-chime-sdk-js';
-import {JoinMeetingInfo} from '../../types';
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
+import { JoinMeetingInfo } from '../../types';
 import useMemoCompare from '../../utils/use-memo-compare';
 
 interface Props {
@@ -36,11 +36,11 @@ interface VoiceFocusState {
 
 const VoiceFocusContext = createContext<VoiceFocusState | null>(null);
 
-const VoiceFocusProvider: React.FC<Props> = ({ 
-  spec, 
-  options, 
+const VoiceFocusProvider: React.FC<Props> = ({
+  spec,
+  options,
   createMeetingResponse,
-  children, 
+  children,
 }) => {
   const [isVoiceFocusSupported, setIsVoiceFocusSupported] = useState<
     boolean | undefined
@@ -58,7 +58,10 @@ const VoiceFocusProvider: React.FC<Props> = ({
       prev: VoiceFocusSpec | undefined,
       next: VoiceFocusSpec | undefined
     ): boolean => {
-      if (Object.is(prev, next) || JSON.stringify(prev) === JSON.stringify(next)) {
+      if (
+        Object.is(prev, next) ||
+        JSON.stringify(prev) === JSON.stringify(next)
+      ) {
         return true;
       }
 
@@ -142,14 +145,14 @@ const VoiceFocusProvider: React.FC<Props> = ({
     spec: VoiceFocusSpec | undefined,
     options: VoiceFocusDeviceOptions | undefined,
     canceled: () => boolean,
-    createMeetingResponse?: JoinMeetingInfo | undefined,
+    createMeetingResponse?: JoinMeetingInfo | undefined
   ): Promise<VoiceFocusDeviceTransformer> {
     const fetch = VoiceFocusDeviceTransformer.create(
-      spec, 
-      options, 
-      undefined, 
+      spec,
+      options,
+      undefined,
       createMeetingResponse
-      );
+    );
     fetch
       .then((transformer) => {
         // A different request arrived afterwards. Drop this one on the floor
@@ -181,12 +184,17 @@ const VoiceFocusProvider: React.FC<Props> = ({
     vfSpec: VoiceFocusSpec | undefined,
     options: VoiceFocusDeviceOptions | undefined,
     canceled: () => boolean,
-    createMeetingResponse: JoinMeetingInfo | undefined,
+    createMeetingResponse: JoinMeetingInfo | undefined
   ) {
     // Throw away the old one and reinitialize.
     setVoiceFocusTransformer(null);
     setVoiceFocusDevice(null);
-    createVoiceFocusDeviceTransformer(vfSpec, options, canceled, createMeetingResponse);
+    createVoiceFocusDeviceTransformer(
+      vfSpec,
+      options,
+      canceled,
+      createMeetingResponse
+    );
   }
 
   useEffect(() => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,14 +76,14 @@ export enum DeviceLabels {
 export type DeviceLabelTrigger = () => Promise<MediaStream>;
 
 export type MeetingFeatures = {
-  Audio: {[key: string]: string};
-}
+  Audio: { [key: string]: string };
+};
 
 export type CreateMeetingResponse = {
   MeetingFeatures: MeetingFeatures;
-}
+};
 
 export type JoinMeetingInfo = {
   Meeting: CreateMeetingResponse;
   Attendee: string;
-}
+};

--- a/src/utils/device-utils.ts
+++ b/src/utils/device-utils.ts
@@ -57,10 +57,10 @@ export function isPrevNextUndefined<T>(prev: T, next: T): boolean {
   const isPrevUndefined = prev === undefined;
   const isNextUndefined = next === undefined;
   return isPrevUndefined && isNextUndefined;
-};
+}
 
 export function isPrevNextEmpty<T>(prev: T, next: T): boolean {
-  const isPrevEmpty = (prev && Object.keys(prev).length === 0);
-  const isNextEmpty = (next && Object.keys(next).length === 0);
+  const isPrevEmpty = prev && Object.keys(prev).length === 0;
+  const isNextEmpty = next && Object.keys(next).length === 0;
   return isPrevEmpty && isNextEmpty;
 }


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Fix a bug with the BG BLur and BG REplacement Providers - the options props were being directly passed to the JS SDK and being mutated - so instead of passing the actual options prop, we pass a copy of the options object to the JS SDK. 

Also, updated the useMemoCompare to be more accurate when comparing the options prop. (For BG BLur and BG Replacement)

Updated the documentation to be a bit more accurate.

I also ran linter to fix syntax issues.

**Testing**
1. Have you successfully run `npm run build:release` locally?
yes

2. How did you test these changes?
Tested in the demo app. Verified that the old processor is not destroyed anymore. 

3. If you made changes to the component library, have you provided corresponding documentation changes?
Yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
