### PR TITLE
Remove log circular structure error for JSON.stringify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Removed
+- Remove logging of the video transform device to avoid circular structure error.
 
 ### Changed
 

--- a/src/providers/BackgroundBlurProvider/index.tsx
+++ b/src/providers/BackgroundBlurProvider/index.tsx
@@ -154,13 +154,6 @@ const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
           selectedDevice,
           [currentProcessor]
         );
-        console.log(
-          `Created video transform device ${JSON.stringify(
-            chosenVideoTransformDevice,
-            null,
-            2
-          )}`
-        );
         return chosenVideoTransformDevice;
       } else {
         throw new Error(

--- a/src/providers/BackgroundReplacementProvider/index.tsx
+++ b/src/providers/BackgroundReplacementProvider/index.tsx
@@ -166,13 +166,6 @@ const BackgroundReplacementProvider: FC<Props> = ({
           selectedDevice,
           [currentProcessor]
         );
-        console.log(
-          `Created video transform device ${JSON.stringify(
-            chosenVideoTransformDevice,
-            null,
-            2
-          )}`
-        );
         return chosenVideoTransformDevice;
       } else {
         throw new Error(


### PR DESCRIPTION
**Issue #:** 
https://github.com/aws/amazon-chime-sdk-component-library-react/issues/756

**Description of changes:**
Remove logging of JSON.stringify to mitigate error thrown by JSON.stringify

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? n/a

3. If you made changes to the component library, have you provided corresponding documentation changes? n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
