### PR TITLE
Remove meetingRegion from MeetingManager

### DIFF
--- a/src/components/migrationToV3.stories.mdx
+++ b/src/components/migrationToV3.stories.mdx
@@ -20,97 +20,38 @@ npm install --save amazon-chime-sdk-component-library-react@beta amazon-chime-sd
 ## What's New
 
 - `MeetingManager`'s `join()` method no longer takes an `EventReporter` and instead takes an `EventController`.
+- Add `MeetingSessionConfiguration` as a required parameter to `MeetingManager.join()` method. With this change the builders have direct access to `MeetingSessionConfiguration`, this will allow more flexibility to customize the `MeetingSession`.
+- Add `MeetingManagerJoinOptions` as a new interface for the `options` parameter of the `MeetingManager.join` method.
+- Add `deviceLabels`, `eventController`, `logLevel`, `postLoggerConfig`, `logger`, `enableWebAudio`, and `activeSpeakerPolicy` to `MeetingManagerJoinOptions` interface.
+- Remove `MeetingSessionConfiguration` properties from `MeetingProvider` props.
+- Remove `deviceLabels`, `eventController`, `logLevel`, `postLogConfig`, `logger`, `enableWebAudio`, and `activeSpeakerPolicy` from `MeetingProvider` props.
+- Remove `meetingRegion` from `MeetingManager`. Previously we just cache this value from meetingInfo returned by
+[CreateMeeting](https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateMeeting.html) but it is not used
+anywhere in the library.
 - Deprecate `useBandwidthMetrics` hook in favor of `useMediaStreamMetrics`.
 - Remove legacy metrics `videoDownstreamGoogFrameHeight`, `videoDownstreamGoogFrameWidth`, `videoUpstreamGoogFrameHeight` and `videoUpstreamGoogFrameWidth` from the `videoStreamMetrics` returned by the `useMediaStreamMetrics` hook to adopt to Amazon Chime SDK for JavaScript V3 changes ([aws/amazon-chime-sdk-js#2086](https://github.com/aws/amazon-chime-sdk-js/pull/2086)).
 - Update the `compilerOptions.target` in `tsconfig.json` from `es5` to `ES2015 (ES6)`.
 - Rename the `global` property of `DefaultTheme` Interface to `globalStyle` to avoid conflict with reserved keyword `global`.
-- Add `MeetingSessionConfiguration` as a required parameter to `MeetingManager.join()` method. With this change the builders have direct access to `MeetingSessionConfiguration`, this will allow more flexibility to customize the `MeetingSession`.
-- Add `MeetingManagerJoinOptions` as a new interface for the `options` parameter of the `MeetingManager.join` method.
-- Add `deviceLabels`, `eventController`, `logLevel`, `postLoggerConfig`, `logger`, `enableWebAudio`, and `activeSpeakerPolicy` to `MeetingManagerJoinOptions` interface. 
-- Remove `MeetingSessionConfiguration` properties from `MeetingProvider` props.
-- Remove `deviceLabels`, `eventController`, `logLevel`, `postLogConfig`, `logger`, `enableWebAudio`, and `activeSpeakerPolicy` from `MeetingProvider` props.
-
-### Updating `EventReporter` to `EventController`
-
-Before in 2.x:
-
-```jsx
-const MyApp = () => {
-  const meetingManager = useMeetingManager();
-  const joinMeeting = async () => {
-    const response = await fetch('/my-meetings-endpoint');
-    const data = await response.json();
-    const joinData = {
-      meetingInfo: data.Meeting,
-      attendeeInfo: data.Attendee,
-      eventReporter: new NoOpEventReporter(),
-    };
-    try {
-      await meetingManager.join(joinData);
-    } catch {
-      console.error('Something went wrong');
-    }
-  };
-
-  return (
-    <button onClick={joinMeeting}>Join Meeting</button>;
-  );
-};
-```
-
-After in 3.x:
-
-```jsx
-const MyApp = () => {
-  const meetingManager = useMeetingManager();
-  const joinMeeting = async () => {
-    const response = await fetch('/my-meetings-endpoint');
-    const data = await response.json();
-    const meetingSessionConfiguration = new MeetingSessionConfiguration(data.Meeting, data.Attendee);
-    const eventController = new DefaultEventController(
-      meetingSessionConfiguration, 
-      new ConsoleLogger('SDK', LogLevel.WARN), 
-      new NoOpEventReporter()
-    );
-    const options = {
-      eventController
-    };
-
-    try {
-      await meetingManager.join(
-        meetingSessionConfiguration,
-        options
-      );
-    } catch {
-      console.error('Something went wrong');
-    }
-  };
-  
-  return (
-    <button onClick={joinMeeting}>Join Meeting</button>;
-  );
-};
-```
 
 ### `MeetingProvider` props change
 
 `MeetingProvider` no longer takes the following props:
 - `MeetingSessionConfiguration` properties:
-  - `VideoDownlinkBandwidthPolicy`
-  - `VideoUplinkBandwidthPolicy`
-  - `simulcastEnabled`
-  - `reconnectTimeoutMs`
-  - `keepLastFrameWhenPaused`
+- `VideoDownlinkBandwidthPolicy`
+- `VideoUplinkBandwidthPolicy`
+- `simulcastEnabled`
+- `reconnectTimeoutMs`
+- `keepLastFrameWhenPaused`
 - Other props:
-  - `deviceLabels`
-  - `eventController`
-  - `logLevel`
-  - `postLogConfig`
-  - `logger`
-  - `enableWebAudio`
-  - `activeSpeakerPolicy`
+- `deviceLabels`
+- `eventController`
+- `logLevel`
+- `postLogConfig`
+- `logger`
+- `enableWebAudio`
+- `activeSpeakerPolicy`
 
-These props can rather be updated by passing the `MeetingSessionConfiguration` object or by passing `options` props to `meetingManager.join()` method. 
+These props can rather be updated by passing the `MeetingSessionConfiguration` object or by passing `options` props to `meetingManager.join()` method.
 
 You can learn more about the `meetingManager.join()` method here: [MeetingManager](/docs/sdk-providers-meetingmanager--page).
 
@@ -258,7 +199,7 @@ const MyApp = () => {
 
 ##### enableWebAudio
 
-The following example uses `enableWebAudio` property as an example to showcase the change. `enableWebAudio` is chosen here because it is one of the properties that is affected and it is not part of `MeetingSessionConfiguration`. 
+The following example uses `enableWebAudio` property as an example to showcase the change. `enableWebAudio` is chosen here because it is one of the properties that is affected and it is not part of `MeetingSessionConfiguration`.
 
 Before in 2.x:
 
@@ -353,13 +294,77 @@ import { MeetingSessionConfiguration } from 'amazon-chime-sdk-js';
 
 const MyApp = () => {
   const meetingSessionConfiguration = new MeetingSessionConfiguration(data.Meeting, data.Attendee);
-  
+
   const meetingManager = useMeetingManager();
   await meetingManager.join(
     meetingSessionConfiguration
   );
 };
 ```
+
+### Updating `EventReporter` to `EventController`
+
+Before in 2.x:
+
+```jsx
+const MyApp = () => {
+  const meetingManager = useMeetingManager();
+  const joinMeeting = async () => {
+    const response = await fetch('/my-meetings-endpoint');
+    const data = await response.json();
+    const joinData = {
+      meetingInfo: data.Meeting,
+      attendeeInfo: data.Attendee,
+      eventReporter: new NoOpEventReporter(),
+    };
+    try {
+      await meetingManager.join(joinData);
+    } catch {
+      console.error('Something went wrong');
+    }
+  };
+
+  return (
+    <button onClick={joinMeeting}>Join Meeting</button>;
+  );
+};
+```
+
+After in 3.x:
+
+```jsx
+const MyApp = () => {
+  const meetingManager = useMeetingManager();
+  const joinMeeting = async () => {
+    const response = await fetch('/my-meetings-endpoint');
+    const data = await response.json();
+    const meetingSessionConfiguration = new MeetingSessionConfiguration(data.Meeting, data.Attendee);
+    const eventController = new DefaultEventController(
+      meetingSessionConfiguration,
+      new ConsoleLogger('SDK', LogLevel.WARN),
+      new NoOpEventReporter()
+    );
+    const options = {
+      eventController
+    };
+
+    try {
+      await meetingManager.join(
+        meetingSessionConfiguration,
+        options
+      );
+    } catch {
+      console.error('Something went wrong');
+    }
+  };
+
+  return (
+    <button onClick={joinMeeting}>Join Meeting</button>;
+  );
+};
+```
+
+
 
 ## WebRTC Metrics Change
 
@@ -368,7 +373,7 @@ const MyApp = () => {
 The `useBandwidthMetrics` hook exposes two WebRTC metrics:
 
 - `availableOutgoingBandwidth`
-- `availableIncomingBandwidth`. 
+- `availableIncomingBandwidth`.
 
 The `useMediaStreamMetrics` covers all metrics of `useBandwidthMetrics` hook, so we decide to deprecate it in V3.
 

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -60,8 +60,6 @@ export class MeetingManager implements AudioVideoObserver {
 
   meetingId: string | null = null;
 
-  meetingRegion: string | null = null;
-
   getAttendee?: (
     chimeAttendeeId: string,
     externalUserId?: string
@@ -151,7 +149,6 @@ export class MeetingManager implements AudioVideoObserver {
     this.audioVideo = null;
     this.meetingSessionConfiguration = undefined;
     this.meetingId = null;
-    this.meetingRegion = null;
     this.selectedAudioOutputDevice = null;
     this.selectedAudioInputDevice = null;
     this.selectedAudioInputTransformDevice = null;
@@ -308,6 +305,14 @@ export class MeetingManager implements AudioVideoObserver {
   audioVideoDidStop = (sessionStatus: MeetingSessionStatus): void => {
     const sessionStatusCode = sessionStatus.statusCode();
     switch (sessionStatusCode) {
+      case MeetingSessionStatusCode.MeetingEnded:
+        console.log(
+          `[MeetingManager audioVideoDidStop] Meeting ended for all: ${sessionStatusCode}`
+        );
+        this.meetingStatus = MeetingStatus.Ended;
+        this.publishMeetingStatus();
+        this.leave();
+        break;
       case MeetingSessionStatusCode.Left:
         console.log(
           `[MeetingManager audioVideoDidStop] Left the meeting: ${sessionStatusCode}`

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,7 +69,7 @@ export enum DevicePermissionStatus {
 }
 
 export enum DeviceLabels {
-  None,
+  None = 1,
   Audio,
   Video,
   AudioAndVideo,


### PR DESCRIPTION
**Description of changes:**
- Remove `meetingRegion` from `MeetingManager` because we do not use that value anywhere in the library. Application can still get it from the `createMeeting` API response in aws-sdk.
- Fix some minor bugs that remove the `meetingStatus.Ended` as well as `DeviceLabels.None` check.

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes

2. How did you test these changes? Manually test with latest meeting demo.

3. If you made changes to the component library, have you provided corresponding documentation changes? Yes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
