### PR TITLE
Fix PreviewVideo not starting if audioVideo is set after the video de…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- Fix `PreviewVideo` not starting if audioVideo is set after the video device.
 - Fix a bug in `BackgroundBlurProvider` and `BackgroundReplacementProvider` where the options objects are updated and causing re-rendering and destroying previous processor.
 
 ### Added

--- a/src/components/sdk/PreviewVideo/index.tsx
+++ b/src/components/sdk/PreviewVideo/index.tsx
@@ -37,7 +37,7 @@ export const PreviewVideo: React.FC<BaseSdkProps> = (props) => {
     return () => {
       meetingManager.unsubscribeFromSelectedVideoInputTranformDevice(setDevice);
     };
-  }, []);
+  }, [meetingManager]);
 
   useEffect(() => {
     const videoElement = videoEl.current;
@@ -47,7 +47,7 @@ export const PreviewVideo: React.FC<BaseSdkProps> = (props) => {
         setIsVideoEnabled(false);
       }
     };
-  }, [audioVideo]);
+  }, [audioVideo, setIsVideoEnabled]);
 
   useEffect(() => {
     if (!audioVideo || !device || !videoEl.current) {
@@ -64,7 +64,7 @@ export const PreviewVideo: React.FC<BaseSdkProps> = (props) => {
       }
     }
     startPreview();
-  }, [device]);
+  }, [meetingManager, device, audioVideo, setIsVideoEnabled]);
 
   return <StyledPreview {...props} ref={videoEl} />;
 };


### PR DESCRIPTION
**Issue #708 :** 

**Description of changes:**
Add the missing dependencies identified by eslint to the useEffect calls in PreviewVideo.  This fixes the PreviewVideo not starting and not showing anything if audioVideo is set after the video device.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Manual testing with and without the changes

3. If you made changes to the component library, have you provided corresponding documentation changes?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
