### PR TITLE
Add integration test app for video filter tests

### DIFF
--- a/integration/app/test-demo/src/app.tsx
+++ b/integration/app/test-demo/src/app.tsx
@@ -4,6 +4,8 @@ import { lightTheme } from 'amazon-chime-sdk-component-library-react';
 import { ThemeProvider } from 'styled-components';
 import { Home } from './pages/Home';
 import { RosterTestApp } from './pages/RosterTestApp';
+import { VideoFilterTestApp } from './pages/VideoFilterTestApp';
+
 
 const App: React.FC = () => (
   <ThemeProvider theme={lightTheme}>
@@ -11,6 +13,7 @@ const App: React.FC = () => (
       <Routes>
         <Route path={routes.HOME} element={<Home />} />
         <Route path={routes.ROSTER_TEST} element={<RosterTestApp />} />
+        <Route path={routes.VIDEO_FILTER_TEST} element={<VideoFilterTestApp />} />
       </Routes>
     </BrowserRouter >
   </ThemeProvider>
@@ -19,6 +22,7 @@ const App: React.FC = () => (
 export const routes = {
   HOME: '/',
   ROSTER_TEST: 'roster-test',
+  VIDEO_FILTER_TEST: 'video-filter',
 };
 
 export default App;

--- a/integration/app/test-demo/src/components/TestApp.tsx
+++ b/integration/app/test-demo/src/components/TestApp.tsx
@@ -5,7 +5,7 @@ const TestApp: React.FC<{ name: string, route: string, components: string[], hoo
   const componentList = components.map(component => <li key={component}>{component}</li>);
   const hookList = hooks.map(hook => <li key={hook}>{hook}</li>);
   return (
-    <li>
+    <li style={{marginBottom: '1rem'}}>
       <Link to={route}>{name}</Link>
       <header>Component Coverage</header>
       <ul>

--- a/integration/app/test-demo/src/pages/Home.tsx
+++ b/integration/app/test-demo/src/pages/Home.tsx
@@ -19,6 +19,16 @@ export const Home: React.FC = () => (
           'useAttendeeAudioStatus',
         ]}
       />
+      <TestApp
+        name='Video Filter Test App'
+        route={routes.VIDEO_FILTER_TEST}
+        components={[
+          `BackgroundBlurProvider`,
+        ]}
+        hooks={[
+          `useBackgroundBlur`,
+        ]}
+        />
     </ul>
   </>
 );

--- a/integration/app/test-demo/src/pages/VideoFilterTestApp.tsx
+++ b/integration/app/test-demo/src/pages/VideoFilterTestApp.tsx
@@ -1,0 +1,117 @@
+import React, { ChangeEvent, useEffect, useState } from 'react';
+import { BackgroundBlurOptions, LogLevel } from 'amazon-chime-sdk-js';
+import {
+  MeetingProvider,
+  useBackgroundBlur,
+  BackgroundBlurProvider,
+  ControlBar,
+  useMeetingManager,
+  useVideoInputs,
+  useLocalVideo,
+  useMeetingStatus,
+  MeetingStatus,
+  VideoTileGrid,
+  FormField,
+  Select,
+  VideoInputBackgroundBlurControl,
+} from 'amazon-chime-sdk-component-library-react';
+import MeetingInfo from '../components/MeetingInfo';
+import MeetingLeaveControl from '../components/MeetingLeaveControl';
+import MeetingForm from '../containers/MeetingForm';
+
+export const VideoFilterTestApp: React.FC = () => {
+  const defaultOptions: BackgroundBlurOptions = {
+    blurStrength: 20,
+    filterCPUUtilization: 20,
+    reportingPeriodMillis: 1000,
+  };
+  const [backgroundBlurOptions, setBackgroundBlurOptions] = useState<BackgroundBlurOptions>(defaultOptions);
+
+  const setBlurStrength = (newBlurStrength: number): void => {
+    console.log(`Setting blur strength to ${newBlurStrength} - should re-initialize the bg blur provider`);
+    const options = {...backgroundBlurOptions, blurStrength : newBlurStrength};
+    setBackgroundBlurOptions(options);
+  }
+
+  return(
+    <div style={{ display: 'flex', flexDirection: 'column', width: '70%', margin: 'auto' }}>
+      <BackgroundBlurProvider options={backgroundBlurOptions}>
+        <MeetingProvider {...{logLevel: LogLevel.INFO}}>
+          <h3 data-testid='app-name'>Video Filter Test</h3>
+          <Meeting onBlurStrengthChanged={(newBlurStrength) => setBlurStrength(newBlurStrength)}/>
+        </MeetingProvider>
+      </BackgroundBlurProvider>
+    </div>
+    )
+};
+
+interface Props {
+  onBlurStrengthChanged: (blurStrength: number) => void;
+}
+
+const Meeting: React.FC<Props> = ({ onBlurStrengthChanged }) => {
+  const { isBackgroundBlurSupported, createBackgroundBlurDevice } = useBackgroundBlur();
+  const meetingManager = useMeetingManager();
+  const { selectedDevice } = useVideoInputs();
+  const { toggleVideo } = useLocalVideo();
+  const meetingStatus = useMeetingStatus();
+  const [ blurStrength, setBlurStrength ] = useState<string>("20");
+
+  useEffect(() => {
+    const addBackgroundBlur = async () => {
+      if (
+        isBackgroundBlurSupported &&
+        meetingStatus === MeetingStatus.Succeeded
+      ) {
+        console.log("Creating background blur device called");
+        const chosenVideoTransformDevice = await createBackgroundBlurDevice(selectedDevice);
+        console.log(chosenVideoTransformDevice);
+        await meetingManager.selectVideoInputDevice(chosenVideoTransformDevice);
+        toggleVideo();
+      }
+    };
+    addBackgroundBlur();
+  }, [
+    isBackgroundBlurSupported,
+    meetingStatus,
+  ]);
+
+  const updateBlurStrength = (e: ChangeEvent<HTMLSelectElement>) => {
+    e.preventDefault();
+    setBlurStrength(e.target.value);
+    console.log('Updated to blurStrength:' + e.target.value);
+    const newBlurStrength = parseInt(e.target.value);
+    onBlurStrengthChanged(newBlurStrength);
+  }
+
+  return (
+    <>
+      <MeetingInfo />
+      { meetingStatus !== MeetingStatus.Succeeded ?
+      <MeetingForm /> :
+      <>
+        <div style={{ display: 'flex', flexDirection: 'column', width: '100%', margin: 'auto' }}>
+          <ControlBar
+            layout='undocked-horizontal'
+            css='margin-bottom: 1rem;'
+            showLabels
+          >
+            <VideoInputBackgroundBlurControl />
+            <FormField
+              field={Select}
+              label="Blur Strength"
+              value={blurStrength}
+              onChange={updateBlurStrength}
+              options={[{value: '20', label: '20'}, {value: '40', label: '40'}, {value: '60', label: '60'}]}
+            />
+            <MeetingLeaveControl />
+          </ControlBar>
+          <div style={{ height: '30rem', width:'100%' }}>
+            <VideoTileGrid />
+          </div>
+        </div>
+      </>}
+    </>
+  )
+};
+


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**

<img width="1400" alt="Screen Shot 2022-02-04 at 2 08 48 PM" src="https://user-images.githubusercontent.com/54328451/152609874-9ec8d43a-d545-493e-9e64-7d53da3de9e7.png">

Adds a integration test app for video filters. No integration tests have been added.


**Testing**
1. Have you successfully run `npm run build:release` locally?
yes

2. How did you test these changes?
Ran the test demo and switched between blur strengths.

3. If you made changes to the component library, have you provided corresponding documentation changes?
N/a - integration test infra

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
