### PR TITLE
Fix PreviewVideo bug by listening to audioVideo changes to start the Preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fix a bug in `BackgroundBlurProvider` and `BackgroundReplacementProvider` where the options objects are updated and causing re-rendering and destroying previous processor.
+- Fix a bug in `PreviewVideo` where the PreviewVideo component did not start when `audioVideo` changed.
 
 ### Added
 
 - Add Amazon Chime Echo Reduction feature. Allow builders to supply the response from a `CreateMeeting` or `CreateMeetingWithAttendees` call when adding a `VoiceFocusProvider` to the component tree. This enables optional features like Amazon Chime Echo Reduction to be added to devices when turning on Amazon Voice Focus.
 - Add `videoAvailabilityDidChange` as an audio observer in `LocalVideoProvider` and a new state `hasReachedVideoLimit` to disable the video button when the video limit is reached.
 - Add `keepLastFrameWhenPaused` as an optional parameter to allow to keep the last frame of the video when a remote video is paused via the pauseVideoTile.
-
 ### Changed
 
 ### Removed

--- a/src/components/sdk/PreviewVideo/index.tsx
+++ b/src/components/sdk/PreviewVideo/index.tsx
@@ -64,7 +64,7 @@ export const PreviewVideo: React.FC<BaseSdkProps> = (props) => {
       }
     }
     startPreview();
-  }, [device]);
+  }, [audioVideo, device]);
 
   return <StyledPreview {...props} ref={videoEl} />;
 };


### PR DESCRIPTION
Fix implemented by https://github.com/aws/amazon-chime-sdk-component-library-react/pull/735 - copied to this PR.

**Issue #:** 
https://github.com/aws/amazon-chime-sdk-component-library-react/issues/708

**Description of changes:**
Fix a bug where the PreviewVideo component is not listening to changes to audioVideo - even when we join the meeting and audioVideo changes, we aren't calling startPreviewVideo. This was a regression, as we used to call startVideoPReview when the audioVideo changed. 

**Testing**
1. Have you successfully run `npm run build:release` locally?
yes

2. How did you test these changes?
Put the VideoPreview component in the Roster integ test app and joined a meeting. Should see the Video Preview component start after joining a meeting. Without this change, I dont see the preview. With this change, I do see the preview. 

3. If you made changes to the component library, have you provided corresponding documentation changes?

yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
