### PR TITLE
Add logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
         "add": "^2.0.6",
-        "amazon-chime-sdk-js": "^3.0.0-beta.1",
+        "amazon-chime-sdk-js": "file:/Users/devalevd/workplace/amazon-chime-sdk-js/amazon-chime-sdk-js-3.0.0-beta.2.tgz",
         "babel-loader": "^8.1.0",
         "css-loader": "^2.1.1",
         "eslint": "^7.32.0",
@@ -93,7 +93,7 @@
         "npm": "^6 || ^7 || ^8"
       },
       "peerDependencies": {
-        "amazon-chime-sdk-js": "^3.0.0-beta.1",
+        "amazon-chime-sdk-js": "file:/Users/devalevd/workplace/amazon-chime-sdk-js/amazon-chime-sdk-js-3.0.0-beta.2.tgz",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "styled-components": "^5.0.0",
@@ -328,6 +328,9 @@
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.12.13",
         "regexpu-core": "^4.7.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
@@ -344,6 +347,9 @@
         "lodash.debounce": "^4.0.8",
         "resolve": "^1.14.2",
         "semver": "^6.1.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0-0"
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider/node_modules/semver": {
@@ -620,6 +626,9 @@
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-remap-async-to-generator": "^7.13.0",
         "@babel/plugin-syntax-async-generators": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-class-properties": {
@@ -630,6 +639,9 @@
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.13.0",
         "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-decorators": {
@@ -659,6 +671,9 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13",
         "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-export-default-from": {
@@ -685,6 +700,9 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-json-strings": {
@@ -695,6 +713,9 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13",
         "@babel/plugin-syntax-json-strings": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-logical-assignment-operators": {
@@ -705,6 +726,9 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
@@ -731,6 +755,9 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13",
         "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-object-rest-spread": {
@@ -742,6 +769,9 @@
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
         "@babel/plugin-transform-parameters": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-optional-catch-binding": {
@@ -752,6 +782,9 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-optional-chaining": {
@@ -779,6 +812,9 @@
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.13.0",
         "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-unicode-property-regex": {
@@ -792,6 +828,9 @@
       },
       "engines": {
         "node": ">=4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
@@ -801,6 +840,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-bigint": {
@@ -810,6 +852,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
@@ -819,6 +864,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-decorators": {
@@ -843,6 +891,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-export-default-from": {
@@ -867,6 +918,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-flow": {
@@ -891,6 +945,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-json-strings": {
@@ -900,6 +957,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
@@ -924,6 +984,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
@@ -933,6 +996,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
@@ -942,6 +1008,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
@@ -951,6 +1020,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
@@ -960,6 +1032,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
@@ -969,6 +1044,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-top-level-await": {
@@ -978,6 +1056,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
@@ -1002,6 +1083,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-async-to-generator": {
@@ -1013,6 +1097,9 @@
         "@babel/helper-module-imports": "^7.12.13",
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-remap-async-to-generator": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
@@ -1022,6 +1109,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
@@ -1031,6 +1121,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
@@ -1046,6 +1139,9 @@
         "@babel/helper-replace-supers": "^7.13.0",
         "@babel/helper-split-export-declaration": "^7.12.13",
         "globals": "^11.1.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
@@ -1055,6 +1151,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
@@ -1064,6 +1163,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-dotall-regex": {
@@ -1074,6 +1176,9 @@
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.12.13",
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-keys": {
@@ -1083,6 +1188,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator": {
@@ -1093,6 +1201,9 @@
       "dependencies": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "^7.12.13",
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-flow-strip-types": {
@@ -1118,6 +1229,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-function-name": {
@@ -1128,6 +1242,9 @@
       "dependencies": {
         "@babel/helper-function-name": "^7.12.13",
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-literals": {
@@ -1137,6 +1254,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-member-expression-literals": {
@@ -1146,6 +1266,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-amd": {
@@ -1157,6 +1280,9 @@
         "@babel/helper-module-transforms": "^7.13.0",
         "@babel/helper-plugin-utils": "^7.13.0",
         "babel-plugin-dynamic-import-node": "^2.3.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
@@ -1188,6 +1314,9 @@
         "@babel/helper-plugin-utils": "^7.12.13",
         "@babel/helper-validator-identifier": "^7.12.11",
         "babel-plugin-dynamic-import-node": "^2.3.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
@@ -1198,6 +1327,9 @@
       "dependencies": {
         "@babel/helper-module-transforms": "^7.13.0",
         "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
@@ -1207,6 +1339,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-new-target": {
@@ -1216,6 +1351,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-object-super": {
@@ -1226,6 +1364,9 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13",
         "@babel/helper-replace-supers": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
@@ -1235,6 +1376,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-property-literals": {
@@ -1244,6 +1388,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-react-display-name": {
@@ -1318,6 +1465,9 @@
       "dev": true,
       "dependencies": {
         "regenerator-transform": "^0.14.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-reserved-words": {
@@ -1327,6 +1477,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
@@ -1336,6 +1489,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-spread": {
@@ -1346,6 +1502,9 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-sticky-regex": {
@@ -1355,6 +1514,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-template-literals": {
@@ -1364,6 +1526,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
@@ -1373,6 +1538,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
@@ -1399,6 +1567,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-unicode-regex": {
@@ -1409,6 +1580,9 @@
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.12.13",
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-env": {
@@ -1485,6 +1659,9 @@
         "babel-plugin-polyfill-regenerator": "^0.1.2",
         "core-js-compat": "^3.9.0",
         "semver": "7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-env/node_modules/semver": {
@@ -1524,6 +1701,9 @@
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-react": {
@@ -1748,6 +1928,9 @@
         "@emotion/serialize": "^0.11.15",
         "@emotion/sheet": "0.9.4",
         "@emotion/utils": "0.11.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
       }
     },
     "node_modules/@emotion/css": {
@@ -1927,24 +2110,28 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
       "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==",
+      "deprecated": "Moved to 'npm install @sideway/address'",
       "dev": true
     },
     "node_modules/@hapi/bourne": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+      "deprecated": "This version has been deprecated and is no longer supported or maintained",
       "dev": true
     },
     "node_modules/@hapi/hoek": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
       "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
+      "deprecated": "This version has been deprecated and is no longer supported or maintained",
       "dev": true
     },
     "node_modules/@hapi/joi": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
       "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+      "deprecated": "Switch to 'npm install joi'",
       "dev": true,
       "dependencies": {
         "@hapi/address": "2.x.x",
@@ -1957,6 +2144,7 @@
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
       "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+      "deprecated": "This version has been deprecated and is no longer supported or maintained",
       "dev": true,
       "dependencies": {
         "@hapi/hoek": "^8.3.0"
@@ -2034,6 +2222,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/console/node_modules/chalk": {
@@ -2047,6 +2238,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/console/node_modules/color-convert": {
@@ -2146,6 +2340,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/core/node_modules/chalk": {
@@ -2159,6 +2356,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/core/node_modules/color-convert": {
@@ -2198,6 +2398,9 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@jest/core/node_modules/strip-ansi": {
@@ -2318,6 +2521,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/reporters/node_modules/chalk": {
@@ -2331,6 +2537,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/reporters/node_modules/color-convert": {
@@ -2471,6 +2680,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/transform/node_modules/chalk": {
@@ -2484,6 +2696,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/transform/node_modules/color-convert": {
@@ -2560,6 +2775,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/types/node_modules/chalk": {
@@ -2573,6 +2791,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/types/node_modules/color-convert": {
@@ -2648,6 +2869,10 @@
         "@mdx-js/mdx": "1.6.22",
         "@mdx-js/react": "1.6.22",
         "loader-utils": "2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/@mdx-js/mdx": {
@@ -2675,6 +2900,10 @@
         "unified": "9.2.0",
         "unist-builder": "2.0.3",
         "unist-util-visit": "2.0.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/@mdx-js/mdx/node_modules/@babel/core": {
@@ -2702,6 +2931,10 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
       }
     },
     "node_modules/@mdx-js/mdx/node_modules/@babel/plugin-syntax-jsx": {
@@ -2711,6 +2944,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@mdx-js/mdx/node_modules/semver": {
@@ -2726,13 +2962,24 @@
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
       "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "react": "^16.13.1 || ^17.0.0"
+      }
     },
     "node_modules/@mdx-js/util": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-1.6.22.tgz",
       "integrity": "sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -2792,6 +3039,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.0.tgz",
       "integrity": "sha512-VhP1qZLXcrXRIaPoqb4YA55JQxLNF3jNR4T55IdOJa3+IFJKNYHtPvtXx8slmeMavj37vCzCfrqQM1vWLsYKLA==",
+      "deprecated": "this version had an improper engines field added, update to 1.1.1",
       "dev": true,
       "dependencies": {
         "@gar/promisify": "^1.0.1",
@@ -2985,7 +3233,11 @@
     "node_modules/@popperjs/core": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.8.6.tgz",
-      "integrity": "sha512-1oXH2bAFXz9SttE1v/0Jp+2ZVePsPEAPGIuPKrmljWZcS3FPBEn2Q4WcANozZC0YiCjTWOF55k0g6rbSZS39ew=="
+      "integrity": "sha512-1oXH2bAFXz9SttE1v/0Jp+2ZVePsPEAPGIuPKrmljWZcS3FPBEn2Q4WcANozZC0YiCjTWOF55k0g6rbSZS39ew==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -3067,6 +3319,9 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.3.4"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -3085,6 +3340,9 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -3099,6 +3357,9 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
       }
     },
     "node_modules/@sideway/address": {
@@ -5983,6 +6244,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@testing-library/dom/node_modules/chalk": {
@@ -5996,6 +6260,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@testing-library/dom/node_modules/color-convert": {
@@ -6083,6 +6350,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@testing-library/jest-dom/node_modules/chalk": {
@@ -6148,6 +6418,10 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/@testing-library/react-hooks": {
@@ -6190,6 +6464,9 @@
       "engines": {
         "node": ">=10",
         "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {
@@ -6590,6 +6867,7 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-10.2.0.tgz",
       "integrity": "sha512-KbU7qVfEwml8G5KFxM+xEfentAAVj/SOQSjW0+HqzjPE0cXpt0IpSamfX4jGYCImznDHgQcfXBPajS7HjLZduw==",
+      "deprecated": "This is a stub types definition. testing-library__react provides its own type definitions, so you do not need this installed.",
       "dev": true,
       "dependencies": {
         "@testing-library/react": "*"
@@ -7109,6 +7387,9 @@
       },
       "engines": {
         "node": ">= 6.9.0 || >= 8.9.0"
+      },
+      "peerDependencies": {
+        "webpack": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/@webpack-contrib/schema-utils/node_modules/ansi-regex": {
@@ -7136,6 +7417,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
       "bin": {
         "uuid": "bin/uuid"
@@ -7213,7 +7495,10 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
     },
     "node_modules/acorn-walk": {
       "version": "7.2.0",
@@ -7296,25 +7581,36 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      }
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
     },
     "node_modules/amazon-chime-sdk-js": {
-      "version": "3.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-3.0.0-beta.1.tgz",
-      "integrity": "sha512-8p5bFpwF62PWkf/XnABO6tMOp3CZBcn3Nnr9fO5X+qI4rwdCvr+qVL6Kg1gpN/vGKP888VkzmsaliNcmtUQEvg==",
+      "version": "3.0.0-beta.2",
+      "resolved": "file:../../../Users/devalevd/workplace/amazon-chime-sdk-js/amazon-chime-sdk-js-3.0.0-beta.2.tgz",
+      "integrity": "sha512-gE7kSdh7a7ycDZG6OdBrxzgEP6eloA/tVB2sMEIIXQfCi8Xv4bW1Sre6DDfFZ6Dxhhb9yoI3yhayYg8ggu+7YQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^2.0.1",
         "@aws-sdk/util-hex-encoding": "^3.47.0",
@@ -7384,6 +7680,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-escapes/node_modules/type-fest": {
@@ -7393,6 +7692,9 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-html-community": {
@@ -7564,6 +7866,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-union": {
@@ -7623,6 +7928,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.map": {
@@ -7806,6 +8114,10 @@
       },
       "bin": {
         "autoprefixer": "bin/autoprefixer"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/autoprefixer"
       }
     },
     "node_modules/aws-sign2": {
@@ -7867,6 +8179,9 @@
       },
       "engines": {
         "node": ">= 10.14.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/babel-jest/node_modules/ansi-styles": {
@@ -7879,6 +8194,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/babel-jest/node_modules/chalk": {
@@ -7892,6 +8210,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/babel-jest/node_modules/color-convert": {
@@ -7946,6 +8267,10 @@
       },
       "engines": {
         "node": ">= 8.9"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "webpack": ">=2"
       }
     },
     "node_modules/babel-loader/node_modules/find-cache-dir": {
@@ -7960,6 +8285,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
     "node_modules/babel-loader/node_modules/json5": {
@@ -7998,6 +8326,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/babel-loader/node_modules/semver": {
@@ -8023,6 +8354,13 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "7.10.4",
         "@mdx-js/util": "1.6.22"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.6"
       }
     },
     "node_modules/babel-plugin-apply-mdx-type-prop/node_modules/@babel/helper-plugin-utils": {
@@ -8065,6 +8403,10 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "7.10.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/babel-plugin-extract-import-names/node_modules/@babel/helper-plugin-utils": {
@@ -8119,7 +8461,10 @@
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.7.tgz",
       "integrity": "sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "@babel/core": "^7.1.0"
+      }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.1.8",
@@ -8130,6 +8475,9 @@
         "@babel/compat-data": "^7.13.0",
         "@babel/helper-define-polyfill-provider": "^0.1.4",
         "semver": "^6.1.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
@@ -8149,6 +8497,9 @@
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.1.4",
         "core-js-compat": "^3.8.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
@@ -8158,6 +8509,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.1.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/babel-plugin-react-docgen": {
@@ -8181,6 +8535,9 @@
         "@babel/helper-module-imports": "^7.0.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
         "lodash": "^4.17.11"
+      },
+      "peerDependencies": {
+        "styled-components": ">= 2"
       }
     },
     "node_modules/babel-plugin-syntax-jsx": {
@@ -8207,6 +8564,9 @@
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
         "@babel/plugin-syntax-top-level-await": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/babel-preset-jest": {
@@ -8220,13 +8580,20 @@
       },
       "engines": {
         "node": ">= 10.14.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/bail": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
       "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.0",
@@ -8321,7 +8688,21 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/batch-processor": {
       "version": "1.0.0",
@@ -8723,7 +9104,21 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/browserify-zlib": {
       "version": "0.2.0",
@@ -8823,6 +9218,9 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/builtin-status-codes": {
@@ -8885,6 +9283,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/c8/node_modules/cliui": {
@@ -8927,6 +9328,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/c8/node_modules/locate-path": {
@@ -8939,6 +9343,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/c8/node_modules/p-limit": {
@@ -8951,6 +9358,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/c8/node_modules/p-locate": {
@@ -8963,6 +9373,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/c8/node_modules/rimraf": {
@@ -8975,6 +9388,9 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/c8/node_modules/strip-ansi": {
@@ -9001,6 +9417,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/c8/node_modules/y18n": {
@@ -9186,6 +9605,9 @@
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-me-maybe": {
@@ -9311,7 +9733,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
       "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -9340,19 +9766,31 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
       "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/character-entities-legacy": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
       "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/character-reference-invalid": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
       "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/charcodes": {
       "version": "0.2.0",
@@ -9645,7 +10083,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
       "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.1",
@@ -9721,7 +10163,11 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
       "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "5.1.0",
@@ -9994,7 +10440,12 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.0.tgz",
       "integrity": "sha512-PyFBJaLq93FlyYdsndE5VaueA9K5cNB7CGzeCj191YYLhkQM0gdZR2SKihM70oF0wdqKSKClv/tEBOpoRmdOVQ==",
-      "dev": true
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.9.0",
@@ -10004,6 +10455,10 @@
       "dependencies": {
         "browserslist": "^4.16.3",
         "semver": "7.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-js-compat/node_modules/semver": {
@@ -10019,7 +10474,12 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.9.0.tgz",
       "integrity": "sha512-3pEcmMZC9Cq0D4ZBh3pe2HLtqxpGNJBLXF/kZ2YzK17RbKp94w0HFbdbSx8H8kAlZG5k76hvLrkPm57Uyef+kg==",
-      "dev": true
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -10557,6 +11017,9 @@
       },
       "engines": {
         "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
       }
     },
     "node_modules/css-loader/node_modules/json5": {
@@ -10702,6 +11165,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
       "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
       "dev": true,
       "dependencies": {
         "atob": "^2.1.2",
@@ -11031,6 +11495,10 @@
       "dev": true,
       "dependencies": {
         "repeat-string": "^1.5.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/detect-browser": {
@@ -11403,6 +11871,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
       }
     },
     "node_modules/emoji-regex": {
@@ -11640,6 +12111,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es5-ext": {
@@ -12547,6 +13021,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/expect/node_modules/color-convert": {
@@ -12922,6 +13399,10 @@
       "dev": true,
       "dependencies": {
         "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/fb-watchman": {
@@ -13315,6 +13796,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/find-process/node_modules/chalk": {
@@ -13328,6 +13812,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/find-process/node_modules/color-convert": {
@@ -13441,6 +13928,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
       "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==",
+      "deprecated": "flatten is deprecated in favor of utility frameworks such as lodash.",
       "dev": true
     },
     "node_modules/flow-parser": {
@@ -13889,6 +14377,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -14013,6 +14502,9 @@
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-package-type": {
@@ -14157,6 +14649,9 @@
       },
       "engines": {
         "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -14390,6 +14885,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.3",
@@ -14427,7 +14923,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
       "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
@@ -14608,7 +15107,21 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/hash.js": {
       "version": "1.1.7",
@@ -14633,6 +15146,10 @@
         "style-to-object": "^0.3.0",
         "unist-util-is": "^4.0.0",
         "web-namespaces": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/hast-util-from-parse5": {
@@ -14647,13 +15164,21 @@
         "vfile": "^4.0.0",
         "vfile-location": "^3.2.0",
         "web-namespaces": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/hast-util-parse-selector": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
       "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/hast-util-raw": {
       "version": "6.0.1",
@@ -14671,6 +15196,10 @@
         "web-namespaces": "^1.0.0",
         "xtend": "^4.0.0",
         "zwitch": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/hast-util-to-parse5": {
@@ -14684,6 +15213,10 @@
         "web-namespaces": "^1.0.0",
         "xtend": "^4.0.0",
         "zwitch": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/hastscript": {
@@ -14697,6 +15230,10 @@
         "hast-util-parse-selector": "^2.0.0",
         "property-information": "^5.0.0",
         "space-separated-tokens": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/he": {
@@ -14837,7 +15374,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.5.tgz",
       "integrity": "sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/html-webpack-plugin": {
       "version": "4.5.2",
@@ -15006,7 +15547,21 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/iferr": {
       "version": "0.1.5",
@@ -15046,6 +15601,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/import-fresh/node_modules/resolve-from": {
@@ -15254,7 +15812,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
       "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/is-alphanumerical": {
       "version": "1.0.4",
@@ -15264,6 +15826,10 @@
       "dependencies": {
         "is-alphabetical": "^1.0.0",
         "is-decimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-arguments": {
@@ -15292,7 +15858,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
       "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -15316,6 +15885,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-buffer": {
@@ -15355,6 +15927,9 @@
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-data-descriptor": {
@@ -15388,13 +15963,20 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-decimal": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
       "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/is-descriptor": {
       "version": "0.1.6",
@@ -15438,6 +16020,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-extendable": {
@@ -15498,7 +16083,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
       "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/is-installed-globally": {
       "version": "0.4.0",
@@ -15538,6 +16127,9 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-npm": {
@@ -15568,6 +16160,9 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-obj": {
@@ -15710,6 +16305,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-typedarray": {
@@ -15734,7 +16332,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
       "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
@@ -15749,7 +16351,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
       "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
@@ -15862,6 +16468,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/istanbul-lib-report/node_modules/semver": {
@@ -16006,6 +16615,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/jest-changed-files/node_modules/get-stream": {
@@ -16018,6 +16630,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-changed-files/node_modules/is-stream": {
@@ -16113,6 +16728,14 @@
       },
       "engines": {
         "node": ">= 10.14.2"
+      },
+      "peerDependencies": {
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-config/node_modules/ansi-regex": {
@@ -16134,6 +16757,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-config/node_modules/chalk": {
@@ -16147,6 +16773,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-config/node_modules/color-convert": {
@@ -16237,6 +16866,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-dev-server/node_modules/chalk": {
@@ -16316,6 +16948,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-diff/node_modules/chalk": {
@@ -16417,6 +17052,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-each/node_modules/chalk": {
@@ -16430,6 +17068,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-each/node_modules/color-convert": {
@@ -16552,6 +17193,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-environment-puppeteer/node_modules/chalk": {
@@ -16660,6 +17304,9 @@
       },
       "engines": {
         "node": ">= 10.14.2"
+      },
+      "peerDependencies": {
+        "jest": ">=20 <=26"
       }
     },
     "node_modules/jest-image-snapshot/node_modules/ansi-styles": {
@@ -16756,6 +17403,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-jasmine2/node_modules/chalk": {
@@ -16769,6 +17419,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-jasmine2/node_modules/color-convert": {
@@ -16857,6 +17510,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-leak-detector/node_modules/color-convert": {
@@ -16935,6 +17591,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-matcher-utils/node_modules/chalk": {
@@ -16948,6 +17607,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-matcher-utils/node_modules/color-convert": {
@@ -17076,6 +17738,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-message-util/node_modules/chalk": {
@@ -17089,6 +17754,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-message-util/node_modules/color-convert": {
@@ -17165,6 +17833,14 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-puppeteer": {
@@ -17175,6 +17851,9 @@
       "dependencies": {
         "expect-puppeteer": "^4.4.0",
         "jest-environment-puppeteer": "^4.4.0"
+      },
+      "peerDependencies": {
+        "puppeteer": ">= 1.5.0 < 3"
       }
     },
     "node_modules/jest-puppeteer-docker": {
@@ -17240,6 +17919,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-resolve/node_modules/chalk": {
@@ -17253,6 +17935,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-resolve/node_modules/color-convert": {
@@ -17335,6 +18020,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-runner/node_modules/chalk": {
@@ -17348,6 +18036,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-runner/node_modules/color-convert": {
@@ -17440,6 +18131,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-runtime/node_modules/chalk": {
@@ -17453,6 +18147,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-runtime/node_modules/color-convert": {
@@ -17553,6 +18250,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-snapshot/node_modules/chalk": {
@@ -17566,6 +18266,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-snapshot/node_modules/color-convert": {
@@ -17682,6 +18385,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-util/node_modules/chalk": {
@@ -17695,6 +18401,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-util/node_modules/color-convert": {
@@ -17772,6 +18481,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-validate/node_modules/camelcase": {
@@ -17781,6 +18493,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-validate/node_modules/chalk": {
@@ -17794,6 +18509,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-validate/node_modules/color-convert": {
@@ -17887,6 +18605,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-watcher/node_modules/chalk": {
@@ -17900,6 +18621,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-watcher/node_modules/color-convert": {
@@ -17986,6 +18710,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest/node_modules/chalk": {
@@ -17999,6 +18726,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest/node_modules/color-convert": {
@@ -18431,6 +19161,14 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsdom/node_modules/parse5": {
@@ -18840,6 +19578,10 @@
       "dependencies": {
         "fault": "^1.0.0",
         "highlight.js": "~10.6.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/lru-cache": {
@@ -18946,7 +19688,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
       "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/markdown-to-jsx": {
       "version": "7.1.6",
@@ -18978,6 +19724,10 @@
       "dev": true,
       "dependencies": {
         "unist-util-remove": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdast-util-definitions": {
@@ -18987,6 +19737,10 @@
       "dev": true,
       "dependencies": {
         "unist-util-visit": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdast-util-to-hast": {
@@ -19003,13 +19757,21 @@
         "unist-util-generated": "^1.0.0",
         "unist-util-position": "^3.0.0",
         "unist-util-visit": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdast-util-to-string": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
       "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/mdurl": {
       "version": "1.0.1",
@@ -19245,6 +20007,9 @@
       },
       "engines": {
         "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.4.0"
       }
     },
     "node_modules/mini-css-extract-plugin/node_modules/json5": {
@@ -19791,6 +20556,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm-run-path": {
@@ -19854,7 +20622,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19949,6 +20716,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.entries": {
@@ -19978,6 +20748,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.getownpropertydescriptors": {
@@ -20094,6 +20867,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/open": {
@@ -20187,6 +20963,9 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-event": {
@@ -20244,6 +21023,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate": {
@@ -20379,6 +21161,10 @@
         "is-alphanumerical": "^1.0.0",
         "is-decimal": "^1.0.0",
         "is-hexadecimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/parse-json": {
@@ -20394,6 +21180,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parse-passwd": {
@@ -21001,6 +21790,10 @@
       },
       "engines": {
         "node": ">= 4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-load-config/node_modules/cosmiconfig": {
@@ -21505,6 +22298,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/pretty-format/node_modules/chalk": {
@@ -21732,6 +22528,10 @@
       "dev": true,
       "dependencies": {
         "xtend": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/protobufjs": {
@@ -21894,7 +22694,9 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-2.1.1.tgz",
       "integrity": "sha512-LWzaDVQkk1EPiuYeTOj+CZRIjda4k2s5w4MK4xoH2+kgWV/SDlkYHmxatDdtYrciHUKSXTsGgPgPP8ILVdBsxg==",
+      "deprecated": "Version no longer supported. Upgrade to @latest",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "@types/mime-types": "^2.1.0",
         "debug": "^4.1.0",
@@ -21990,6 +22792,9 @@
       },
       "engines": {
         "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/qss": {
@@ -22014,12 +22819,16 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
@@ -22038,7 +22847,21 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
       "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/ramda": {
       "version": "0.21.0",
@@ -22164,7 +22987,6 @@
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.1.tgz",
       "integrity": "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -22189,7 +23011,11 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.1.4.tgz",
       "integrity": "sha512-WOEpRNz8Oo2SEU4eYQ279jEKFSjpFPa9Vi2U/K0DGwP9wOQ8wYkJcNSd5Qbv1L8OFvyKDCbWekjftXaU5mbmtg==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
     },
     "node_modules/react-docgen": {
       "version": "5.4.0",
@@ -22219,7 +23045,10 @@
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-1.21.0.tgz",
       "integrity": "sha512-E4y/OcXwHukgiVafCGlxwoNHr4BDmM70Ww7oimL/QkMo5dmGALhceewe/xmVjdMxxI7E5syOGOc9/tbHL742rg==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "typescript": ">= 3.x"
+      }
     },
     "node_modules/react-docgen-typescript-loader": {
       "version": "3.7.2",
@@ -22230,6 +23059,9 @@
         "@webpack-contrib/schema-utils": "^1.0.0-beta.0",
         "loader-utils": "^1.2.3",
         "react-docgen-typescript": "^1.15.0"
+      },
+      "peerDependencies": {
+        "typescript": "*"
       }
     },
     "node_modules/react-docgen-typescript-loader/node_modules/json5": {
@@ -22273,6 +23105,9 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "scheduler": "^0.20.1"
+      },
+      "peerDependencies": {
+        "react": "17.0.1"
       }
     },
     "node_modules/react-draggable": {
@@ -22358,6 +23193,9 @@
       "dev": true,
       "dependencies": {
         "prop-types": "^15.5.8"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0"
       }
     },
     "node_modules/react-is": {
@@ -22395,6 +23233,10 @@
       "dependencies": {
         "react-fast-compare": "^3.0.1",
         "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.0.0",
+        "react": "^16.8.0 || ^17"
       }
     },
     "node_modules/react-popper-tooltip": {
@@ -22479,6 +23321,10 @@
         "prop-types": "^15.6.0",
         "react-input-autosize": "^3.0.0",
         "react-transition-group": "^4.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/react-sizeme": {
@@ -22491,6 +23337,10 @@
         "invariant": "^2.2.4",
         "shallowequal": "^1.1.0",
         "throttle-debounce": "^3.0.1"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0-0 || ^16.0.0 || ^17.0.0",
+        "react-dom": "^0.14.0 || ^15.0.0-0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/react-sizeme/node_modules/throttle-debounce": {
@@ -22513,6 +23363,9 @@
         "lowlight": "^1.14.0",
         "prismjs": "^1.21.0",
         "refractor": "^3.1.0"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
       }
     },
     "node_modules/react-textarea-autosize": {
@@ -22542,6 +23395,10 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/read-pkg": {
@@ -22571,6 +23428,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg-up/node_modules/type-fest": {
@@ -22748,6 +23608,9 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/regexpp": {
@@ -22850,13 +23713,21 @@
         "mdast-util-definitions": "^4.0.0",
         "space-separated-tokens": "^1.0.0",
         "unist-util-visit": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-footnotes": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/remark-footnotes/-/remark-footnotes-2.0.0.tgz",
       "integrity": "sha512-3Clt8ZMH75Ayjp9q4CorNeyjwIxHFcTkaektplKGl2A1jNGEUey8cKL0ZC5vJwfcD5GFGsNLImLG/NGzWIzoMQ==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/remark-mdx": {
       "version": "1.6.22",
@@ -22872,6 +23743,10 @@
         "is-alphabetical": "1.0.4",
         "remark-parse": "8.0.3",
         "unified": "9.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-mdx/node_modules/@babel/core": {
@@ -22899,6 +23774,10 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
       }
     },
     "node_modules/remark-mdx/node_modules/@babel/helper-plugin-utils": {
@@ -22916,6 +23795,9 @@
         "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
         "@babel/plugin-transform-parameters": "^7.12.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/remark-mdx/node_modules/@babel/plugin-syntax-jsx": {
@@ -22925,6 +23807,9 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/remark-mdx/node_modules/semver": {
@@ -22958,6 +23843,10 @@
         "unist-util-remove-position": "^2.0.0",
         "vfile-location": "^3.0.0",
         "xtend": "^4.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-slug": {
@@ -22969,6 +23858,10 @@
         "github-slugger": "^1.0.0",
         "mdast-util-to-string": "^1.0.0",
         "unist-util-visit": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-squeeze-paragraphs": {
@@ -22978,6 +23871,10 @@
       "dev": true,
       "dependencies": {
         "mdast-squeeze-paragraphs": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remove-trailing-separator": {
@@ -23021,6 +23918,7 @@
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -23058,12 +23956,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
       }
     },
     "node_modules/request-promise-native": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
       "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
       "dev": true,
       "dependencies": {
         "request-promise-core": "1.1.4",
@@ -23072,6 +23974,9 @@
       },
       "engines": {
         "node": ">=0.12.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
       }
     },
     "node_modules/request-promise-native/node_modules/tough-cookie": {
@@ -23127,6 +24032,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
       "bin": {
         "uuid": "bin/uuid"
@@ -23176,6 +24082,9 @@
       "dependencies": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-cwd": {
@@ -23246,6 +24155,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "dev": true
     },
     "node_modules/responselike": {
@@ -23317,7 +24227,10 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz",
       "integrity": "sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "rollup": "*"
+      }
     },
     "node_modules/rollup-plugin-typescript2": {
       "version": "0.27.3",
@@ -23330,6 +24243,10 @@
         "fs-extra": "8.1.0",
         "resolve": "1.17.0",
         "tslib": "2.0.1"
+      },
+      "peerDependencies": {
+        "rollup": ">=1.26.3",
+        "typescript": ">=2.4.0"
       }
     },
     "node_modules/rollup-plugin-typescript2/node_modules/find-cache-dir": {
@@ -23344,6 +24261,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
     "node_modules/rollup-plugin-typescript2/node_modules/fs-extra": {
@@ -23365,7 +24285,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
+      "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
     },
@@ -23379,6 +24299,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/rollup-plugin-typescript2/node_modules/resolve": {
@@ -23388,6 +24311,9 @@
       "dev": true,
       "dependencies": {
         "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/rollup-plugin-typescript2/node_modules/semver": {
@@ -23428,6 +24354,20 @@
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
@@ -23487,6 +24427,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
       "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+      "deprecated": "some dependency vulnerabilities fixed, support for node < 10 dropped, and newer ECMAScript syntax/features added",
       "dev": true,
       "dependencies": {
         "@cnakazawa/watch": "^1.0.3",
@@ -23692,6 +24633,10 @@
       },
       "engines": {
         "node": ">= 8.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/semver": {
@@ -23990,6 +24935,9 @@
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -24258,6 +25206,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
       "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
       "dev": true,
       "dependencies": {
         "atob": "^2.1.2",
@@ -24290,6 +25239,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
       "dev": true
     },
     "node_modules/sourcemap-codec": {
@@ -24302,7 +25252,11 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
       "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/spawnd": {
       "version": "4.4.0",
@@ -24636,7 +25590,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
       "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/static-extend": {
       "version": "0.1.2",
@@ -24906,6 +25864,9 @@
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
@@ -24916,6 +25877,9 @@
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -24976,6 +25940,9 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/style-loader": {
@@ -25059,13 +26026,27 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0",
+        "react-is": ">= 16.8.0"
       }
     },
     "node_modules/styled-react-modal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/styled-react-modal/-/styled-react-modal-2.0.1.tgz",
       "integrity": "sha512-uoyPlwdM8FLmdOE8dvA3iv2IOnlqMsygPxLAZy8WaK0pEcon67+SWJY/osAWZuBvRKtSo/VXn1fRCYVgbD0KUQ==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "react": "^16.9.0",
+        "react-dom": "^16.9.0",
+        "styled-components": "^5.0.1"
+      }
     },
     "node_modules/styled-system": {
       "version": "5.1.5",
@@ -25301,6 +26282,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/terser": {
@@ -25715,13 +26699,21 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz",
       "integrity": "sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/trough": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/ts-dedent": {
       "version": "2.0.0",
@@ -25761,6 +26753,10 @@
       },
       "engines": {
         "node": ">= 10"
+      },
+      "peerDependencies": {
+        "jest": ">=26 <27",
+        "typescript": ">=3.8 <5.0"
       }
     },
     "node_modules/ts-jest/node_modules/@types/jest": {
@@ -25792,6 +26788,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/ts-jest/node_modules/chalk": {
@@ -25805,6 +26804,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/ts-jest/node_modules/color-convert": {
@@ -25917,6 +26919,9 @@
       },
       "engines": {
         "node": ">=8.6"
+      },
+      "peerDependencies": {
+        "typescript": "*"
       }
     },
     "node_modules/ts-loader/node_modules/json5": {
@@ -26129,6 +27134,9 @@
         "has-bigints": "^1.0.1",
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/unfetch": {
@@ -26145,6 +27153,10 @@
       "dependencies": {
         "inherits": "^2.0.0",
         "xtend": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -26199,6 +27211,10 @@
         "is-plain-obj": "^2.0.0",
         "trough": "^1.0.0",
         "vfile": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/unified/node_modules/is-buffer": {
@@ -26206,6 +27222,20 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
       "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "engines": {
         "node": ">=4"
       }
@@ -26265,25 +27295,41 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-2.0.3.tgz",
       "integrity": "sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/unist-util-generated": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.6.tgz",
       "integrity": "sha512-cln2Mm1/CZzN5ttGK7vkoGw+RZ8VcUH6BtGbq98DDtRGquAAOXig1mrBQYelOwMXYS8rK+vZDyyojSjp7JX+Lg==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/unist-util-is": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.4.tgz",
       "integrity": "sha512-3dF39j/u423v4BBQrk1AQ2Ve1FxY5W3JKwXxVFzBODQ6WEvccguhgp802qQLKSnxPODE6WuRZtV+ohlUg4meBA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/unist-util-position": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
       "integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/unist-util-remove": {
       "version": "2.0.1",
@@ -26292,6 +27338,10 @@
       "dev": true,
       "dependencies": {
         "unist-util-is": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/unist-util-remove-position": {
@@ -26301,6 +27351,10 @@
       "dev": true,
       "dependencies": {
         "unist-util-visit": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/unist-util-stringify-position": {
@@ -26310,6 +27364,10 @@
       "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/unist-util-visit": {
@@ -26321,6 +27379,10 @@
         "@types/unist": "^2.0.0",
         "unist-util-is": "^4.0.0",
         "unist-util-visit-parents": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/unist-util-visit-parents": {
@@ -26331,6 +27393,10 @@
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/universalify": {
@@ -26530,6 +27596,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "deprecated": "Please see https://github.com/lydell/urix#deprecated",
       "dev": true
     },
     "node_modules/url": {
@@ -26554,6 +27621,15 @@
       },
       "engines": {
         "node": ">= 8.9.0"
+      },
+      "peerDependencies": {
+        "file-loader": "*",
+        "webpack": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "file-loader": {
+          "optional": true
+        }
       }
     },
     "node_modules/url-loader/node_modules/json5": {
@@ -26637,13 +27713,24 @@
       "dev": true,
       "dependencies": {
         "ts-essentials": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/use-isomorphic-layout-effect": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
       "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/use-latest": {
       "version": "1.2.0",
@@ -26652,6 +27739,14 @@
       "dev": true,
       "dependencies": {
         "use-isomorphic-layout-effect": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util": {
@@ -26780,13 +27875,21 @@
         "is-buffer": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0",
         "vfile-message": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vfile-location": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.2.0.tgz",
       "integrity": "sha512-aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/vfile-message": {
       "version": "2.0.4",
@@ -26796,6 +27899,10 @@
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vfile/node_modules/is-buffer": {
@@ -26803,6 +27910,20 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
       "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "engines": {
         "node": ">=4"
       }
@@ -26857,7 +27978,9 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "dev": true
+      "deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
+      "dev": true,
+      "hasInstallScript": true
     },
     "node_modules/wait-port": {
       "version": "0.2.9",
@@ -26905,11 +28028,11 @@
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dev": true,
       "dependencies": {
-        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
+        "chokidar": "^3.4.1",
         "watchpack-chokidar2": "^2.0.1"
       }
     },
@@ -26996,13 +28119,13 @@
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
       "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+      "deprecated": "Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies",
       "dev": true,
       "optional": true,
       "dependencies": {
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -27011,6 +28134,9 @@
         "path-is-absolute": "^1.0.0",
         "readdirp": "^2.2.1",
         "upath": "^1.1.1"
+      },
+      "optionalDependencies": {
+        "fsevents": "^1.2.7"
       }
     },
     "node_modules/watchpack-chokidar2/node_modules/fill-range": {
@@ -27046,6 +28172,7 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -27167,7 +28294,11 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
       "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
@@ -27213,6 +28344,18 @@
       },
       "engines": {
         "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        },
+        "webpack-command": {
+          "optional": true
+        }
       }
     },
     "node_modules/webpack-cli": {
@@ -27238,6 +28381,9 @@
       },
       "engines": {
         "node": ">=6.11.5"
+      },
+      "peerDependencies": {
+        "webpack": "4.x.x"
       }
     },
     "node_modules/webpack-cli/node_modules/ansi-regex": {
@@ -28036,6 +29182,9 @@
       },
       "engines": {
         "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
       }
     },
     "node_modules/webpack/node_modules/to-regex-range": {
@@ -28109,6 +29258,9 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/which-module": {
@@ -28204,6 +29356,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/wrap-ansi/node_modules/color-convert": {
@@ -28261,6 +29416,18 @@
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xdg-basedir": {
@@ -28366,13 +29533,20 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zwitch": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
       "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
-      "dev": true
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     }
   },
   "dependencies": {
@@ -30600,7 +31774,8 @@
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
       "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@mdx-js/util": {
       "version": "1.6.22",
@@ -33957,7 +35132,8 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -34034,18 +35210,19 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "amazon-chime-sdk-js": {
-      "version": "3.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-3.0.0-beta.1.tgz",
-      "integrity": "sha512-8p5bFpwF62PWkf/XnABO6tMOp3CZBcn3Nnr9fO5X+qI4rwdCvr+qVL6Kg1gpN/vGKP888VkzmsaliNcmtUQEvg==",
+      "version": "file:/Users/devalevd/workplace/amazon-chime-sdk-js/amazon-chime-sdk-js-3.0.0-beta.2.tgz",
+      "integrity": "sha512-gE7kSdh7a7ycDZG6OdBrxzgEP6eloA/tVB2sMEIIXQfCi8Xv4bW1Sre6DDfFZ6Dxhhb9yoI3yhayYg8ggu+7YQ==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-js": "^2.0.1",
@@ -34700,7 +35877,8 @@
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.7.tgz",
       "integrity": "sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.1.8",
@@ -42080,7 +43258,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-puppeteer": {
       "version": "4.4.0",
@@ -44227,8 +45406,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -46095,7 +47273,6 @@
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.1.tgz",
       "integrity": "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -46117,7 +47294,8 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.1.4.tgz",
       "integrity": "sha512-WOEpRNz8Oo2SEU4eYQ279jEKFSjpFPa9Vi2U/K0DGwP9wOQ8wYkJcNSd5Qbv1L8OFvyKDCbWekjftXaU5mbmtg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react-docgen": {
       "version": "5.4.0",
@@ -46149,7 +47327,8 @@
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-1.21.0.tgz",
       "integrity": "sha512-E4y/OcXwHukgiVafCGlxwoNHr4BDmM70Ww7oimL/QkMo5dmGALhceewe/xmVjdMxxI7E5syOGOc9/tbHL742rg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react-docgen-typescript-loader": {
       "version": "3.7.2",
@@ -47072,7 +48251,8 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz",
       "integrity": "sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "rollup-plugin-typescript2": {
       "version": "0.27.3",
@@ -48522,7 +49702,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/styled-react-modal/-/styled-react-modal-2.0.1.tgz",
       "integrity": "sha512-uoyPlwdM8FLmdOE8dvA3iv2IOnlqMsygPxLAZy8WaK0pEcon67+SWJY/osAWZuBvRKtSo/VXn1fRCYVgbD0KUQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "styled-system": {
       "version": "5.1.5",
@@ -49773,7 +50954,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
       "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "use-latest": {
       "version": "1.2.0",
@@ -51136,7 +52318,8 @@
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "add": "^2.0.6",
-    "amazon-chime-sdk-js": "^3.0.0-beta.1",
+    "amazon-chime-sdk-js": "file:/Users/devalevd/workplace/amazon-chime-sdk-js/amazon-chime-sdk-js-3.0.0-beta.2.tgz",
     "babel-loader": "^8.1.0",
     "css-loader": "^2.1.1",
     "eslint": "^7.32.0",
@@ -121,7 +121,7 @@
     "webpack-cli": "^3.3.2"
   },
   "peerDependencies": {
-    "amazon-chime-sdk-js": "^3.0.0-beta.1",
+    "amazon-chime-sdk-js": "file:/Users/devalevd/workplace/amazon-chime-sdk-js/amazon-chime-sdk-js-3.0.0-beta.2.tgz",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "styled-components": "^5.0.0",

--- a/src/components/sdk/DeviceSelection/CameraSelection/BackgroundBlurCheckbox.tsx
+++ b/src/components/sdk/DeviceSelection/CameraSelection/BackgroundBlurCheckbox.tsx
@@ -9,6 +9,7 @@ import {
 import React, { useEffect, useState } from 'react';
 
 import { useBackgroundBlur } from '../../../../providers/BackgroundBlurProvider';
+import { useLogger } from '../../../../providers/LoggerProvider';
 import { useMeetingManager } from '../../../../providers/MeetingProvider';
 import { Checkbox } from '../../../ui/Checkbox';
 import { FormField } from '../../../ui/FormField';
@@ -23,6 +24,7 @@ export const BackgroundBlurCheckbox: React.FC<Props> = ({
   label = 'Blur my background',
   ...rest
 }) => {
+  const logger = useLogger();
   const { isBackgroundBlurSupported, createBackgroundBlurDevice } =
     useBackgroundBlur();
   const [isLoading, setIsLoading] = useState(false);
@@ -50,7 +52,7 @@ export const BackgroundBlurCheckbox: React.FC<Props> = ({
         const transformedVideoDevice = await createBackgroundBlurDevice(device);
         await meetingManager.selectVideoInputDevice(transformedVideoDevice);
       } else {
-        meetingManager.logger?.warn(
+        logger.warn(
           'Background blur processor is not supported yet.'
         );
       }

--- a/src/components/sdk/MeetingControls/AudioInputVFControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioInputVFControl.tsx
@@ -14,6 +14,7 @@ import { PopOverSeparator } from '../../..';
 import { useToggleLocalMute } from '../../../hooks/sdk/useToggleLocalMute';
 import { useAudioVideo } from '../../../providers/AudioVideoProvider';
 import { useAudioInputs } from '../../../providers/DevicesProvider';
+import { useLogger } from '../../../providers/LoggerProvider';
 import { useMeetingManager } from '../../../providers/MeetingProvider';
 import { useVoiceFocus } from '../../../providers/VoiceFocusProvider';
 import { DeviceConfig, DeviceType } from '../../../types';
@@ -55,6 +56,7 @@ const AudioInputVFControl: React.FC<Props> = ({
   appendSampleDevices = true,
   ...rest
 }) => {
+  const logger = useLogger();
   const audioVideo = useAudioVideo();
   const meetingManager = useMeetingManager();
   const [isLoading, setIsLoading] = useState(false);
@@ -92,7 +94,7 @@ const AudioInputVFControl: React.FC<Props> = ({
   }, []);
 
   useEffect(() => {
-    console.info(
+    logger.info(
       `Amazon Voice Focus is ${isVoiceFocusEnabled ? 'enabled' : 'disabled'}.`
     );
   }, [isVoiceFocusEnabled]);
@@ -177,13 +179,13 @@ const AudioInputVFControl: React.FC<Props> = ({
     async function onVFCheckboxChange() {
       let current = device;
       if (isVoiceFocusChecked) {
-        console.info('User turned on Amazon Voice Focus.');
+        logger.info('User turned on Amazon Voice Focus.');
         if (typeof device === 'string') {
           const currentDevice = audioInputSelectionToDevice(device);
           current = await addVoiceFocus(currentDevice);
         }
       } else {
-        console.info(
+        logger.info(
           'Amazon Voice Focus is off by default or user turned off Amazon Voice Focus.'
         );
         if (device instanceof VoiceFocusTransformDevice) {

--- a/src/components/sdk/MeetingControls/VideoInputBackgroundBlurControl.tsx
+++ b/src/components/sdk/MeetingControls/VideoInputBackgroundBlurControl.tsx
@@ -12,6 +12,7 @@ import React, { ReactNode, useEffect, useState } from 'react';
 import { useBackgroundBlur } from '../../../providers/BackgroundBlurProvider';
 import { useVideoInputs } from '../../../providers/DevicesProvider';
 import { useLocalVideo } from '../../../providers/LocalVideoProvider';
+import { useLogger } from '../../../providers/LoggerProvider';
 import { useMeetingManager } from '../../../providers/MeetingProvider';
 import { DeviceType } from '../../../types';
 import {
@@ -37,6 +38,7 @@ const VideoInputBackgroundBlurControl: React.FC<Props> = ({
   backgroundBlurLabel = 'Enable Background Blur',
   ...rest
 }) => {
+  const logger = useLogger();
   const meetingManager = useMeetingManager();
   const { devices, selectedDevice } = useVideoInputs();
   const { isVideoEnabled, toggleVideo } = useLocalVideo();
@@ -73,14 +75,14 @@ const VideoInputBackgroundBlurControl: React.FC<Props> = ({
     if (!isVideoTransformDevice(current)) {
       // Enable video transform on the non-transformed device
       current = await createBackgroundBlurDevice(current);
-      meetingManager.logger?.info(
+      logger.info(
         'Video filter turned on - selecting video transform device: ' +
           JSON.stringify(current)
       );
     } else {
       // switch back to the inner device
       current = await current.intrinsicDevice();
-      meetingManager.logger?.info(
+      logger.info(
         'Video filter was turned off - selecting inner device: ' +
           JSON.stringify(current)
       );
@@ -109,7 +111,7 @@ const VideoInputBackgroundBlurControl: React.FC<Props> = ({
                 activeVideoDevice.chooseNewInnerDevice(receivedDevice);
               await meetingManager.selectVideoInputDevice(transformedDevice);
             } else {
-              meetingManager.logger?.error(
+              logger.error(
                 'Transform device cannot choose new inner device'
               );
             }

--- a/src/components/ui/Modal/ModalButtonGroup.tsx
+++ b/src/components/ui/Modal/ModalButtonGroup.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, HTMLAttributes, ReactElement } from 'react';
+import { useLogger } from '../../../providers/LoggerProvider';
 
 import { BaseProps } from '../Base';
 import { useModalContext } from './ModalContext';
@@ -21,6 +22,7 @@ export const ModalButtonGroup: FC<ModalButtonGroupProps> = ({
   secondaryButtons,
   ...rest
 }) => {
+  const logger = useLogger();
   const context = useModalContext();
 
   const addCloseBehaviorToButton = (button: any) => {
@@ -40,7 +42,7 @@ export const ModalButtonGroup: FC<ModalButtonGroupProps> = ({
       (buttons instanceof Array && buttons.length === 0)
     ) {
       context.dismissible &&
-        console.warn(
+        logger.warn(
           "the 'dismissible prop prevents buttons from closing the modal"
         );
       return buttons;

--- a/src/components/ui/WithTooltip/index.tsx
+++ b/src/components/ui/WithTooltip/index.tsx
@@ -3,6 +3,7 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
+import { useLogger } from '../../../providers/LoggerProvider';
 
 import { StyledTooltip } from './Styled';
 
@@ -38,6 +39,7 @@ export const WithTooltip =
     container_id?: string
   ) =>
   (props: P & ToolTipProps) => {
+    const logger = useLogger();
     const [{ show, bounds }, setShow] =
       useState<WithTooltipState>(initialState);
     const [container, setContainer] = useState<HTMLElement | null>(null);
@@ -70,7 +72,7 @@ export const WithTooltip =
       );
 
       if (!container) {
-        console.warn(`
+        logger.warn(`
         Attempted to use 'WithTooltip' but could not find container element.
         Pass a valid element ID or add 'Tooltip__container' ID to existing element
       `);

--- a/src/hooks/sdk/useSelectVideoQuality.tsx
+++ b/src/hooks/sdk/useSelectVideoQuality.tsx
@@ -4,10 +4,12 @@
 import { useCallback } from 'react';
 
 import { useAudioVideo } from '../../providers/AudioVideoProvider';
+import { useLogger } from '../../providers/LoggerProvider';
 
 export type VideoQuality = '360p' | '540p' | '720p';
 
 export function useSelectVideoQuality() {
+  const logger = useLogger();
   const audioVideo = useAudioVideo();
 
   const selectVideoQuality = useCallback(
@@ -16,7 +18,7 @@ export function useSelectVideoQuality() {
         return;
       }
 
-      console.log(`Selecting video quality: ${quality}`);
+      logger.info(`Selecting video quality: ${quality}`);
 
       switch (quality) {
         case '360p':
@@ -29,7 +31,7 @@ export function useSelectVideoQuality() {
           audioVideo.chooseVideoInputQuality(1280, 720, 15, 1400);
           break;
         default:
-          console.log(`Unsupported video quality: ${quality}`);
+          logger.info(`Unsupported video quality: ${quality}`);
       }
     },
     [audioVideo]

--- a/src/index.ts
+++ b/src/index.ts
@@ -165,7 +165,6 @@ export { FeaturedVideoTileProvider } from './providers/FeaturedVideoTileProvider
 export { VoiceFocusProvider } from './providers/VoiceFocusProvider';
 export { BackgroundBlurProvider } from './providers/BackgroundBlurProvider';
 export { BackgroundReplacementProvider } from './providers/BackgroundReplacementProvider';
-
 export {
   UserActivityProvider,
   useUserActivityState,
@@ -174,6 +173,11 @@ export {
   useMeetingEvent,
   MeetingEventProvider,
 } from './providers/MeetingEventProvider';
+export {
+  LoggerContext,
+  LoggerProvider,
+  useLogger,
+} from './providers/LoggerProvider';
 
 // Themes
 export { lightTheme, darkTheme, GlobalStyles, StyledReset } from './theme';

--- a/src/providers/BackgroundBlurProvider/index.tsx
+++ b/src/providers/BackgroundBlurProvider/index.tsx
@@ -24,6 +24,7 @@ import React, {
 import { BaseSdkProps } from '../../components/sdk/Base';
 import { isPrevNextEmpty, isPrevNextUndefined } from '../../utils/device-utils';
 import useMemoCompare from '../../utils/use-memo-compare';
+import { useLogger } from '../LoggerProvider';
 
 interface Props extends BaseSdkProps {
   /** The spec defines the assets that will be used for adding background blur to a frame. For more information, refer to
@@ -46,6 +47,7 @@ const BackgroundBlurProviderContext = createContext<
 >(undefined);
 
 const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
+  const logger = useLogger();
   const [isBackgroundBlurSupported, setIsBackgroundBlurSupported] = useState<
     boolean | undefined
   >(undefined);
@@ -88,7 +90,7 @@ const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
   useEffect(() => {
     initializeBackgroundBlur();
     return () => {
-      console.log(
+      logger.info(
         'Specs or options were changed. Destroying and re-initializing background blur processor.'
       );
       processor?.destroy();
@@ -98,7 +100,7 @@ const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
   async function initializeBackgroundBlur(): Promise<
     BackgroundBlurProcessor | undefined
   > {
-    console.log('Initializing background blur processor with', spec, options);
+    logger.info(`Initializing background blur processor with, ${JSON.stringify(spec)}, ${JSON.stringify(options)}`);
 
     try {
       const createdProcessor = await BackgroundBlurVideoFrameProcessor.create(
@@ -110,12 +112,12 @@ const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
       // BackgroundBlurVideoFrameProcessor.create() can also throw an error in case loading
       // the assets are not fetched successfully.
       if (createdProcessor instanceof NoOpVideoFrameProcessor) {
-        console.warn(`Initialized NoOpVideoFrameProcessor.`);
+        logger.info(`Initialized NoOpVideoFrameProcessor.`);
         setProcessor(undefined);
         setIsBackgroundBlurSupported(false);
         return undefined;
       } else {
-        console.log(
+        logger.info(
           `Initialized background blur processor: ${JSON.stringify(
             createdProcessor
           )}`
@@ -125,9 +127,9 @@ const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
         return createdProcessor;
       }
     } catch (error) {
-      console.error(
-        `Error creating a background blur video frame processor device`,
-        error
+      logger.error(
+        `Error creating a background blur video frame processor device,
+        ${error}`
       );
       setProcessor(undefined);
       setIsBackgroundBlurSupported(false);
@@ -138,7 +140,7 @@ const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
   const createBackgroundBlurDevice = async (
     selectedDevice: Device
   ): Promise<DefaultVideoTransformDevice> => {
-    console.log(
+    logger.info(
       `Calling createBackgroundBlurDevice with device: ${JSON.stringify(
         selectedDevice
       )}`
@@ -154,7 +156,7 @@ const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
           selectedDevice,
           [currentProcessor]
         );
-        console.log(
+        logger.info(
           `Created video transform device ${JSON.stringify(
             chosenVideoTransformDevice,
             null,

--- a/src/providers/DevicesProvider/AudioInputProvider.tsx
+++ b/src/providers/DevicesProvider/AudioInputProvider.tsx
@@ -19,6 +19,7 @@ import { AUDIO_INPUT } from '../../constants/additional-audio-video-devices';
 import { DeviceConfig, DeviceTypeContext } from '../../types';
 import { getFormattedDropdownDeviceOptions } from '../../utils/device-utils';
 import { useAudioVideo } from '../AudioVideoProvider';
+import { useLogger } from '../LoggerProvider';
 import { useMeetingManager } from '../MeetingProvider';
 
 interface Props {
@@ -34,6 +35,7 @@ const AudioInputProvider: React.FC<Props> = ({
   children,
   onDeviceReplacement,
 }) => {
+  const logger = useLogger();
   const meetingManager = useMeetingManager();
   const audioVideo = useAudioVideo();
   const [audioInputs, setAudioInputs] = useState<MediaDeviceInfo[]>([]);
@@ -86,7 +88,7 @@ const AudioInputProvider: React.FC<Props> = ({
 
     const observer: DeviceChangeObserver = {
       audioInputsChanged: async (newAudioInputs: MediaDeviceInfo[]) => {
-        console.log('AudioInputProvider - audio inputs updated');
+        logger.info('AudioInputProvider - audio inputs updated');
 
         const hasSelectedDevice = newAudioInputs.some(
           (device) => device.deviceId === selectedInputRef.current
@@ -98,7 +100,7 @@ const AudioInputProvider: React.FC<Props> = ({
           !hasSelectedDevice &&
           newAudioInputs.length
         ) {
-          console.log(
+          logger.info(
             'Previously selected audio input lost. Selecting a default device.'
           );
           nextInput = newAudioInputs[0].deviceId;
@@ -106,7 +108,7 @@ const AudioInputProvider: React.FC<Props> = ({
           // Safari and Firefox don't have this "default" as device Id
           // Only Chrome have this "default" device
         } else if (selectedInputRef.current === 'default') {
-          console.log(
+          logger.info(
             `Audio devices updated and "default" device is selected. Reselecting input.`
           );
         }
@@ -115,7 +117,7 @@ const AudioInputProvider: React.FC<Props> = ({
         try {
           await meetingManager.selectAudioInputDevice(nextDevice);
         } catch (e) {
-          console.error(`Error in selecting audio input device - ${e}`);
+          logger.error(`Error in selecting audio input device - ${e}`);
         }
 
         setAudioInputs(newAudioInputs);

--- a/src/providers/LocalAudioOutputProvider/index.tsx
+++ b/src/providers/LocalAudioOutputProvider/index.tsx
@@ -13,10 +13,12 @@ import React, {
 
 import { LocalAudioOutputContextType } from '../../types';
 import { useAudioVideo } from '../AudioVideoProvider';
+import { useLogger } from '../LoggerProvider';
 
 const Context = createContext<LocalAudioOutputContextType | null>(null);
 
 const LocalAudioOutputProvider: React.FC = ({ children }) => {
+  const logger = useLogger();
   const audioVideo = useAudioVideo();
   const [isAudioOn, setIsAudioOn] = useState(true);
   const audioRef = useRef<HTMLAudioElement>(null);
@@ -31,7 +33,7 @@ const LocalAudioOutputProvider: React.FC = ({ children }) => {
         try {
           await audioVideo.bindAudioElement(element);
         } catch (e) {
-          console.error('Failed to bind audio element.', e);
+          logger.error(`Failed to bind audio element., ${e}`);
         }
       })(audioRef.current);
     }
@@ -53,7 +55,7 @@ const LocalAudioOutputProvider: React.FC = ({ children }) => {
         try {
           await audioVideo?.bindAudioElement(element);
         } catch (e) {
-          console.error('Failed to bind audio element.', e);
+          logger.error(`Failed to bind audio element., ${e}`);
         }
       })(audioRef.current);
     }

--- a/src/providers/LocalVideoProvider/index.tsx
+++ b/src/providers/LocalVideoProvider/index.tsx
@@ -13,11 +13,13 @@ import React, {
 
 import { LocalVideoContextType } from '../../types';
 import { useAudioVideo } from '../AudioVideoProvider';
+import { useLogger } from '../LoggerProvider';
 import { useMeetingManager } from '../MeetingProvider';
 
 const Context = createContext<LocalVideoContextType | null>(null);
 
 const LocalVideoProvider: React.FC = ({ children }) => {
+  const logger = useLogger();
   const meetingManager = useMeetingManager();
   const audioVideo = useAudioVideo();
   const [isVideoEnabled, setIsVideoEnabled] = useState(false);
@@ -40,9 +42,9 @@ const LocalVideoProvider: React.FC = ({ children }) => {
         } else {
           setHasReachedVideoLimit(false);
         }
-        console.log(
-          'video availability changed: canStartLocalVideo ',
-          availability.canStartLocalVideo
+        logger.info(
+          `video availability changed: canStartLocalVideo ,
+          ${availability.canStartLocalVideo}`
         );
       },
     };
@@ -56,14 +58,14 @@ const LocalVideoProvider: React.FC = ({ children }) => {
 
   useEffect(() => {
     if (hasReachedVideoLimit) {
-      console.warn('Reach the number of maximum active videos');
+      logger.warn('Reach the number of maximum active videos');
     }
   }, [hasReachedVideoLimit]);
 
   const toggleVideo = useCallback(async (): Promise<void> => {
     if (isVideoEnabled || !meetingManager.selectedVideoInputTransformDevice) {
       if (!meetingManager.selectedVideoInputTransformDevice) {
-        console.warn('There is no input video device chosen!');
+        logger.warn('There is no input video device chosen!');
       }
       audioVideo?.stopLocalVideoTile();
       setIsVideoEnabled(false);
@@ -74,7 +76,7 @@ const LocalVideoProvider: React.FC = ({ children }) => {
       audioVideo?.startLocalVideoTile();
       setIsVideoEnabled(true);
     } else {
-      console.error('Video limit is reached and can not turn on more videos!');
+      logger.error('Video limit is reached and can not turn on more videos!');
     }
   }, [
     audioVideo,

--- a/src/providers/LoggerProvider/index.tsx
+++ b/src/providers/LoggerProvider/index.tsx
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ConsoleLogger, Logger, LogLevel } from 'amazon-chime-sdk-js';
+import React, { useContext } from 'react';
+
+const consoleLogger: Logger = new ConsoleLogger(
+  'ChimeSDKReactComponent',
+  LogLevel.INFO
+);
+export const LoggerContext = React.createContext<Logger>(consoleLogger);
+
+interface Props {
+  logger: Logger;
+}
+
+export const LoggerProvider: React.FC<Props> = ({ logger, children }) => {
+  return (
+    <LoggerContext.Provider value={logger}>{children}</LoggerContext.Provider>
+  );
+};
+
+export const useLogger = (): Logger => {
+  const logger = useContext(LoggerContext);
+  return logger;
+};

--- a/src/providers/MeetingProvider/index.tsx
+++ b/src/providers/MeetingProvider/index.tsx
@@ -14,6 +14,7 @@ import { MeetingEventProvider } from '../MeetingEventProvider';
 import { RemoteVideoTileProvider } from '../RemoteVideoTileProvider';
 import { RosterProvider } from '../RosterProvider';
 import MeetingManager from './MeetingManager';
+import { useLogger } from '../LoggerProvider';
 
 interface Props {
   onDeviceReplacement?: (
@@ -34,8 +35,9 @@ export const MeetingProvider: React.FC<Props> = ({
   meetingManager: meetingManagerProp,
   children,
 }) => {
+  const logger = useLogger();
   const [meetingManager] = useState(
-    () => meetingManagerProp || new MeetingManager()
+    () => meetingManagerProp || new MeetingManager(logger)
   );
 
   return (

--- a/src/providers/MeetingProvider/types.ts
+++ b/src/providers/MeetingProvider/types.ts
@@ -4,8 +4,6 @@
 import {
   ActiveSpeakerPolicy,
   EventController,
-  Logger,
-  LogLevel,
 } from 'amazon-chime-sdk-js';
 
 import { DeviceLabels, DeviceLabelTrigger } from '../../types';
@@ -20,9 +18,6 @@ export enum DevicePermissionStatus {
 export interface MeetingManagerJoinOptions {
   deviceLabels?: DeviceLabels | DeviceLabelTrigger;
   eventController?: EventController;
-  logLevel?: LogLevel;
-  postLoggerConfig?: PostLoggerConfig;
-  logger?: Logger;
   enableWebAudio?: boolean;
   activeSpeakerPolicy?: ActiveSpeakerPolicy;
 }
@@ -40,11 +35,3 @@ export type FullDeviceInfoType = {
   audioOutputDevices: MediaDeviceInfo[] | null;
   videoInputDevices: MediaDeviceInfo[] | null;
 };
-
-export interface PostLoggerConfig {
-  name: string;
-  batchSize: number;
-  intervalMs: number;
-  url: string;
-  logLevel: LogLevel;
-}

--- a/src/providers/VoiceFocusProvider/index.tsx
+++ b/src/providers/VoiceFocusProvider/index.tsx
@@ -12,6 +12,7 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 
 import { JoinMeetingInfo } from '../../types';
 import useMemoCompare from '../../utils/use-memo-compare';
+import { useLogger } from '../LoggerProvider';
 
 interface Props {
   /** Determines how you want Amazon Voice Focus to behave. This spec is used to derive a runtime configuration when a transformer is created. */
@@ -42,6 +43,7 @@ const VoiceFocusProvider: React.FC<Props> = ({
   createMeetingResponse,
   children,
 }) => {
+  const logger = useLogger();
   const [isVoiceFocusSupported, setIsVoiceFocusSupported] = useState<
     boolean | undefined
   >(undefined);
@@ -92,7 +94,7 @@ const VoiceFocusProvider: React.FC<Props> = ({
 
     if (voiceFocusDevice) {
       const vf = await voiceFocusDevice.chooseNewInnerDevice(device);
-      console.info(
+      logger.info(
         'Re-used the same internal state to create an Amazon Voice Focus transform device.'
       );
       setVoiceFocusDevice(vf);
@@ -100,7 +102,7 @@ const VoiceFocusProvider: React.FC<Props> = ({
     }
 
     if (!isVoiceFocusSupported) {
-      console.debug('Not supported, not creating device.');
+      logger.debug('Not supported, not creating device.');
       return device;
     }
 
@@ -108,12 +110,12 @@ const VoiceFocusProvider: React.FC<Props> = ({
       const transformer = await getVoiceFocusDeviceTransformer();
       const vf = await transformer?.createTransformDevice(device);
       if (vf) {
-        console.info('Created a new Amazon Voice Focus transform device.');
+        logger.info('Created a new Amazon Voice Focus transform device.');
         setVoiceFocusDevice(vf);
         return vf;
       }
-    } catch (e) {
-      console.warn('Amazon Voice Focus is not supported.', e);
+    } catch (error) {
+      logger.warn(`Amazon Voice Focus is not supported. ${error}`);
     }
 
     return device;
@@ -213,9 +215,9 @@ const VoiceFocusProvider: React.FC<Props> = ({
     }
 
     if (isVoiceFocusSupported) {
-      console.info('Amazon Voice Focus is supported.');
+      logger.info('Amazon Voice Focus is supported.');
     } else {
-      console.warn('Amazon Voice Focus is not supported.');
+      logger.warn('Amazon Voice Focus is not supported.');
     }
   }, [isVoiceFocusSupported]);
 

--- a/tst/hooks/sdk/useActiveSpeakersState.test.tsx
+++ b/tst/hooks/sdk/useActiveSpeakersState.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { renderHook } from '@testing-library/react-hooks';
-import { LogLevel } from 'amazon-chime-sdk-js';
+import { ConsoleLogger } from 'amazon-chime-sdk-js';
 import React from 'react';
 
 import useActiveSpeakersState from '../../../src/hooks/sdk/useActiveSpeakersState';
@@ -29,10 +29,11 @@ describe('useActiveSpeakersState', () => {
 
   it('should use active speaker', () => {
     expect(mockMeetingManager).toHaveBeenCalledTimes(0);
+    const logger = new ConsoleLogger('SDK');
     const { result, unmount } = renderHook(() => useActiveSpeakersState(), {
       wrapper: ({ children }) => (
         <MeetingContext.Provider
-          value={ new MeetingManager() }
+          value={ new MeetingManager(logger) }
         >
           {children}
         </MeetingContext.Provider>

--- a/tst/providers/LoggerProvider/index.test.tsx
+++ b/tst/providers/LoggerProvider/index.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { ConsoleLogger, LogLevel } from 'amazon-chime-sdk-js';
+import {
+  LoggerProvider,
+  useLogger,
+} from '../../../src/providers/LoggerProvider';
+
+describe('useLogger', () => {
+  it('should provide logger if LoggerProvider is used', () => {
+    const logger = new ConsoleLogger('SDK', LogLevel.ERROR);
+    const { result } = renderHook(() => useLogger(), {
+      wrapper: ({ children }) => (
+        <LoggerProvider logger={logger}>{children}</LoggerProvider>
+      ),
+    });
+    expect(result.current.getLogLevel()).toBe(LogLevel.ERROR);
+  });
+
+  it('should provide default ConsoleLogger with INFO log level if LoggerProvider is not used', () => {
+    const { result } = renderHook(() => useLogger());
+    expect(result.current.getLogLevel()).toBe(LogLevel.INFO);
+  });
+});

--- a/tst/providers/MeetingProvider/MeetingManager.test.ts
+++ b/tst/providers/MeetingProvider/MeetingManager.test.ts
@@ -8,10 +8,7 @@ import {
   DefaultActiveSpeakerPolicy,
   DefaultDeviceController,
   DefaultMeetingSession,
-  LogLevel,
   MeetingSessionConfiguration,
-  MeetingSessionPOSTLogger,
-  MultiLogger,
 } from 'amazon-chime-sdk-js';
 
 import { MeetingManager } from '../../../src/providers/MeetingProvider/MeetingManager';
@@ -28,16 +25,6 @@ describe('Meeting Manager', () => {
     // @ts-ignore
     MeetingSessionConfiguration = jest.fn().mockImplementation(() => {});
     mockMeetingSessionConfiguration = new MeetingSessionConfiguration();
-    mockMeetingManagerJoinOptions = {
-      logLevel: LogLevel.WARN,
-    };
-    meetingManager = new MeetingManager();
-    // @ts-ignore
-    ConsoleLogger = jest.fn().mockReturnValue({});
-    // @ts-ignore 
-    MultiLogger = jest.fn().mockReturnValue({});
-    // @ts-ignore
-    MeetingSessionPOSTLogger = jest.fn().mockReturnValue({});
     // @ts-ignore
     DefaultDeviceController = jest.fn().mockReturnValue({});
     // @ts-ignore
@@ -67,66 +54,18 @@ describe('Meeting Manager', () => {
     });
   });
 
-  describe('join', () => {
-    it('should call MeetingSessionPOSTLogger with PostLogConfig', async () => {
-      mockMeetingManagerJoinOptions = {
-        logLevel: LogLevel.ERROR,
-        postLoggerConfig: {
-          name: 'Test',
-          batchSize: 20,
-          intervalMs: 100,
-          url: 'http://test-url.com',
-          logLevel: LogLevel.INFO,
-        }
-      }
-      await meetingManager.join(mockMeetingSessionConfiguration, mockMeetingManagerJoinOptions);
-      expect(MeetingSessionPOSTLogger).toHaveBeenCalledWith(
-        'Test',
-        mockMeetingSessionConfiguration,
-        20,
-        100,
-        'http://test-url.com',
-        LogLevel.INFO,
-    );
-      expect(MeetingSessionPOSTLogger).toHaveBeenCalledTimes(1);
+  describe('constructor', () => {
+    it('can be constructed', () => {
+      const logger = new ConsoleLogger('SDK');
+      meetingManager = new MeetingManager(logger);
+      expect(meetingManager).toBeDefined;
     });
+  });
 
-    it('should call MultiLogger if PostLoggerConfig is passed', async () => {
-      mockMeetingManagerJoinOptions = {
-        logLevel: LogLevel.ERROR,
-        postLoggerConfig: {
-          name: 'Test',
-          batchSize: 20,
-          intervalMs: 100,
-          url: 'http://test-url.com',
-          logLevel: LogLevel.INFO,
-        }
-      }
-      await meetingManager.join(mockMeetingSessionConfiguration, mockMeetingManagerJoinOptions);
-      expect(ConsoleLogger).toHaveBeenCalledWith(
-        'SDK',
-        LogLevel.ERROR,
-      );
-      expect(MeetingSessionPOSTLogger).toHaveBeenCalledWith(
-        'Test',
-        mockMeetingSessionConfiguration,
-        20,
-        100,
-        'http://test-url.com',
-        LogLevel.INFO,
-      );
-      expect(MultiLogger).toHaveBeenCalledWith(
-        new ConsoleLogger('SDK', LogLevel.ERROR),
-        new MeetingSessionPOSTLogger(
-          'Test',
-          mockMeetingSessionConfiguration,
-          20,
-          100,
-          'http://test-url.com',
-          LogLevel.INFO,
-        ),
-      );
-      expect(MultiLogger).toHaveBeenCalledTimes(1);
+  describe('join', () => {
+    beforeEach(() => {
+      const logger = new ConsoleLogger('SDK');
+      meetingManager = new MeetingManager(logger);
     });
 
     it('should call subscribeToActiveSpeakerDetector with new DefaultActiveSpeakerPolicy if one is not passed via MeetinManagerJoinOptions', async () => {

--- a/tst/providers/MeetingProvider/index.test.tsx
+++ b/tst/providers/MeetingProvider/index.test.tsx
@@ -5,7 +5,6 @@ import {
   DefaultEventController,
   EventAttributes,
   EventName,
-  LogLevel,
   MeetingSessionConfiguration,
   MeetingSessionCredentials,
   MeetingSessionURLs,
@@ -43,15 +42,16 @@ describe('Meeting Provider', () => {
       }, 
       attendeeInfo: new MeetingSessionCredentials(),  
     }
+
+    const logger = new NoOpDebugLogger();
     let eventController = new DefaultEventController(
       new MeetingSessionConfiguration(joinData.meetingInfo, joinData.attendeeInfo), 
-      new NoOpDebugLogger(),
+      logger,
       );
     let meetingManagerJoinOptions: MeetingManagerJoinOptions = {
-      logLevel: LogLevel.OFF,
       eventController: eventController,
     };
-    let meetingManager = new MeetingManager();
+    let meetingManager = new MeetingManager(logger);
     await meetingManager.join(new MeetingSessionConfiguration(joinData.meetingInfo, joinData.attendeeInfo),
       meetingManagerJoinOptions,
     );


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
- Add `LoggerProvider` and `useLogger`.
- Update console.log|info|warn|error usages to use `logger` from `useLogger`.
- Add unit test and update existing tests for the change.
- This is to get early feedback on implementation changes.
- Meeting Demo update PR depending on this change: https://github.com/aws-samples/amazon-chime-sdk/pull/184

Next Steps:
- Once DeviceController PRs merge in I will rebase with documentation and migration docs.

**Testing**
1. Have you successfully run `npm run build:release` locally?
- Yes.

3. How did you test these changes?
- Updated the React meeting demo in AWS Samples.
- Deployed it and checked whether we get console logs as well as logs in AWS CloudWatch in the deployed account.
- If `LoggerProvider` is not mounted, only console logger will work as it is provided by default.

5. If you made changes to the component library, have you provided corresponding documentation changes?
- Will be followed as stated in next steps.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
