### PR TITLE
Add BackgroundBlurProvider unit test to verify prop changes (#745)

### DIFF
--- a/src/providers/BackgroundBlurProvider/index.tsx
+++ b/src/providers/BackgroundBlurProvider/index.tsx
@@ -98,7 +98,7 @@ const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
   async function initializeBackgroundBlur(): Promise<
     BackgroundBlurProcessor | undefined
     > {
-    console.log('Initializing background blur processor with ', spec, options);
+    console.log('Initializing background blur processor with', spec, options);
 
     try {
       const createdProcessor = await BackgroundBlurVideoFrameProcessor.create(

--- a/tst/providers/BackgroundBlurProvider/index.test.tsx
+++ b/tst/providers/BackgroundBlurProvider/index.test.tsx
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import '@testing-library/jest-dom';
+
+import React from 'react';
+import { act, renderHook } from '@testing-library/react-hooks'
+import { BackgroundBlurOptions } from 'amazon-chime-sdk-js';
+import { BackgroundBlurProvider, useBackgroundBlur } from '../../../src';
+
+describe('BackgroundBlurProvider', () => {
+  it('should not change props', async () => {
+    const blurOptions: BackgroundBlurOptions = {
+      blurStrength: 20
+    };
+
+    // Mock the user agent to ensure the BackgroundBlurVideoFrameProcessor gets
+    // created. Otherwise, the amazon-chime-sdk-js will not detect a valid
+    // browser to use.
+    const userAgentGet = jest.spyOn(navigator, 'userAgent', 'get');
+    userAgentGet.mockReturnValue('Chrome/96.0');
+
+    // Spy on the console logs to verify React lifecycle state.
+    const consoleLogMock = jest.spyOn(console, 'log').mockImplementation();
+    const consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation();
+    const consoleErrorMock = jest.spyOn(console, 'error').mockImplementation();
+
+    // Render and unmount the provider.
+    const { unmount } = renderHook(() => useBackgroundBlur(), {
+      wrapper: ({ children }) => (
+        <BackgroundBlurProvider options={blurOptions}>
+          {children}
+        </BackgroundBlurProvider>
+      ),
+    });
+    await act(async () => {
+      unmount();
+    });
+    userAgentGet.mockRestore();
+
+    // Verify the options object passed is not changed by reference.
+    expect(blurOptions).toStrictEqual({ blurStrength: 20 });
+
+    // Verify the console logs. Note that we expect the background blur
+    // processor to be cleaned up at most once during this test. This
+    // happens when the component remounts. If it is happening more than
+    // once, that means some dependency or parent is changing the parameters
+    // erroneously.
+    expect(consoleLogMock).toHaveBeenCalledTimes(2);
+    expect(consoleLogMock).toHaveBeenCalledWith("Initializing background blur processor with", undefined, blurOptions);
+    expect(consoleLogMock).toHaveBeenCalledWith("Specs or options were changed. Destroying and re-initializing background blur processor.");
+
+    // Even though we are using a NoOpVideoFrameProcessor, the input specs
+    // and options that are passed to the amazon-chime-sdk-js are still
+    // run through `resolveOptions` and `resolveSpec` in the
+    // `BackgroundBlurVideoFrameProcessor` constructor so any invalid API
+    // boundary changes to those are still validated by this test. The
+    // first warning call is output by `BackgroundBlurVideoFrameProcessor`
+    // and we don't validate it strictly because there's a non-deterministic
+    // timestamp. Verifying the call count should be good enough.
+    expect(consoleWarnMock).toHaveBeenCalledTimes(2);
+    expect(consoleWarnMock).toHaveBeenLastCalledWith("Initialized NoOpVideoFrameProcessor.");
+
+    // No errors should happen.
+    expect(consoleErrorMock).toHaveBeenCalledTimes(0);
+
+    // Restore the mocks.
+    consoleLogMock.mockRestore();
+    consoleWarnMock.mockRestore();
+    consoleErrorMock.mockRestore();
+  });
+});


### PR DESCRIPTION
**Issue #:** #745 

**Description of changes:**
We should have a test to verify that the BackgroundBlurProvider does not re-render unnecessarily in the case that its props are changed by the downstream dependency on BackgroundBlurVideoFrameProcessor in the amazon-chime-sdk-js. This is essentially a follow-up on https://github.com/aws/amazon-chime-sdk-component-library-react/commit/21ba0cfa808c6694c62fc223975fb01f47110728 to add coverage and ensure we don't run into the same problem again.

This is the same as #746 except not forked.

Note that this also adds `jest-useragent-mock` as a dev dependency for ease of testing (needed to mock user agents).

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
This pull request adds a test and verifies that it passes. Also verifies that all existing unit tests pass by running npm run test.

3. If you made changes to the component library, have you provided corresponding documentation changes?
No documentation changes needed since no changes to the component library (except a minor typo fix to the console log).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
