### PR TITLE
Bump the version of react component library in integration test demo

### DIFF
--- a/integration/app/test-demo/package-lock.json
+++ b/integration/app/test-demo/package-lock.json
@@ -8,7 +8,7 @@
       "name": "test-demo",
       "version": "0.1.0",
       "dependencies": {
-        "amazon-chime-sdk-component-library-react": "^2.11.1",
+        "amazon-chime-sdk-component-library-react": "^2.15.0",
         "amazon-chime-sdk-js": "^2.27.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -31,6 +31,101 @@
         "webpack": "^5.64.1",
         "webpack-cli": "^4.9.1",
         "webpack-dev-server": "^4.5.0"
+      }
+    },
+    "../../..": {
+      "version": "2.15.0",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@popperjs/core": "^2.2.2",
+        "fast-memoize": "^2.5.2",
+        "lodash.isequal": "^4.5.0",
+        "react-popper": "^2.2.4",
+        "throttle-debounce": "^2.3.0",
+        "uuid": "^8.0.0"
+      },
+      "devDependencies": {
+        "@rollup/plugin-commonjs": "^13.0.0",
+        "@rollup/plugin-node-resolve": "^8.0.1",
+        "@storybook/addon-a11y": "^6.4.18",
+        "@storybook/addon-docs": "^6.4.18",
+        "@storybook/addon-knobs": "^6.4.0",
+        "@storybook/addon-storysource": "^6.4.18",
+        "@storybook/addon-viewport": "^6.4.18",
+        "@storybook/addons": "^6.4.18",
+        "@storybook/react": "^6.4.18",
+        "@storybook/storybook-deployer": "^2.8.10",
+        "@storybook/theming": "^6.4.18",
+        "@testing-library/jest-dom": "^5.11.9",
+        "@testing-library/react": "^11.2.5",
+        "@testing-library/react-hooks": "^7.0.2",
+        "@testing-library/user-event": "^12.8.0",
+        "@types/classnames": "^2.3.1",
+        "@types/jest": "^25.2.1",
+        "@types/lodash.isequal": "^4.5.5",
+        "@types/puppeteer": "^5.4.3",
+        "@types/react": "^17.0.1",
+        "@types/react-dom": "^17.0.1",
+        "@types/react-test-renderer": "^17.0.1",
+        "@types/resize-observer-browser": "^0.1.3",
+        "@types/styled-components": "^5.1.0",
+        "@types/styled-system": "^5.1.9",
+        "@types/testing-library__react": "^10.0.1",
+        "@types/throttle-debounce": "^2.1.0",
+        "@types/uuid": "^7.0.3",
+        "@typescript-eslint/eslint-plugin": "^4.33.0",
+        "@typescript-eslint/parser": "^4.33.0",
+        "add": "^2.0.6",
+        "amazon-chime-sdk-js": "^2.26.0",
+        "babel-loader": "^8.1.0",
+        "css-loader": "^2.1.1",
+        "eslint": "^7.32.0",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-prettier": "^4.0.0",
+        "eslint-plugin-react": "^7.26.1",
+        "eslint-plugin-simple-import-sort": "^7.0.0",
+        "jest": "^26.6.3",
+        "jest-image-snapshot": "^4.4.0",
+        "jest-puppeteer-docker": "^1.4.2",
+        "mini-css-extract-plugin": "^0.7.0",
+        "postcss-loader": "^3.0.0",
+        "postcss-preset-env": "^6.6.0",
+        "prettier": "^2.4.1",
+        "prompt-sync": "^4.2.0",
+        "puppeteer": "^2.1.1",
+        "react": "^17.0.1",
+        "react-docgen-typescript-loader": "^3.7.2",
+        "react-dom": "^17.0.1",
+        "react-is": "^17.0.0",
+        "resize-observer-polyfill": "^1.5.1",
+        "rimraf": "^2.6.3",
+        "rollup": "^2.26.3",
+        "rollup-plugin-peer-deps-external": "^2.2.2",
+        "rollup-plugin-typescript2": "^0.27.1",
+        "start-server-and-test": "^1.14.0",
+        "storybook": "^6.4.18",
+        "style-loader": "^0.23.1",
+        "styled-components": "^5.1.0",
+        "styled-system": "^5.1.5",
+        "themeprovider-storybook": "^1.8.0",
+        "ts-jest": "^26.5.2",
+        "ts-loader": "^6.0.2",
+        "typescript": "^4.2.1",
+        "url-loader": "^2.0.0",
+        "webpack": "^4.33.0",
+        "webpack-cli": "^3.3.2"
+      },
+      "engines": {
+        "node": "^12 || ^14 || ^15 || ^16",
+        "npm": "^6 || ^7 || ^8"
+      },
+      "peerDependencies": {
+        "amazon-chime-sdk-js": "^2.26.0",
+        "react": "^17.0.1",
+        "react-dom": "^17.0.1",
+        "styled-components": "^5.0.0",
+        "styled-system": "^5.1.5"
       }
     },
     "node_modules/@babel/generator": {
@@ -372,9 +467,9 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
-      "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
+      "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -1111,9 +1206,9 @@
       }
     },
     "node_modules/amazon-chime-sdk-component-library-react": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-component-library-react/-/amazon-chime-sdk-component-library-react-2.11.1.tgz",
