### PR TITLE
Update webdriver and js sdk version for integration test

### DIFF
--- a/integration/app/test-demo/package-lock.json
+++ b/integration/app/test-demo/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "amazon-chime-sdk-component-library-react": "^2.11.1",
-        "amazon-chime-sdk-js": "^2.21.1",
+        "amazon-chime-sdk-js": "^2.27.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "styled-components": "^5.3.3",
@@ -1135,9 +1135,9 @@
       }
     },
     "node_modules/amazon-chime-sdk-js": {
-      "version": "2.21.1",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.21.1.tgz",
-      "integrity": "sha512-Y8/qabhzIMMvicu/4RAYezFJzBAV0fs4yOD9fCmwdTmNIbq35/X6rpgI8AmpqRNhob1Xv7X/5+elKPYgxhiTfg==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.27.0.tgz",
+      "integrity": "sha512-uHoUGSCMlag+Sm5p2HOQ/n+xyJRl1ajhXqciFkQUMlW7Ed35hCmLMe+EUYiv+kCQAobDHQvHLj9P6rjq5Hh89A==",
       "dependencies": {
         "@types/dom-mediacapture-record": "^1.0.7",
         "@types/ua-parser-js": "^0.7.35",
@@ -6555,9 +6555,9 @@
       }
     },
     "amazon-chime-sdk-js": {
-      "version": "2.21.1",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.21.1.tgz",
-      "integrity": "sha512-Y8/qabhzIMMvicu/4RAYezFJzBAV0fs4yOD9fCmwdTmNIbq35/X6rpgI8AmpqRNhob1Xv7X/5+elKPYgxhiTfg==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.27.0.tgz",
+      "integrity": "sha512-uHoUGSCMlag+Sm5p2HOQ/n+xyJRl1ajhXqciFkQUMlW7Ed35hCmLMe+EUYiv+kCQAobDHQvHLj9P6rjq5Hh89A==",
       "requires": {
         "@types/dom-mediacapture-record": "^1.0.7",
         "@types/ua-parser-js": "^0.7.35",

--- a/integration/app/test-demo/package.json
+++ b/integration/app/test-demo/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "dependencies": {
     "amazon-chime-sdk-component-library-react": "^2.11.1",
-    "amazon-chime-sdk-js": "^2.21.1",
+    "amazon-chime-sdk-js": "^2.27.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "styled-components": "^5.3.3",

--- a/integration/package-lock.json
+++ b/integration/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "chromedriver": "^96.0.0",
+        "chromedriver": "^98.0.1",
         "fs-extra": "^10.0.0",
-        "geckodriver": "^2.0.4",
+        "geckodriver": "^3.0.1",
         "minimist": "^1.2.5",
         "mocha": "^9.2.0",
         "selenium-webdriver": "^4.1.0",
@@ -73,9 +73,9 @@
       }
     },
     "node_modules/@testim/chrome-version": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.0.7.tgz",
-      "integrity": "sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.1.2.tgz",
+      "integrity": "sha512-1c4ZOETSRpI0iBfIFUqU4KqwBAB2lHUAlBjZz/YqOHqwM9dTTzjV6Km0ZkiEiSCx/tLr1BtESIKyWWMww+RUqw=="
     },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.2",
@@ -129,9 +129,9 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
     },
     "node_modules/adm-zip": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.5.tgz",
-      "integrity": "sha512-IWwXKnCbirdbyXSfUDvCCrmYrOHANRZcc8NcRrvTlIApdl7PwE9oGcsYvNeJPAVY1M+70b4PxXGKIf8AEuiQ6w==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
+      "integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==",
       "engines": {
         "node": ">=6.0"
       }
@@ -215,11 +215,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.4"
       }
     },
     "node_modules/balanced-match": {
@@ -370,13 +370,13 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "96.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-96.0.0.tgz",
-      "integrity": "sha512-4g6Hn5RHGsbaBmOrJbDlz/hdVPOc22eRsbvoAAMqkZxR2NJCcddHzCw2FAQeW8lX/C7xWVz3nyDsKX3fE9lIIw==",
+      "version": "98.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-98.0.1.tgz",
+      "integrity": "sha512-/04KkHHE/K/lfwdPTQr5fxi1dWvM83p8T/IkYbyGK2PBlH7K49Dd71A9jrS+aWgXlZYkuHhbwiy2PA2QqZ5qQw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@testim/chrome-version": "^1.0.7",
-        "axios": "^0.21.2",
+        "@testim/chrome-version": "^1.1.2",
+        "axios": "^0.24.0",
         "del": "^6.0.0",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.0",
@@ -725,16 +725,16 @@
       }
     },
     "node_modules/geckodriver": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-2.0.4.tgz",
