### PR TITLE
[V3] Add a new param meetingSessionConfiguration to meetingManager.join method

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -45,6 +45,7 @@
     "no-trailing-spaces": "error",
     "brace-style": "error",
     "spaced-comment": ["error", "always"],
+    "eol-last": ["error", "always"],
 
     // React
     "react/prop-types": "off",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add styling guide documentation for customizing SDK and UI component CSS.
 - Extend and enabled style customizing capabilities on the SDK components.
+- Add `MeetingSessionConfiguration` as a required parameter to `MeetingManager.join()` method. With this change the builders have direct access to `MeetingSessionConfiguration`, this will allow more flexibility to customize the `MeetingSession`.
+- Add `MeetingManagerJoinOptions` as a new interface for the `options` parameter of the `MeetingManager.join` method.
+- Add `deviceLabels`, `eventController`, `logLevel`, `postLoggerConfig`, `logger`, `enableWebAudio`, and `activeSpeakerPolicy` to `MeetingManagerJoinOptions` interface. 
 
 ### Changed
 
@@ -31,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove all deprecated `MeetingSessionStatusCode`.  
 - Remove legacy metrics `videoDownstreamGoogFrameHeight`, `videoDownstreamGoogFrameWidth`, `videoUpstreamGoogFrameHeight` and `videoUpstreamGoogFrameWidth` from the `videoStreamMetrics` returned by the `useMediaStreamMetrics` hook to adopt to Amazon Chime SDK for JavaScript V3 changes ([aws/amazon-chime-sdk-js#2086](https://github.com/aws/amazon-chime-sdk-js/pull/2086)).
 - Deprecate `useBandwidthMetrics` hook as we already have `useMediaStreamMetrics`.
+- Remove `MeetingSessionConfiguration` properties from `MeetingProvider` props.
+- Remove `deviceLabels`, `eventController`, `logLevel`, `postLogConfig`, `logger`, `enableWebAudio`, and `activeSpeakerPolicy` from `MeetingProvider` props.
 
 ## [2.15.0] - 2022-02-03
 

--- a/integration/app/test-demo/src/containers/MeetingForm.tsx
+++ b/integration/app/test-demo/src/containers/MeetingForm.tsx
@@ -10,6 +10,7 @@ import {
   useMeetingManager,
 } from 'amazon-chime-sdk-component-library-react';
 import { createGetAttendeeCallback, fetchMeeting } from '../utils/api';
+import { MeetingSessionConfiguration } from 'amazon-chime-sdk-js';
 
 const MeetingForm: React.FC = () => {
   const meetingManager = useMeetingManager();
@@ -23,10 +24,9 @@ const MeetingForm: React.FC = () => {
 
     try {
       const { JoinInfo } = await fetchMeeting(meetingId, name, 'us-east-1');
-      await meetingManager.join({
-        meetingInfo: JoinInfo.Meeting,
-        attendeeInfo: JoinInfo.Attendee,
-      });
+      await meetingManager.join(
+        new MeetingSessionConfiguration(JoinInfo.Meeting, JoinInfo.Attendee),
+      );
     } catch (error: any) {
       updateErrorMessage(error.message);
     }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  testRegex: './*\\.test\\.tsx$',
+  testRegex: './*\\.test\\.tsx?$',
   setupFilesAfterEnv: ['./tst/setupTests.js'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'json', 'jsx', 'node'],
   transform: {

--- a/src/components/introduction.stories.mdx
+++ b/src/components/introduction.stories.mdx
@@ -49,16 +49,29 @@ const Root = () => (
   </ThemeProvider>
 );
 ```
-
 3. Join a meeting
 
-To join a meeting, you need to fetch the meeting and attendee data from Chime's [CreateAttendee](https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateAttendee.html) and [CreateMeeting](https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateMeeting.html) APIs. 
+To join a meeting, you need to do the following sub steps:
+
+* Fetch the meeting and attendee data from Chime
+
+* Intialize `MeetingSessionConfiguration`
+
+* Create and join the meeting
+
+First, you need to fetch the meeting and attendee data from Chime's [CreateAttendee](https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateAttendee.html) and [CreateMeeting](https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateMeeting.html) APIs. 
 
 * Check the [Getting responses from your server application](https://github.com/aws/amazon-chime-sdk-js#getting-responses-from-your-server-application) for details.
 * Check the [MeetingForm component](https://github.com/aws-samples/amazon-chime-sdk/blob/main/apps/meeting/src/containers/MeetingForm/index.tsx), the [API calls](https://github.com/aws-samples/amazon-chime-sdk/blob/main/apps/meeting/src/utils/api.ts), and [server application](https://github.com/aws-samples/amazon-chime-sdk/blob/main/apps/meeting/server.js) in our [React meeting demo](https://github.com/aws-samples/amazon-chime-sdk/tree/main/apps/meeting) as examples.
 
+Then, intialize `MeetingSessionConfiguration` with the meeting and attendee data from the last step. You can choose to modify the `MeetingSessionConfiguration` properties to customize the meeting to your preference.
+
+Updating the `MeetingSessionConfiguration` props is an optional step. You can learn more about the available props here: [MeetingSessionConfiguration](https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html)
+
+Lastly, pass the `MeetingSessionConfiguration` to the `join` method to create a meeting session. You can now start the meeting session and join the meeting. 
 ```jsx
 import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+import { MeetingSessionConfiguration } from 'amazon-chime-sdk-js';
 
 const MyApp = () => {
   const meetingManager = useMeetingManager();
@@ -68,13 +81,11 @@ const MyApp = () => {
     const response = await fetch('/my-server');
     const data = await response.json();
 
-    const joinData = {
-      meetingInfo: data.Meeting,
-      attendeeInfo: data.Attendee,
-    };
+    // Initalize the `MeetingSessionConfiguration`
+    const meetingSessionConfiguration = new MeetingSessionConfiguration(data.Meeting, data.Attendee);
 
-    // Create a `MeetingSession` using `join()` function with the above data
-    await meetingManager.join(joinData);
+    // Create a `MeetingSession` using `join()` function with the `MeetingSessionConfiguration`
+    await meetingManager.join(meetingSessionConfiguration);
 
     // At this point you could let users setup their devices, or by default 
     // the SDK will select the first device in the list for the kind indicated

--- a/src/components/migrationToV3.stories.mdx
+++ b/src/components/migrationToV3.stories.mdx
@@ -6,7 +6,7 @@ Version 3 of the Amazon Chime React Component Library makes small changes to the
 
 ### IMPORTANT - Version 3 of the library also requires a dependency to version 3.0.0 or higher of the amazon-chime-sdk-js.
 
-In many cases you will need to adjust your application code because interface parameters to root providers like Meeting Provider are updated.
+In many cases, you will need to adjust your application code because interface parameters to root providers like `MeetingProvider` are updated.
 
 ## Installation
 
@@ -24,6 +24,11 @@ npm install --save amazon-chime-sdk-component-library-react@beta amazon-chime-sd
 - Remove legacy metrics `videoDownstreamGoogFrameHeight`, `videoDownstreamGoogFrameWidth`, `videoUpstreamGoogFrameHeight` and `videoUpstreamGoogFrameWidth` from the `videoStreamMetrics` returned by the `useMediaStreamMetrics` hook to adopt to Amazon Chime SDK for JavaScript V3 changes ([aws/amazon-chime-sdk-js#2086](https://github.com/aws/amazon-chime-sdk-js/pull/2086)).
 - Update the `compilerOptions.target` in `tsconfig.json` from `es5` to `ES2015 (ES6)`.
 - Rename the `global` property of `DefaultTheme` Interface to `globalStyle` to avoid conflict with reserved keyword `global`.
+- Add `MeetingSessionConfiguration` as a required parameter to `MeetingManager.join()` method. With this change the builders have direct access to `MeetingSessionConfiguration`, this will allow more flexibility to customize the `MeetingSession`.
+- Add `MeetingManagerJoinOptions` as a new interface for the `options` parameter of the `MeetingManager.join` method.
+- Add `deviceLabels`, `eventController`, `logLevel`, `postLoggerConfig`, `logger`, `enableWebAudio`, and `activeSpeakerPolicy` to `MeetingManagerJoinOptions` interface. 
+- Remove `MeetingSessionConfiguration` properties from `MeetingProvider` props.
+- Remove `deviceLabels`, `eventController`, `logLevel`, `postLogConfig`, `logger`, `enableWebAudio`, and `activeSpeakerPolicy` from `MeetingProvider` props.
 
 ### Updating `EventReporter` to `EventController`
 
@@ -38,7 +43,7 @@ const MyApp = () => {
     const joinData = {
       meetingInfo: data.Meeting,
       attendeeInfo: data.Attendee,
-      eventReporter: new NoOpEventReporter()
+      eventReporter: new NoOpEventReporter(),
     };
     try {
       await meetingManager.join(joinData);
@@ -63,17 +68,19 @@ const MyApp = () => {
     const data = await response.json();
     const meetingSessionConfiguration = new MeetingSessionConfiguration(data.Meeting, data.Attendee);
     const eventController = new DefaultEventController(
-        meetingSessionConfiguration, 
-        meetingManager.createLogger(meetingSessionConfiguration), 
-        new NoOpEventReporter()
-      );
-    const joinData = {
-      meetingSessionConfiguration: meetingSessionConfiguration,
-      eventController: eventController
+      meetingSessionConfiguration, 
+      new ConsoleLogger('SDK', LogLevel.WARN), 
+      new NoOpEventReporter()
+    );
+    const options = {
+      eventController
     };
 
     try {
-      await meetingManager.join(joinData);
+      await meetingManager.join(
+        meetingSessionConfiguration,
+        options
+      );
     } catch {
       console.error('Something went wrong');
     }
@@ -81,6 +88,275 @@ const MyApp = () => {
   
   return (
     <button onClick={joinMeeting}>Join Meeting</button>;
+  );
+};
+```
+
+### `MeetingProvider` props change
+
+`MeetingProvider` no longer takes the following props:
+- `MeetingSessionConfiguration` properties:
+  - `VideoDownlinkBandwidthPolicy`
+  - `VideoUplinkBandwidthPolicy`
+  - `simulcastEnabled`
+  - `reconnectTimeoutMs`
+  - `keepLastFrameWhenPaused`
+- Other props:
+  - `deviceLabels`
+  - `eventController`
+  - `logLevel`
+  - `postLogConfig`
+  - `logger`
+  - `enableWebAudio`
+  - `activeSpeakerPolicy`
+
+These props can rather be updated by passing the `MeetingSessionConfiguration` object or by passing `options` props to `meetingManager.join()` method. 
+
+You can learn more about the `meetingManager.join()` method here: [MeetingManager](/docs/sdk-providers-meetingmanager--page).
+
+#### Examples
+
+##### VideoDownlinkBandwidthPolicy
+
+The following example uses `VideoDownlinkBandwidthPolicy` property as an example to showcase the change.
+
+Before in 2.x:
+
+```jsx
+import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+
+const App = () => {
+  // MyVideoDownlinkBandwidthPolicy is a custom class implementing VideoDownlinkBandwidthPolicy interface from amazon-chime-sdk-js.
+  const videoDownlinkBandwidthPolicy = new MyVideoDownlinkBandwidthPolicy();
+  const meetingConfig = {
+    videoDownlinkBandwidthPolicy,
+  };
+
+  return (
+    <MeetingProvider {...meetingConfig}>
+      <MyApp />
+    </MeetingProvider>
+  );
+};
+
+const MyApp = () => {
+  const meetingManager = useMeetingManager();
+  await meetingManger.join({
+    data.Meeting,
+    data.Attendee
+  });
+
+  return (
+    <div>
+      ...
+    </div>
+  );
+};
+```
+
+After in 3.x:
+
+```jsx
+import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+import { MeetingSessionConfiguration } from 'amazon-chime-sdk-js';
+
+const App = () => {
+  return(
+    <MeetingProvider>
+      <MyApp />
+    </MeetingProvider>
+  );
+};
+
+const MyApp = () => {
+  // MyVideoDownlinkBandwidthPolicy is a custom class implementing VideoDownlinkBandwidthPolicy interface from amazon-chime-sdk-js.
+  const videoDownlinkBandwidthPolicy = new MyVideoDownlinkBandwidthPolicy();
+
+  const meetingSessionConfiguration = new MeetingSessionConfiguration(data.Meeting, data.Attendee);
+  meetingSessionConfiguration.videoDownlinkBandwidthPolicy = videoDownlinkBandwidthPolicy;
+
+  const meetingManager = useMeetingManager();
+  await meetingManager.join(
+    meetingSessionConfiguration
+  );
+
+  return (
+    <div>
+      ...
+    </div>
+  );
+};
+```
+
+##### simulcastEnabled
+
+One thing to note is that the `MeetingProvider` props might not have the same mapping with `MeetingSessionConfiguration` properties.
+For example, `simulcastEnabled` in `MeetingProvider` and the property in `MeetingSessionConfiguration` is different. The following code example should help remove any confusion.
+
+Before in 2.x:
+
+```jsx
+import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+
+const App = () => {
+  const meetingConfig = {
+    simulcastEnabled: false,
+  };
+
+  return(
+    <MeetingProvider {...meetingConfig}>
+      <MyApp />
+    </MeetingProvider>
+  );
+};
+
+const MyApp = () => {
+  const meetingManager = useMeetingManager();
+  await meetingManger.join({
+    data.Meeting,
+    data.Attendee
+  });
+
+  return (
+    <div>
+      ...
+    </div>
+  );
+};
+```
+
+After in 3.x:
+
+```jsx
+import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+import { MeetingSessionConfiguration } from 'amazon-chime-sdk-js';
+
+const App = () => {
+  return(
+    <MeetingProvider>
+      <MyApp />
+    </MeetingProvider>
+  );
+};
+
+const MyApp = () => {
+  const meetingSessionConfiguration = new MeetingSessionConfiguration(data.Meeting, data.Attendee);
+  meetingSessionConfiguration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = false;
+
+  const meetingManager = useMeetingManager();
+  await meetingManager.join(
+    meetingSessionConfiguration
+  );
+
+  return (
+    <div>
+      ...
+    </div>
+  );
+};
+```
+
+##### enableWebAudio
+
+The following example uses `enableWebAudio` property as an example to showcase the change. `enableWebAudio` is chosen here because it is one of the properties that is affected and it is not part of `MeetingSessionConfiguration`. 
+
+Before in 2.x:
+
+```jsx
+import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+
+const App = () => {
+  const meetingConfig = {
+    enableWebAudio: true,
+  };
+
+  return(
+    <MeetingProvider {...meetingConfig}>
+      <MyApp />
+    </MeetingProvider>
+  );
+};
+
+const MyApp = () => {
+  const meetingManager = useMeetingManager();
+  await meetingManger.join({
+    data.Meeting,
+    data.Attendee
+  });
+
+  return (
+    <div>
+      ...
+    </div>
+  );
+};
+```
+
+After in 3.x:
+
+```jsx
+import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+import { MeetingSessionConfiguration } from 'amazon-chime-sdk-js';
+
+const App = () => {
+  return(
+    <MeetingProvider>
+      <MyApp />
+    </MeetingProvider>
+  );
+};
+
+const MyApp = () => {
+  const meetingSessionConfiguration = new MeetingSessionConfiguration(data.Meeting, data.Attendee);
+  const options = {
+    enableWebAudio: true,
+  };
+
+  const meetingManager = useMeetingManager();
+  await meetingManager.join(
+    meetingSessionConfiguration,
+    options
+  );
+
+  return (
+    <div>
+      ...
+    </div>
+  );
+};
+```
+
+### `MeetingManager` `join` method parameter change
+
+In V3, `MeetingManager`'s `join` method takes `MeetingSessionConfiguraiton` and `options` as parameter.
+`meetingInfo` and `attendeeInfo` parameters are removed from the interface and are rather passed to the constructor of `MeetingSessionConfiguration`.
+
+Before in 2.x:
+
+```jsx
+import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+
+const MyApp = () => {
+  const meetingManager = useMeetingManager();
+  await meetingManager.join({
+    data.Meeting,
+    data.Attendee
+  });
+};
+```
+
+After in 3.x:
+
+```jsx
+import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+import { MeetingSessionConfiguration } from 'amazon-chime-sdk-js';
+
+const MyApp = () => {
+  const meetingSessionConfiguration = new MeetingSessionConfiguration(data.Meeting, data.Attendee);
+  
+  const meetingManager = useMeetingManager();
+  await meetingManager.join(
+    meetingSessionConfiguration
   );
 };
 ```

--- a/src/components/quickStarts.stories.mdx
+++ b/src/components/quickStarts.stories.mdx
@@ -19,6 +19,7 @@ For example, a simple App to join the meeting in view-only mode.
 
 ```jsx
 import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+import { MeetingSessionConfiguration } from 'amazon-chime-sdk-js';
 
 const MyApp = () => {
   const meetingManager = useMeetingManager();
@@ -28,15 +29,16 @@ const MyApp = () => {
     const response = await fetch('/my-server');
     const data = await response.json();
 
-    const joinData = {
-      meetingInfo: data.Meeting,
-      attendeeInfo: data.Attendee,
-      // SDK doesn't choose any device
+    const meetingSessionConfiguration = new MeetingSessionConfiguration(data.Meeting, data.Attendee);
+    const options = {
       deviceLabels: DeviceLabels.None,
-    };
+    }
 
     // Use the join API to create a meeting session using the above data
-    await meetingManager.join(joinData);
+    await meetingManager.join(
+      meetingSessionConfiguration,
+      options
+    );
 
     // Skip devices setup
 
@@ -91,6 +93,7 @@ For example, a simple App to join a meeting that only requires camera using pres
 
 ```jsx
 import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+import { MeetingSessionConfiguration } from 'amazon-chime-sdk-js';
 
 const MyApp = () => {
   const meetingManager = useMeetingManager();
@@ -100,15 +103,16 @@ const MyApp = () => {
     const response = await fetch('/my-server');
     const data = await response.json();
 
-    const joinData = {
-      meetingInfo: data.Meeting,
-      attendeeInfo: data.Attendee,
-      // Use preset options from `DeviceLabels` enum
+    const meetingSessionConfiguration = new MeetingSessionConfiguration(data.Meeting, data.Attendee);
+    const options = {
       deviceLabels: DeviceLabels.Video,
     };
 
-    // Use the join API to create a meeting session using the above data
-    await meetingManager.join(joinData);
+    // Use the join API to create a meeting session using DeviceLabels.Video
+    await meetingManager.join(
+      meetingSessionConfiguration,
+      options
+    );
 
     // At this point you can let users setup their camera device
     // Or by default the SDK selects the first device in the list for the kind indicated by `deviceLabels`
@@ -142,6 +146,7 @@ For example, a simple App to join a meeting that only requires camera permission
 
 ```jsx
 import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+import { MeetingSessionConfiguration } from 'amazon-chime-sdk-js';
 
 const MyApp = () => {
   const meetingManager = useMeetingManager();
@@ -151,22 +156,25 @@ const MyApp = () => {
     const response = await fetch('/my-server');
     const data = await response.json();
 
-    const joinData = {
-      meetingInfo: data.Meeting,
-      attendeeInfo: data.Attendee,
-      // Customize your own `DeviceLabelTrigger`
-      deviceLabels: async () => {
-          // Do something
-          const stream = await navigator.mediaDevices.getUserMedia({
-            video: true,
-          });
-          // Do something
-          return stream;
-        },
+    const meetingSessionConfiguration = new MeetingSessionConfiguration(data.Meeting, data.Attendee);
+    // Customize your own `DeviceLabelTrigger`
+    const deviceLabels = async () => {
+      // Do something
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: true,
+      });
+      // Do something
+      return stream;
+    };
+    const options = {
+      deviceLabels,
     };
 
-    // Use the join API to create a meeting session using the above data
-    await meetingManager.join(joinData);
+    // Use the join API to create a meeting session using the `MeetingSessionConfiguration` and custom device label trigger
+    await meetingManager.join(
+      meetingSessionConfiguration,
+      options
+    );
 
     // At this point you can let users setup their camera
     ...
@@ -201,6 +209,7 @@ For example, join a meeting that doesn't require any device permission, and obta
 
 ```jsx
 import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+import { MeetingSessionConfiguration } from 'amazon-chime-sdk-js';
 
 const MyApp = () => {
   const meetingManager = useMeetingManager();
@@ -210,15 +219,17 @@ const MyApp = () => {
     const response = await fetch('/my-server');
     const data = await response.json();
 
-    const joinData = {
-      meetingInfo: data.Meeting,
-      attendeeInfo: data.Attendee,
-      // Join a meeting without triggering any device permission prompt
+    const meetingSessionConfiguration = new MeetingSessionConfiguration(data.Meeting, data.Attendee);
+    const options = {
       deviceLabels: DeviceLabels.None,
     };
 
-    // Use join API to create a MeetingSession using the above data
-    await meetingManager.join(joinData);
+    // Use join API to create a MeetingSession using the `MeetingSessionConfiguration` and device labels as None
+    // DeviceLabels.None will join a meeting without triggering any device permission prompt
+    await meetingManager.join(
+      meetingSessionConfiguration,
+      options
+    );
 
     // Skip devices setup
 
@@ -343,7 +354,7 @@ For example, to enable camera and display the video stream, in addition to using
 import {
   useLocalVideo,
   useMeetingManager,
-  VideoTileGrid
+  VideoTileGrid,
 } from 'amazon-chime-sdk-component-library-react';
 
 const MeetingView = () => {
@@ -447,11 +458,11 @@ const MyApp = () => {
       const user = await response.json();
 
       return {
-        name: user.name
+        name: user.name,
       }
     }
   }, [])
-}
+};
 ```
 
 ## How to Enable a Meeting to Post Logs to a URL?
@@ -501,7 +512,7 @@ import React from 'react';
 import { NoOpEventReporter, DefaultEventController, MeetingSessionConfiguration } from 'amazon-chime-sdk-js';
 import {
   MeetingProvider,
-  useMeetingManager
+  useMeetingManager,
 } from 'amazon-chime-sdk-component-library-react';
 
 const MyApp = () => {
@@ -511,17 +522,19 @@ const MyApp = () => {
     const data = await response.json();
     const meetingSessionConfiguration = new MeetingSessionConfiguration(data.Meeting, data.Attendee);
     const eventController = new DefaultEventController(
-        meetingSessionConfiguration, 
-        meetingManager.createLogger(meetingSessionConfiguration), 
-        new NoOpEventReporter()
-      );
-    const joinData = {
-      meetingSessionConfiguration: meetingSessionConfiguration,
-      eventController: eventController
+      meetingSessionConfiguration, 
+      new ConsoleLogger('SDK', LogLevel.INFO), 
+      new NoOpEventReporter()
+    );
+    const options = {
+      eventController,
     };
 
     try {
-      await meetingManager.join(joinData);
+      await meetingManager.join(
+        meetingSessionConfiguration,
+        options
+      );
     } catch {
       console.error('Something went wrong');
     }

--- a/src/components/sdk/introduction.stories.mdx
+++ b/src/components/sdk/introduction.stories.mdx
@@ -42,6 +42,7 @@ import {
   VideoTileGrid,
   useMeetingManager
 } from 'amazon-chime-sdk-component-library-react';
+import { MeetingSessionConfiguration } from 'amazon-chime-sdk-js';
 
 const MyApp = () => {
   const meetingManager = useMeetingManager();
@@ -51,13 +52,13 @@ const MyApp = () => {
     const response = await fetch('/my-server');
     const data = await response.json();
 
-    const joinData = {
-      meetingInfo: data.Meeting,
-      attendeeInfo: data.Attendee
-    };
+    // Initalize the `MeetingSessionConfiguration`
+    const meetingSessionConfiguration = new MeetingSessionConfiguration(data.Meeting, data.Attendee);
 
-    // Use the join API to create a meeting session using the above data
-    await meetingManager.join(joinData);
+    // Use the join API to create a meeting session using the MeetingSessionConfiguration
+    await meetingManager.join(
+      meetingSessionConfiguration
+    );
 
     // At this point you could let users setup their devices, or by default 
     // the SDK will select the first device in the list for the s indicated

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,7 +196,6 @@ export { MeetingManager } from './providers/MeetingProvider/MeetingManager';
 
 // Interface
 export { NotificationType, Action } from './providers/NotificationProvider';
-export { MeetingManagerConfig } from './providers/MeetingProvider/types';
 
 // Utilities
 export { Versioning } from './versioning/Versioning';

--- a/src/providers/BackgroundBlurProvider/index.tsx
+++ b/src/providers/BackgroundBlurProvider/index.tsx
@@ -97,7 +97,7 @@ const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
 
   async function initializeBackgroundBlur(): Promise<
     BackgroundBlurProcessor | undefined
-    > {
+  > {
     console.log('Initializing background blur processor with', spec, options);
 
     try {

--- a/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
+++ b/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
@@ -8,64 +8,57 @@ You can pass in the same `MeetingManager` instance to multiple different `Meetin
 the `MeetingProvider`. This is to support very specific cases where you may have different React trees within you applications. For example, you are migrating
 from an Angular application to a React application.
 
-
 You can access the `MeetingManager` instance with the `useMeetingManager` hook.
-
-## Usage
-
-`MeetingProvider` must be rendered somewhere higher in the tree.
-
-```jsx
-import React from 'react';
-import { MeetingProvider, useMeetingManager } from 'amazon-chime-sdk-component-library-react';
-
-const App = () => (
-  <MeetingProvider>
-    <MyApp />
-  </MeetingProvider>
-);
-
-const MyApp = () => {
-  const meetingManager = useMeetingManager();
-
-  ...
-}
-```
-
-## Constructor
-
-Accepts a config object of `logLevel`, `postLogConfig`, `simulcastEnabled`, `enableWebAudio`, `logger`,
-`activeSpeakerPolicy`, `videoUplinkBandwidthPolicy`, `videoDownlinkBandwidthPolicy`, `reconnectTimeoutMs`, and
-`keepLastFrameWhenPaused` that will be used when joining a meeting session. See [MeetingProvider](/docs/sdk-providers-meetingprovider--page) documentation for more details.
 
 ## Interface
 
 ### `meetingManager.join`
 
-Creates a meeting session using the meeting and attendee data passed. It will attempt to select default devices for the user.
+`meetingManager.join` creates a `MeetingSession` using the passed `MeetingSessionConfiguration` and `options`. `options` use `MeetingManagerJoinOptions` type interface. 
+`join` will attempt to select default devices for the user.
 
 ```typescript
-import { EventController } from 'amazon-chime-sdk-js';
-import { MeetingManagerConfig } from 'amazon-chime-sdk-component-library-react';
+(meetingSessionConfiguration: MeetingSessionConfiguration, options?: MeetingManagerJoinOptions) => Promise<void>
+```
+Let's take a deeper look at the interface of the `join` method params.
 
-(data: MeetingJoinData) => Promise<void>
+##### `MeetingSessionConfiguration`
 
-interface MeetingJoinData {
-  // The response of calling chime:CreateMeeting from your server.
-  meetingInfo: any;
+```typescript
+// Use the `MeetingSessionConfiguration`.
+// The default properties of the `MeetingSessionConfiguration` can be updated to customize the meeting as per the builder's preference.
+// Reference `MeetingSessionConfiguration` properties in Amazon Chime SDK for JavaScript: https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html
+meetingSessionConfiguration: MeetingSessionConfiguration;
+```
 
-  // The response of calling chime:CreateAttendee from your server.
-  attendeeInfo: any;
-
+##### `MeetingManagerJoinOptions`
+```typescript
+options?: {
   // The kind of device for which the browser requests permission.
   // Or override the default device label trigger in the Amazon Chime SDK for JavaScript.
   deviceLabels?: DeviceLabels | DeviceLabelTrigger;
 
-  // Override the default event reporter in the Amazon Chime SDK for JavaScript.
+  // Override the default event controller in the Amazon Chime SDK for JavaScript.
   eventController?: EventController;
-
-  // Set the meeting config. This will override the props from MeetingProvider.
-  meetingManagerConfig?: MeetingManagerConfig;
+  
+  // The level of logging you want with your meeting session. 
+  // It is defined by the LogLevel (https://aws.github.io/amazon-chime-sdk-js/enums/loglevel.html) enum in `amazon-chime-sdk-js`.
+  logLevel?: LogLevel;
+  
+  // Configuration for setting up a MeetingSessionPOSTLogger (https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionpostlogger.html).
+  postLoggerConfig?: PostLogConfig;
+  
+  // The `Logger` object that you want to be used in the meeting session.
+  // If you pass in a `Logger` object using this parameter, the `MeetingManager` will use this object instead of creating a logger based on `logLevel` and `postLogConfig` to initialize the meeting session.
+  logger?: Logger;
+  
+  // If you want to enable Amazon Voice Focus feature, you should enable Web Audio for the meeting and pass the `enableWebAudio` prop with value set to `true`. 
+  // By default, `enableWebAudio` is `false`.
+  enableWebAudio?: boolean;
+  
+  // The `ActiveSpeakerPolicy` object that you want to be used in the meeting session.
+  // For more information on `ActiveSpeakerPolicy`, check Amazon Chime SDK for JavaScript ActiveSpeakerPolicy (https://aws.github.io/amazon-chime-sdk-js/interfaces/activespeakerpolicy.html).
+  activeSpeakerPolicy?: ActiveSpeakerPolicy;
 }
 ```
 
@@ -103,9 +96,30 @@ interface AttendeeResponse {
 }
 ```
 
-#### Example
+## Usage
 
-1. `MeetingManager` instance is created internally in the `MeetingProvider` and can be retrived using `useMeetingManager` hook.
+`MeetingProvider` must be rendered somewhere higher in the tree. Call `useMeetingManager` hook to get the `MeetingManager` object.
+
+```jsx
+import React from 'react';
+import { MeetingProvider, useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <MeetingProvider>
+    <MyApp />
+  </MeetingProvider>
+);
+
+const MyApp = () => {
+  const meetingManager = useMeetingManager();
+
+  ...
+}
+```
+
+## Usage Examples
+
+### `MeetingManager` instance is created internally in the `MeetingProvider` and can be retrived using `useMeetingManager` hook.
 ```jsx
 import { MeetingProvider, useMeetingManager } from 'amazon-chime-sdk-component-library-react';
 
@@ -131,7 +145,54 @@ const MyApp = () => {
 }
 ```
 
-2. Share the same `MeetingManager` instance with multiple different `MeetingProvider`s.
+### Update the `MeetingSessionConfiguration` properties being passed to the `join` method
+
+With V3 of the Amazon Chime SDK for JavaScript, builders now have the option of updating the properties of `MeetingSessionConfiguration`. `MeetingSessionConfiguration` is a class that allows the users to configure the meeting session.
+
+The class contains several properties like `videoUplinkBandwidthPolicy`, `videoDownlinkBandwidthPolicy`, `attendeePresenceTimeoutMs` etc. You can learn more about the available properties at [MeetingSessionConfiguration](https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html)
+in the SDK documentation. The following code example shows a `MeetingSessionConfiguration` where the default value of the properties are overridden to cusomize the meeting session.
+
+```jsx
+import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
+import { MeetingSessionConfiguration, VideoPriorityBasedPolicyConfig } from 'amazon-chime-sdk-js';
+
+const MyApp = () => {
+  const meetingManager = useMeetingManager();
+
+  const joinMeeting = async () => {
+    // Fetch the meeting and attendee data from your server application
+    const response = await fetch('/my-server');
+    const data = await response.json();
+
+    // Initalize the `MeetingSessionConfiguration`
+    const meetingSessionConfiguration = new MeetingSessionConfiguration(data.Meeting, data.Attendee);
+
+    // Update the `MeetingSessionConfiguration` properties
+    meetingSessionConfiguration.attendeePresenceTimeoutMs = 120;
+    meetingSessionConfiguration.videoDownlinkBandwidthPolicy = new VideoPriorityBasedPolicy(
+      logger,
+      VideoPriorityBasedPolicyConfig.UnstableNetworkPreset,
+    );
+
+    // Create a `MeetingSession` using `join()` function with the modified `MeetingSessionConfiguration`
+    await meetingManager.join(
+      meetingSessionConfiguration
+    );
+
+    // At this point you could let users setup their devices, or by default 
+    // the SDK will select the first device in the list for the kind indicated
+    // by `deviceLabels` (the default value is DeviceLabels.AudioAndVideo)
+    ...
+
+    // Start the `MeetingSession` to join the meeting
+    await meetingManager.start();
+  };
+
+  return <button onClick={joinMeeting}>Join</button>;
+};
+```
+
+### Share the same `MeetingManager` instance with multiple different `MeetingProvider`s.
 
 **IMPORTANT NOTE**
 This approach has limitations. This should be used only in very specific cases where you want to share the meeting manager instance
@@ -163,7 +224,7 @@ const Root = () => {
 }
 ```
 
-3. Opt-out of client event ingestion.
+### Opt-out of client event ingestion.
 
 The Amazon Chime SDK for JavaScript sends meeting events to the Amazon Chime backend to analyze meeting health trends or identify common failures.
 This helps to improve your meeting experience. For more information, check the [client event ingestion guide](https://aws.github.io/amazon-chime-sdk-js/modules/clientevent_ingestion.html) in the Amazon Chime SDK for JavaScript guides.
@@ -177,17 +238,22 @@ import { MeetingProvider } from 'amazon-chime-sdk-component-library-react';
 
 const MeetingForm = () => {
   const meetingManager = useMeetingManager();
-  const meetingSessionConfiguration = new DefaultMeetingSessionConfiguration(...);
+  
+  const response = await fetch('/my-meetings-endpoint');
+  const data = await response.json();
+  
+  const meetingSessionConfiguration = new MeetingSessionConfiguration(data.Meeting, data.Attendee);
   const eventController = new DefaultEventController(
-        meetingSessionConfiguration, 
-        meetingManager.createLogger(meetingSessionConfiguration), 
-        new NoOpEventReporter()
-      );
+    meetingSessionConfiguration, 
+    new ConsoleLogger('SDK', LogLevel.WARN), 
+    new NoOpEventReporter()
+  );
+
   const handleJoinMeeting = async (event) => {
-    await meetingManager.join({
+    await meetingManager.join(
       meetingSessionConfiguration,
-      eventController: eventController
-    });
+      options
+    );
   }
   return (
     <PrimaryButton label="Continue" onClick={handleJoinMeeting} />

--- a/src/providers/MeetingProvider/docs/MeetingProvider.stories.mdx
+++ b/src/providers/MeetingProvider/docs/MeetingProvider.stories.mdx
@@ -37,8 +37,8 @@ This approach has limitations. This should be used only in very specific cases w
 variable values or you will not use video, roster and audio at both places. Still, the hooks and providers may not work as expected as `MeetingProvider` wraps all the other providers.
 The video will not work due to limitations of JS SDK to bind a video stream to a single video tile only. Please check [this](https://github.com/aws/amazon-chime-sdk-component-library-react/issues/492#issuecomment-846317339) issue for more details.
 
-Please make sure your app calls `meetingManager.join()` only once with the same `attendeeInfo`.
-Otherwise,  the previous attendee who joined the meeting will leave the meeting with [AudioJoinedFromAnotherDevice](https://aws.github.io/amazon-chime-sdk-js/enums/meetingsessionstatuscode.html#audiojoinedfromanotherdevice).
+Please make sure your app calls `meetingManager.join(meetingSessionConfiguration)` only once. The `join` method needs `MeetingSessionConfiguration` as a required parameter. `MeetingSessionConfiguration` should be created with the same `attendeeInfo`.
+Otherwise, the previous attendee who joined the meeting will leave the meeting with [AudioJoinedFromAnotherDevice](https://aws.github.io/amazon-chime-sdk-js/enums/meetingsessionstatuscode.html#audiojoinedfromanotherdevice).
 
 ```jsx
 import { MeetingProvider, useMeetingManager } from 'amazon-chime-sdk-component-library-react';
@@ -64,48 +64,6 @@ const Root = () => {
 
 ### Prop values
 
-#### logLevel
-
-The level of logging you want with your meeting session. It is defined by the [LogLevel](https://aws.github.io/amazon-chime-sdk-js/enums/loglevel.html) enum in `amazon-chime-sdk-js`.
-
-```javascript
-enum LogLevel {
-  DEBUG,
-  INFO,
-  WARN,
-  ERROR,
-  OFF
-}
-```
-
-#### postLogConfig
-
-Configuration for setting up a [MeetingSessionPOSTLogger](https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionpostlogger.html).
-
-```javascript
-interface PostLogConfig = {
-  name: string;
-  batchSize: number;
-  intervalMs: number;
-  url: string;
-  logLevel: LogLevel
-}
-```
-
-#### simulcastEnabled
-
-To enable simulcast for the meeting pass the `simulcastEnabled` prop with value set to `true`. By default, it is `false`.
-For more information on Simulcast, check Amazon Chime SDK for JavaScript [simulcast guide](https://github.com/aws/amazon-chime-sdk-js/blob/master/guides/05_Simulcast.md).
-
-#### enableWebAudio
-
-If you want to enable Amazon Voice Focus feature, you should enable Web Audio for the meeting and pass the `enableWebAudio` prop with value set to `true`. By default, it is `false`.
-
-#### logger
-
-The `Logger` object that you want to be used in the meeting session.
-If you pass in a `Logger` object using this parameter, the `MeetingManager` will use this object instead of creating a logger based on `logLevel` and `postLogConfig` to initialize the meeting session.
-
 #### onDeviceReplacement
 
 When a selected device is disconnected, or when the Operating System (OS) default device is selected and is changed by the OS (e.g., if a Bluetooth headset is disconnected),
@@ -113,88 +71,6 @@ the `AudioInputProvider` encapsulated by `DevicesProvider` is forced to automati
 However, when your application is using a transform device like Amazon Voice Focus, the `AudioInputProvider` needs a way to transform the newly selected device to avoid reverting to a non-transform device.
 This is accomplished by exposing a `onDeviceReplacement` prop on `MeetingProvider` and `DevicesProvider`, allowing your application to customize the behavior of this device reselection step.
 Provide a function that accepts a `Device` as input and returns a `Device` or `AudioTransformDevice` of your choice.
-
-#### activeSpeakerPolicy
-
-The `ActiveSpeakerPolicy` object that you want to be used in the meeting session.
-For more information on `ActiveSpeakerPolicy`, check Amazon Chime SDK for JavaScript [ActiveSpeakerPolicy](https://aws.github.io/amazon-chime-sdk-js/interfaces/activespeakerpolicy.html).
-
-For example, if you do not want to prioritize the active speaker during a call you can override the
-`DefaultActiveSpeakerPolicy`:
-```jsx
-import {
-  LogLevel,
-  ConsoleLogger,
-  DefaultActiveSpeakerPolicy,
-  VideoPriorityBasedPolicy,
-} from 'amazon-chime-sdk-js';
-import { MeetingProvider } from 'amazon-chime-sdk-component-library-react';
-
-class MyActiveSpeakerPolicy extends DefaultActiveSpeakerPolicy {
-  prioritizeVideoSendBandwidthForActiveSpeaker() {
-    return false;
-  }
-}
-
-const Root = () => {
-  const logger = new ConsoleLogger('SDK', LogLevel.INFO);
-  const activeSpeakerPolicy = new MyActiveSpeakerPolicy();
-  const meetingConfig = {
-    logger,
-    activeSpeakerPolicy,
-  };
-
-  return (
-    <MeetingProvider {...meetingConfig}>
-      <MyApp />
-    </MeetingProvider>
-  );
-};
-```
-
-#### videoUplinkBandwidthPolicy and videoDownlinkBandwidthPolicy
-
-The `VideoUplinkBandwidthPolicy` and `VideoDownlinkBandwidthPolicy` object that you want to be used in the meeting
-session.
-For more information on `VideoUplinkBandwidthPolicy` and `VideoDownlinkBandwidthPolicy`, check Amazon Chime SDK for JavaScript
-[VideoUplinkBandwidthPolicy](https://aws.github.io/amazon-chime-sdk-js/interfaces/videouplinkbandwidthpolicy.html)
-and [VideoDownlinkBandwidthPolicy](https://aws.github.io/amazon-chime-sdk-js/interfaces/videodownlinkbandwidthpolicy.html).
-
-For example, to use the `VideoPriorityBasedPolicy` in the meeting:
-
-```jsx
-import {
-  LogLevel,
-  ConsoleLogger,
-  VideoPriorityBasedPolicy,
-} from 'amazon-chime-sdk-js';
-import { MeetingProvider } from 'amazon-chime-sdk-component-library-react';
-
-const Root = () => {
-  const logger = new ConsoleLogger('SDK', LogLevel.INFO);
-  const videoDownlinkBandwidthPolicy = new VideoPriorityBasedPolicy(logger);
-
-  const meetingConfig = {
-    logger,
-    videoDownlinkBandwidthPolicy,
-  };
-
-  return (
-    <MeetingProvider {...meetingConfig}>
-      <MyApp />
-    </MeetingProvider>
-  );
-};
-```
-For more information on `VideoPriorityBasedPolicy`, check Amazon Chime SDK for JavaScript [priority downlink policy guide](https://aws.github.io/amazon-chime-sdk-js/modules/prioritybased_downlink_policy.html).
-
-#### reconnectTimeoutMs
-
-The `reconnectTimeoutMs` specifies the maximum amount of time in milliseconds to allow for reconnecting. Refer to the [JS SDK FAQ](https://aws.github.io/amazon-chime-sdk-js/modules/faqs.html#what-is-the-timeout-for-connect-and-reconnect-and-where-can-i-configure-the-value) for more information.
-
-#### keepLastFrameWhenPaused
-
-The `keepLastFrameWhenPaused` keeps the last frame of the video when a remote video is paused via the pauseVideoTile.
 
 #### meetingManager
 

--- a/src/providers/MeetingProvider/index.tsx
+++ b/src/providers/MeetingProvider/index.tsx
@@ -1,15 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-  ActiveSpeakerPolicy,
-  AudioTransformDevice,
-  Device,
-  Logger,
-  LogLevel,
-  VideoDownlinkBandwidthPolicy,
-  VideoUplinkBandwidthPolicy,
-} from 'amazon-chime-sdk-js';
+import { AudioTransformDevice, Device } from 'amazon-chime-sdk-js';
 import React, { createContext, useContext, useState } from 'react';
 
 import { AudioVideoProvider } from '../AudioVideoProvider';
@@ -22,51 +14,12 @@ import { MeetingEventProvider } from '../MeetingEventProvider';
 import { RemoteVideoTileProvider } from '../RemoteVideoTileProvider';
 import { RosterProvider } from '../RosterProvider';
 import MeetingManager from './MeetingManager';
-import { PostLogConfig } from './types';
 
 interface Props {
-  /** Determines how verbose the logging statements will be */
-  logLevel?: LogLevel;
-  /** Configuration for a MeetingSessionPOSTLogger */
-  postLogConfig?: PostLogConfig;
-  /** Whether or not to enable simulcast for the meeting session */
-  simulcastEnabled?: boolean;
-  /** Whether or not to enable Web Audio for the meeting session */
-  enableWebAudio?: boolean;
-  /** The `Logger` object you want to use in meeting session.
-   * If you pass in a `Logger` object using this parameter,
-   * the `MeetingManager` will use this object instead of creating a logger
-   * based on `logLevel` and `postLogConfig` to initialize the meeting session.
-   */
-  logger?: Logger;
-  /** Determines how to handle the current audio input device when devices
-   *  change in `AudioInputProvider`.
-   */
   onDeviceReplacement?: (
     nextDevice: string,
     currentDevice: Device | AudioTransformDevice
   ) => Promise<Device | AudioTransformDevice>;
-  /**
-   * The [VideoDownlinkBandwidthPolicy](https://aws.github.io/amazon-chime-sdk-js/interfaces/videodownlinkbandwidthpolicy.html) object you want to use in the meeting session
-   *
-   */
-  videoDownlinkBandwidthPolicy?: VideoDownlinkBandwidthPolicy;
-  /**
-   * The [VideoUplinkBandwidthPolicy](https://aws.github.io/amazon-chime-sdk-js/interfaces/videouplinkbandwidthpolicy.html) object you want to use in the meeting session
-   */
-  videoUplinkBandwidthPolicy?: VideoUplinkBandwidthPolicy;
-  /**
-   * The [ActiveSpeakerPolicy](https://aws.github.io/amazon-chime-sdk-js/interfaces/activespeakerpolicy.html) object that you want to use in the meeting session.
-   */
-  activeSpeakerPolicy?: ActiveSpeakerPolicy;
-  /**
-   * Maximum amount of time in milliseconds to allow for reconnecting. Default is 120 seconds. [Refer to the documentation.](https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html#reconnecttimeoutms)
-   */
-  reconnectTimeoutMs?: number;
-  /**
-   * Keep the last frame of the video when a remote video is paused via the pauseVideoTile API.
-   */
-  keepLastFrameWhenPaused?: boolean;
   /** Pass a `MeetingManager` instance if you want to share this instance
    * across multiple different `MeetingProvider`s. This approach has limitations.
    * Check `meetingManager` prop documentation for more information.
@@ -77,35 +30,12 @@ interface Props {
 export const MeetingContext = createContext<MeetingManager | null>(null);
 
 export const MeetingProvider: React.FC<Props> = ({
-  logLevel = LogLevel.WARN,
-  postLogConfig,
-  simulcastEnabled = false,
-  enableWebAudio = false,
-  logger,
   onDeviceReplacement,
-  videoDownlinkBandwidthPolicy,
-  videoUplinkBandwidthPolicy,
-  reconnectTimeoutMs,
-  activeSpeakerPolicy,
-  keepLastFrameWhenPaused,
   meetingManager: meetingManagerProp,
   children,
 }) => {
   const [meetingManager] = useState(
-    () =>
-      meetingManagerProp ||
-      new MeetingManager({
-        logLevel,
-        postLogConfig,
-        simulcastEnabled,
-        enableWebAudio,
-        logger,
-        videoDownlinkBandwidthPolicy,
-        videoUplinkBandwidthPolicy,
-        reconnectTimeoutMs,
-        keepLastFrameWhenPaused,
-        activeSpeakerPolicy,
-      })
+    () => meetingManagerProp || new MeetingManager()
   );
 
   return (

--- a/src/providers/MeetingProvider/types.ts
+++ b/src/providers/MeetingProvider/types.ts
@@ -6,8 +6,6 @@ import {
   EventController,
   Logger,
   LogLevel,
-  VideoDownlinkBandwidthPolicy,
-  VideoUplinkBandwidthPolicy,
 } from 'amazon-chime-sdk-js';
 
 import { DeviceLabels, DeviceLabelTrigger } from '../../types';
@@ -19,12 +17,14 @@ export enum DevicePermissionStatus {
   DENIED = 'DENIED',
 }
 
-export interface MeetingJoinData {
-  meetingInfo: any;
-  attendeeInfo: any;
+export interface MeetingManagerJoinOptions {
   deviceLabels?: DeviceLabels | DeviceLabelTrigger;
   eventController?: EventController;
-  meetingManagerConfig?: MeetingManagerConfig;
+  logLevel?: LogLevel;
+  postLoggerConfig?: PostLoggerConfig;
+  logger?: Logger;
+  enableWebAudio?: boolean;
+  activeSpeakerPolicy?: ActiveSpeakerPolicy;
 }
 
 export interface AttendeeResponse {
@@ -41,23 +41,10 @@ export type FullDeviceInfoType = {
   videoInputDevices: MediaDeviceInfo[] | null;
 };
 
-export interface PostLogConfig {
+export interface PostLoggerConfig {
   name: string;
   batchSize: number;
   intervalMs: number;
   url: string;
   logLevel: LogLevel;
-}
-
-export interface MeetingManagerConfig {
-  logLevel: LogLevel;
-  postLogConfig?: PostLogConfig;
-  simulcastEnabled?: boolean;
-  enableWebAudio?: boolean;
-  logger?: Logger;
-  activeSpeakerPolicy?: ActiveSpeakerPolicy;
-  videoUplinkBandwidthPolicy?: VideoUplinkBandwidthPolicy;
-  videoDownlinkBandwidthPolicy?: VideoDownlinkBandwidthPolicy;
-  reconnectTimeoutMs?: number;
-  keepLastFrameWhenPaused?: boolean;
 }

--- a/src/providers/introduction.stories.mdx
+++ b/src/providers/introduction.stories.mdx
@@ -67,6 +67,7 @@ import {
   MeetingProvider,
   useMeetingManager
 } from 'amazon-chime-sdk-component-library-react';
+import { MeetingSessionConfiguration } from 'amazon-chime-sdk-js';
 
 const App = () => (
   <MeetingProvider>
@@ -81,13 +82,12 @@ const MyApp = () => {
     const response = await fetch('/my-meetings-endpoint');
     const data = await response.json();
 
-    const joinData = {
-      meetingInfo: data.Meeting,
-      attendeeInfo: data.Attendee
-    };
+    const meetingSessionConfiguration = new MeetingSessionConfiguration(data.Meeting, data.Attendee);
 
     try {
-      await meetingManager.join(joinData);
+      await meetingManager.join(
+        meetingSessionConfiguration
+      );
     } catch {
       console.error('Something went wrong');
     }
@@ -119,6 +119,7 @@ import {
   MeetingProvider,
   useMeetingManager
 } from 'amazon-chime-sdk-component-library-react';
+import { MeetingSessionConfiguration } from 'amazon-chime-sdk-js';
 
 const MyApp = () => {
   const meetingManager = useMeetingManager();
@@ -128,17 +129,19 @@ const MyApp = () => {
     const data = await response.json();
     const meetingSessionConfiguration = new MeetingSessionConfiguration(data.Meeting, data.Attendee);
     const eventController = new DefaultEventController(
-        meetingSessionConfiguration, 
-        meetingManager.createLogger(meetingSessionConfiguration), 
-        new NoOpEventReporter()
-      );
-    const joinData = {
-      meetingSessionConfiguration: meetingSessionConfiguration,
-      eventController: eventController
+      meetingSessionConfiguration, 
+      new ConsoleLogger('SDK', LogLevel.WARN), 
+      new NoOpEventReporter()
+    );
+    const options = {
+      eventController,
     };
 
     try {
-      await meetingManager.join(joinData);
+      await meetingManager.join(
+        meetingSessionConfiguration,
+        options
+      );
     } catch {
       console.error('Something went wrong');
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,10 +25,11 @@
   "exclude": [
     "node_modules",
     "build",
-    "tst",
+    "demo",
     "scripts",
     ".storybook",
     "src/**/*.stories.tsx",
     "coverage",
+    "tst" // TODO: This tst folder exclusion is causing parserIssues on linter due to the include on line 24. This tst folder include and exclude needs to be adjusted to remove the parserError. This tst folder exclusion cannot be removed as npm starts to fail.
   ]
 }

--- a/tst/hooks/sdk/useActiveSpeakersState.test.tsx
+++ b/tst/hooks/sdk/useActiveSpeakersState.test.tsx
@@ -32,7 +32,7 @@ describe('useActiveSpeakersState', () => {
     const { result, unmount } = renderHook(() => useActiveSpeakersState(), {
       wrapper: ({ children }) => (
         <MeetingContext.Provider
-          value={new MeetingManager({ logLevel: LogLevel.OFF })}
+          value={ new MeetingManager() }
         >
           {children}
         </MeetingContext.Provider>

--- a/tst/providers/BackgroundBlurProvider/index.test.tsx
+++ b/tst/providers/BackgroundBlurProvider/index.test.tsx
@@ -7,7 +7,7 @@ import { act, renderHook } from '@testing-library/react-hooks';
 import { BackgroundBlurOptions } from 'amazon-chime-sdk-js';
 import React from 'react';
 
-import { BackgroundBlurProvider, useBackgroundBlur } from '../../../src';
+import { BackgroundBlurProvider, useBackgroundBlur } from '../../../src/providers/BackgroundBlurProvider';
 
 describe('BackgroundBlurProvider', () => {
   it('should not change props', async () => {

--- a/tst/providers/MeetingProvider/MeetingManager.test.ts
+++ b/tst/providers/MeetingProvider/MeetingManager.test.ts
@@ -1,0 +1,155 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import '@testing-library/jest-dom';
+
+import {
+  ConsoleLogger,
+  DefaultActiveSpeakerPolicy,
+  DefaultDeviceController,
+  DefaultMeetingSession,
+  LogLevel,
+  MeetingSessionConfiguration,
+  MeetingSessionPOSTLogger,
+  MultiLogger,
+} from 'amazon-chime-sdk-js';
+
+import { MeetingManager } from '../../../src/providers/MeetingProvider/MeetingManager';
+import { MeetingManagerJoinOptions } from '../../../src/providers/MeetingProvider/types';
+
+describe('Meeting Manager', () => {
+  let mockMeetingManagerJoinOptions: MeetingManagerJoinOptions;
+  let mockMeetingSessionConfiguration: MeetingSessionConfiguration;
+  let meetingManager: MeetingManager;
+  // eslint-disable-next-line
+  const GlobalAny = global as any;
+
+  beforeEach(() => {
+    // @ts-ignore
+    MeetingSessionConfiguration = jest.fn().mockImplementation(() => {});
+    mockMeetingSessionConfiguration = new MeetingSessionConfiguration();
+    mockMeetingManagerJoinOptions = {
+      logLevel: LogLevel.WARN,
+    };
+    meetingManager = new MeetingManager();
+    // @ts-ignore
+    ConsoleLogger = jest.fn().mockReturnValue({});
+    // @ts-ignore 
+    MultiLogger = jest.fn().mockReturnValue({});
+    // @ts-ignore
+    MeetingSessionPOSTLogger = jest.fn().mockReturnValue({});
+    // @ts-ignore
+    DefaultDeviceController = jest.fn().mockReturnValue({});
+    // @ts-ignore
+    DefaultMeetingSession = jest.fn().mockReturnValue({
+      audioVideo: {
+        addObserver: jest.fn().mockReturnValue({}),
+        removeObserver: jest.fn().mockReturnValue({}),
+        listAudioInputDevices: jest.fn().mockReturnValue({}),
+        listVideoInputDevices: jest.fn().mockReturnValue({}),
+        listAudioOutputDevices: jest.fn().mockReturnValue({}),
+        chooseAudioInputDevice: jest.fn().mockReturnValue({}),
+        setDeviceLabelTrigger: jest.fn().mockReturnValue({}),
+        subscribeToActiveSpeakerDetector: jest.fn().mockReturnValue({}),
+      },
+      eventController:  {
+        addObserver: jest.fn().mockReturnValue({}),
+        removeObserver: jest.fn().mockReturnValue({}),
+      },
+    });
+    GlobalAny.navigator = jest.fn().mockReturnValue({
+      mediaDevices: jest.fn().mockReturnValue({
+        enumerateDevices: jest.fn().mockReturnValue(() => {}),
+        getUserMedia: jest.fn().mockReturnValue({
+          some: () => {}
+        }),
+      })
+    });
+  });
+
+  describe('join', () => {
+    it('should call MeetingSessionPOSTLogger with PostLogConfig', async () => {
+      mockMeetingManagerJoinOptions = {
+        logLevel: LogLevel.ERROR,
+        postLoggerConfig: {
+          name: 'Test',
+          batchSize: 20,
+          intervalMs: 100,
+          url: 'http://test-url.com',
+          logLevel: LogLevel.INFO,
+        }
+      }
+      await meetingManager.join(mockMeetingSessionConfiguration, mockMeetingManagerJoinOptions);
+      expect(MeetingSessionPOSTLogger).toHaveBeenCalledWith(
+        'Test',
+        mockMeetingSessionConfiguration,
+        20,
+        100,
+        'http://test-url.com',
+        LogLevel.INFO,
+    );
+      expect(MeetingSessionPOSTLogger).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call MultiLogger if PostLoggerConfig is passed', async () => {
+      mockMeetingManagerJoinOptions = {
+        logLevel: LogLevel.ERROR,
+        postLoggerConfig: {
+          name: 'Test',
+          batchSize: 20,
+          intervalMs: 100,
+          url: 'http://test-url.com',
+          logLevel: LogLevel.INFO,
+        }
+      }
+      await meetingManager.join(mockMeetingSessionConfiguration, mockMeetingManagerJoinOptions);
+      expect(ConsoleLogger).toHaveBeenCalledWith(
+        'SDK',
+        LogLevel.ERROR,
+      );
+      expect(MeetingSessionPOSTLogger).toHaveBeenCalledWith(
+        'Test',
+        mockMeetingSessionConfiguration,
+        20,
+        100,
+        'http://test-url.com',
+        LogLevel.INFO,
+      );
+      expect(MultiLogger).toHaveBeenCalledWith(
+        new ConsoleLogger('SDK', LogLevel.ERROR),
+        new MeetingSessionPOSTLogger(
+          'Test',
+          mockMeetingSessionConfiguration,
+          20,
+          100,
+          'http://test-url.com',
+          LogLevel.INFO,
+        ),
+      );
+      expect(MultiLogger).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call subscribeToActiveSpeakerDetector with new DefaultActiveSpeakerPolicy if one is not passed via MeetinManagerJoinOptions', async () => {
+      await meetingManager.join(mockMeetingSessionConfiguration, mockMeetingManagerJoinOptions);
+      expect(meetingManager?.audioVideo?.subscribeToActiveSpeakerDetector).toHaveBeenCalledWith(
+        new DefaultActiveSpeakerPolicy(),
+        meetingManager.activeSpeakerListener,
+      );
+      expect(meetingManager?.audioVideo?.subscribeToActiveSpeakerDetector).toHaveBeenCalledTimes(
+        1
+      );
+    });
+
+    it('should call DefaultMeetingSession', async () => {
+      await meetingManager.join(mockMeetingSessionConfiguration, mockMeetingManagerJoinOptions);
+      expect(DefaultMeetingSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call addObserver on AudioVideoFacade', async () => {
+      await meetingManager.join(mockMeetingSessionConfiguration, mockMeetingManagerJoinOptions);
+      expect(meetingManager?.audioVideo?.addObserver).toHaveBeenCalledTimes(
+        1
+      );
+    });
+  });
+});


### PR DESCRIPTION
**Issue #724:** 

**Description of changes:**
- Add `MeetingSessionConfiguration` as a required param to `MeetingManager` join method.
- Remove `MeetingSessionConfiguration` properties from `MeetingProvider` props.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
By writing unit tests
3. If you made changes to the component library, have you provided corresponding documentation changes?
Documentation changes will follow in a separate PR. Will link the other PR when ready.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