-      "integrity": "sha512-Fa6QTZIM8/XGkGYNUka/S9YwBCcgtuu71eRR0h61+S1u3xOZa7ohOw0OJO/Vp6jIIlLUa76ES2uKPr9qbK+SvA==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-component-library-react/-/amazon-chime-sdk-component-library-react-2.15.0.tgz",
+      "integrity": "sha512-l8korQta0eYVktnNlaILyMm2Slh/TvTvqLaDj6mBhn9dzOUUeZFXkUiCiy1lk30DgrMSwuh/vlAEFWDsm5NJFw==",
       "dependencies": {
         "@popperjs/core": "^2.2.2",
         "fast-memoize": "^2.5.2",
@@ -1127,7 +1222,7 @@
         "npm": "^6 || ^7 || ^8"
       },
       "peerDependencies": {
-        "amazon-chime-sdk-js": "^2.20.0",
+        "amazon-chime-sdk-js": "^2.26.0",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "styled-components": "^5.0.0",
@@ -5850,9 +5945,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
-      "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ=="
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
+      "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -6542,9 +6637,9 @@
       "requires": {}
     },
     "amazon-chime-sdk-component-library-react": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-component-library-react/-/amazon-chime-sdk-component-library-react-2.11.1.tgz",
-      "integrity": "sha512-Fa6QTZIM8/XGkGYNUka/S9YwBCcgtuu71eRR0h61+S1u3xOZa7ohOw0OJO/Vp6jIIlLUa76ES2uKPr9qbK+SvA==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-component-library-react/-/amazon-chime-sdk-component-library-react-2.15.0.tgz",
+      "integrity": "sha512-l8korQta0eYVktnNlaILyMm2Slh/TvTvqLaDj6mBhn9dzOUUeZFXkUiCiy1lk30DgrMSwuh/vlAEFWDsm5NJFw==",
       "requires": {
         "@popperjs/core": "^2.2.2",
         "fast-memoize": "^2.5.2",

--- a/integration/app/test-demo/package.json
+++ b/integration/app/test-demo/package.json
@@ -2,7 +2,7 @@
   "name": "test-demo",
   "version": "0.1.0",
   "dependencies": {
-    "amazon-chime-sdk-component-library-react": "^2.11.1",
+    "amazon-chime-sdk-component-library-react": "^2.15.0",
     "amazon-chime-sdk-js": "^2.27.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Update the version for `amazon-chime-sdk-component-library-react" from 2.11.1 to 2.15.0 in test demo.

**Testing**
1. Have you successfully run `npm run build:release` locally?
N/A

2. How did you test these changes?
Yes, confirm the test demo works fine.

3. If you made changes to the component library, have you provided corresponding documentation changes?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