-      "integrity": "sha512-3Fu75v6Ov8h5Vt25+djJU56MJA2gRctgjhvG5xGzLFTQjltPz7nojQdBHbmgWznUt3CHl8VaiDn8MaepY7B0dA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-3.0.1.tgz",
+      "integrity": "sha512-cHmbNFqt4eelymsuVt7B5nh+qYGpPCltM7rd+k+CBaTvxGGr4j6STeOYahXMNdSeUbCVhqP345OuqWnvHYAz4Q==",
       "hasInstallScript": true,
       "dependencies": {
-        "adm-zip": "0.5.5",
+        "adm-zip": "0.5.9",
         "bluebird": "3.7.2",
         "got": "11.8.2",
         "https-proxy-agent": "5.0.0",
-        "tar": "6.1.9"
+        "tar": "6.1.11"
       },
       "bin": {
         "geckodriver": "bin/geckodriver"
@@ -1650,9 +1650,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.9",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.9.tgz",
-      "integrity": "sha512-XjLaMNl76o07zqZC/aW4lwegdY07baOH1T8w3AEfrHAdyg/oYO4ctjzEBq9Gy9fEP9oHqLIgvx6zuGDGe+bc8Q==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -1904,9 +1904,9 @@
       }
     },
     "@testim/chrome-version": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.0.7.tgz",
-      "integrity": "sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.1.2.tgz",
+      "integrity": "sha512-1c4ZOETSRpI0iBfIFUqU4KqwBAB2lHUAlBjZz/YqOHqwM9dTTzjV6Km0ZkiEiSCx/tLr1BtESIKyWWMww+RUqw=="
     },
     "@types/cacheable-request": {
       "version": "6.0.2",
@@ -1960,9 +1960,9 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
     },
     "adm-zip": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.5.tgz",
-      "integrity": "sha512-IWwXKnCbirdbyXSfUDvCCrmYrOHANRZcc8NcRrvTlIApdl7PwE9oGcsYvNeJPAVY1M+70b4PxXGKIf8AEuiQ6w=="
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
+      "integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg=="
     },
     "agent-base": {
       "version": "6.0.2",
@@ -2019,11 +2019,11 @@
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.4"
       }
     },
     "balanced-match": {
@@ -2132,12 +2132,12 @@
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
     },
     "chromedriver": {
-      "version": "96.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-96.0.0.tgz",
-      "integrity": "sha512-4g6Hn5RHGsbaBmOrJbDlz/hdVPOc22eRsbvoAAMqkZxR2NJCcddHzCw2FAQeW8lX/C7xWVz3nyDsKX3fE9lIIw==",
+      "version": "98.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-98.0.1.tgz",
+      "integrity": "sha512-/04KkHHE/K/lfwdPTQr5fxi1dWvM83p8T/IkYbyGK2PBlH7K49Dd71A9jrS+aWgXlZYkuHhbwiy2PA2QqZ5qQw==",
       "requires": {
-        "@testim/chrome-version": "^1.0.7",
-        "axios": "^0.21.2",
+        "@testim/chrome-version": "^1.1.2",
+        "axios": "^0.24.0",
         "del": "^6.0.0",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.0",
@@ -2376,15 +2376,15 @@
       "optional": true
     },
     "geckodriver": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-2.0.4.tgz",
-      "integrity": "sha512-3Fu75v6Ov8h5Vt25+djJU56MJA2gRctgjhvG5xGzLFTQjltPz7nojQdBHbmgWznUt3CHl8VaiDn8MaepY7B0dA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-3.0.1.tgz",
+      "integrity": "sha512-cHmbNFqt4eelymsuVt7B5nh+qYGpPCltM7rd+k+CBaTvxGGr4j6STeOYahXMNdSeUbCVhqP345OuqWnvHYAz4Q==",
       "requires": {
-        "adm-zip": "0.5.5",
+        "adm-zip": "0.5.9",
         "bluebird": "3.7.2",
         "got": "11.8.2",
         "https-proxy-agent": "5.0.0",
-        "tar": "6.1.9"
+        "tar": "6.1.11"
       }
     },
     "get-caller-file": {
@@ -3026,9 +3026,9 @@
       }
     },
     "tar": {
-      "version": "6.1.9",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.9.tgz",
-      "integrity": "sha512-XjLaMNl76o07zqZC/aW4lwegdY07baOH1T8w3AEfrHAdyg/oYO4ctjzEBq9Gy9fEP9oHqLIgvx6zuGDGe+bc8Q==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",

--- a/integration/package.json
+++ b/integration/package.json
@@ -8,9 +8,9 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "chromedriver": "^96.0.0",
+    "chromedriver": "^98.0.1",
     "fs-extra": "^10.0.0",
-    "geckodriver": "^2.0.4",
+    "geckodriver": "^3.0.1",
     "minimist": "^1.2.5",
     "mocha": "^9.2.0",
     "selenium-webdriver": "^4.1.0",


### PR DESCRIPTION
**Issue #:** 
Dependencies of integration testing framework is kinda out of date.

**Description of changes:**
* update `chromedriver` to `98.0.1`
* update `geckodriver` to `3.0.1`
* update `amazon-chime-sdk-js` to `2.27.0`

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Run the test demo manually and confirm it works fine.

3. If you made changes to the component library, have you provided corresponding documentation changes?
N/A
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
