### PR TITLE
Add logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.0-beta.1] - 2022-03-17
+## [3.0.0] - 2022-03-17
 
 ### Added
+- Add `LoggerProvider` and `useLogger` components to enable unniversal logging in component library.
 
 ### Removed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "amazon-chime-sdk-component-library-react",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-chime-sdk-component-library-react",
-      "version": "3.0.0-beta.1",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@popperjs/core": "^2.2.2",
-        "amazon-chime-sdk-js": "^3.0.0",
         "fast-memoize": "^2.5.2",
         "lodash.isequal": "^4.5.0",
         "react-popper": "^2.2.4",
@@ -49,6 +48,7 @@
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
         "add": "^2.0.6",
+        "amazon-chime-sdk-js": "^3.0.0",
         "babel-loader": "^8.1.0",
         "css-loader": "^2.1.1",
         "eslint": "^7.32.0",
@@ -93,6 +93,7 @@
         "npm": "^6 || ^7 || ^8"
       },
       "peerDependencies": {
+        "amazon-chime-sdk-js": "^3.0.0",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "styled-components": "^5.0.0",
@@ -115,6 +116,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.1.tgz",
       "integrity": "sha512-mbHTBSPBvg6o/mN/c18Z/zifM05eJrapj5ggoOIeHIWckvkv5VgGi7r/wYpt+QAO2ySKXLNvH2d8L7bne4xrMQ==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/util": "^2.0.1",
         "@aws-sdk/types": "^3.1.0",
@@ -124,12 +126,14 @@
     "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@aws-crypto/util": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
       "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "^3.1.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -139,12 +143,14 @@
     "node_modules/@aws-crypto/util/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@aws-sdk/types": {
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.55.0.tgz",
       "integrity": "sha512-wrDZjuy1CVAYxDCbm3bWQIKMGfNs7XXmG0eG4858Ixgqmq2avsIn5TORy8ynBxcXn9aekV/+tGEQ7BBSYzIVNQ==",
+      "dev": true,
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -153,6 +159,7 @@
       "version": "3.58.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.58.0.tgz",
       "integrity": "sha512-Rl+jXUzk/FJkOLYfUVYPhKa2aUmTpeobRP31l8IatQltSzDgLyRHO35f6UEs7Ztn5s1jbu/POatLAZ2WjbgVyg==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -164,6 +171,7 @@
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.55.0.tgz",
       "integrity": "sha512-ljzqJcyjfJpEVSIAxwtIS8xMRUly84BdjlBXyp6cu4G8TUufgjNS31LWdhyGhgmW5vYBNr+LTz0Kwf6J+ou7Ug==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -2982,27 +2990,32 @@
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+      "dev": true
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+      "dev": true
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "dev": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -3011,27 +3024,32 @@
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
+      "dev": true
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+      "dev": true
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+      "dev": true
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+      "dev": true
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+      "dev": true
     },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "13.0.2",
@@ -6249,7 +6267,8 @@
     "node_modules/@types/dom-mediacapture-record": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.11.tgz",
-      "integrity": "sha512-ODVOH95x08arZhbQOjH3no7Iye64akdO+55nM+IGtTzpu2ACKr9CQTrI//CCVieIjlI/eL+rK1hQjMycxIgylQ=="
+      "integrity": "sha512-ODVOH95x08arZhbQOjH3no7Iye64akdO+55nM+IGtTzpu2ACKr9CQTrI//CCVieIjlI/eL+rK1hQjMycxIgylQ==",
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "0.0.39",
@@ -6365,7 +6384,8 @@
     "node_modules/@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+      "dev": true
     },
     "node_modules/@types/mdast": {
       "version": "3.0.3",
@@ -6584,7 +6604,8 @@
     "node_modules/@types/ua-parser-js": {
       "version": "0.7.36",
       "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz",
-      "integrity": "sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ=="
+      "integrity": "sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ==",
+      "dev": true
     },
     "node_modules/@types/uglify-js": {
       "version": "3.13.1",
@@ -7293,6 +7314,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-3.0.0.tgz",
       "integrity": "sha512-VMPJ7I2OCDCFU3ZzR3fCbciUlVWCSUI6QxPvP/6A6vFfggAgpHdyPzM9LJmT7LdtCQqHOhD7gXWKsDB7FPM8kA==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "^2.0.1",
         "@aws-sdk/util-hex-encoding": "^3.47.0",
@@ -7312,12 +7334,14 @@
     "node_modules/amazon-chime-sdk-js/node_modules/pako": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
-      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==",
+      "dev": true
     },
     "node_modules/amazon-chime-sdk-js/node_modules/ua-parser-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
       "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11012,7 +11036,8 @@
     "node_modules/detect-browser": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
-      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==",
+      "dev": true
     },
     "node_modules/detect-file": {
       "version": "1.0.0",
@@ -18775,7 +18800,8 @@
     "node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "dev": true
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -21712,6 +21738,7 @@
       "version": "6.8.9",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.9.tgz",
       "integrity": "sha512-j2JlRdUeL/f4Z6x4aU4gj9I2LECglC+5qR2TrWb193Tla1qfdaNQTZ8I27Pt7K0Ajmvjjpft7O3KWTGciz4gpw==",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -21736,7 +21763,8 @@
     "node_modules/protobufjs/node_modules/@types/node": {
       "version": "10.17.60",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "dev": true
     },
     "node_modules/protocols": {
       "version": "1.4.8",
@@ -23131,7 +23159,8 @@
     "node_modules/resize-observer": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/resize-observer/-/resize-observer-1.0.4.tgz",
-      "integrity": "sha512-AQ2MdkWTng9d6JtjHvljiQR949qdae91pjSNugGGeOFzKIuLHvoZIYhUTjePla5hCFDwQHrnkciAIzjzdsTZew=="
+      "integrity": "sha512-AQ2MdkWTng9d6JtjHvljiQR949qdae91pjSNugGGeOFzKIuLHvoZIYhUTjePla5hCFDwQHrnkciAIzjzdsTZew==",
+      "dev": true
     },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
@@ -25942,7 +25971,8 @@
     "node_modules/tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -28359,6 +28389,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.1.tgz",
       "integrity": "sha512-mbHTBSPBvg6o/mN/c18Z/zifM05eJrapj5ggoOIeHIWckvkv5VgGi7r/wYpt+QAO2ySKXLNvH2d8L7bne4xrMQ==",
+      "dev": true,
       "requires": {
         "@aws-crypto/util": "^2.0.1",
         "@aws-sdk/types": "^3.1.0",
@@ -28368,7 +28399,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -28376,6 +28408,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
       "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "^3.1.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -28385,19 +28418,22 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
     "@aws-sdk/types": {
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.55.0.tgz",
-      "integrity": "sha512-wrDZjuy1CVAYxDCbm3bWQIKMGfNs7XXmG0eG4858Ixgqmq2avsIn5TORy8ynBxcXn9aekV/+tGEQ7BBSYzIVNQ=="
+      "integrity": "sha512-wrDZjuy1CVAYxDCbm3bWQIKMGfNs7XXmG0eG4858Ixgqmq2avsIn5TORy8ynBxcXn9aekV/+tGEQ7BBSYzIVNQ==",
+      "dev": true
     },
     "@aws-sdk/util-hex-encoding": {
       "version": "3.58.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.58.0.tgz",
       "integrity": "sha512-Rl+jXUzk/FJkOLYfUVYPhKa2aUmTpeobRP31l8IatQltSzDgLyRHO35f6UEs7Ztn5s1jbu/POatLAZ2WjbgVyg==",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -28406,6 +28442,7 @@
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.55.0.tgz",
       "integrity": "sha512-ljzqJcyjfJpEVSIAxwtIS8xMRUly84BdjlBXyp6cu4G8TUufgjNS31LWdhyGhgmW5vYBNr+LTz0Kwf6J+ou7Ug==",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -30738,27 +30775,32 @@
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+      "dev": true
     },
     "@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true
     },
     "@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true
     },
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+      "dev": true
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "dev": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -30767,27 +30809,32 @@
     "@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
+      "dev": true
     },
     "@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+      "dev": true
     },
     "@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+      "dev": true
     },
     "@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+      "dev": true
     },
     "@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+      "dev": true
     },
     "@rollup/plugin-commonjs": {
       "version": "13.0.2",
@@ -33081,7 +33128,8 @@
     "@types/dom-mediacapture-record": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.11.tgz",
-      "integrity": "sha512-ODVOH95x08arZhbQOjH3no7Iye64akdO+55nM+IGtTzpu2ACKr9CQTrI//CCVieIjlI/eL+rK1hQjMycxIgylQ=="
+      "integrity": "sha512-ODVOH95x08arZhbQOjH3no7Iye64akdO+55nM+IGtTzpu2ACKr9CQTrI//CCVieIjlI/eL+rK1hQjMycxIgylQ==",
+      "dev": true
     },
     "@types/estree": {
       "version": "0.0.39",
@@ -33197,7 +33245,8 @@
     "@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+      "dev": true
     },
     "@types/mdast": {
       "version": "3.0.3",
@@ -33416,7 +33465,8 @@
     "@types/ua-parser-js": {
       "version": "0.7.36",
       "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz",
-      "integrity": "sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ=="
+      "integrity": "sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ==",
+      "dev": true
     },
     "@types/uglify-js": {
       "version": "3.13.1",
@@ -33996,6 +34046,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-3.0.0.tgz",
       "integrity": "sha512-VMPJ7I2OCDCFU3ZzR3fCbciUlVWCSUI6QxPvP/6A6vFfggAgpHdyPzM9LJmT7LdtCQqHOhD7gXWKsDB7FPM8kA==",
+      "dev": true,
       "requires": {
         "@aws-crypto/sha256-js": "^2.0.1",
         "@aws-sdk/util-hex-encoding": "^3.47.0",
@@ -34011,12 +34062,14 @@
         "pako": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
-          "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
+          "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==",
+          "dev": true
         },
         "ua-parser-js": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
-          "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg=="
+          "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==",
+          "dev": true
         }
       }
     },
@@ -37049,7 +37102,8 @@
     "detect-browser": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
-      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==",
+      "dev": true
     },
     "detect-file": {
       "version": "1.0.0",
@@ -43288,7 +43342,8 @@
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -45683,6 +45738,7 @@
       "version": "6.8.9",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.9.tgz",
       "integrity": "sha512-j2JlRdUeL/f4Z6x4aU4gj9I2LECglC+5qR2TrWb193Tla1qfdaNQTZ8I27Pt7K0Ajmvjjpft7O3KWTGciz4gpw==",
+      "dev": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -45702,7 +45758,8 @@
         "@types/node": {
           "version": "10.17.60",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+          "dev": true
         }
       }
     },
@@ -46886,7 +46943,8 @@
     "resize-observer": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/resize-observer/-/resize-observer-1.0.4.tgz",
-      "integrity": "sha512-AQ2MdkWTng9d6JtjHvljiQR949qdae91pjSNugGGeOFzKIuLHvoZIYhUTjePla5hCFDwQHrnkciAIzjzdsTZew=="
+      "integrity": "sha512-AQ2MdkWTng9d6JtjHvljiQR949qdae91pjSNugGGeOFzKIuLHvoZIYhUTjePla5hCFDwQHrnkciAIzjzdsTZew==",
+      "dev": true
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",
@@ -49168,7 +49226,8 @@
     "tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
     },
     "tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-component-library-react",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0",
   "description": "Amazon Chime SDK Component Library - React",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",
@@ -42,7 +42,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@popperjs/core": "^2.2.2",
-    "amazon-chime-sdk-js": "^3.0.0",
     "fast-memoize": "^2.5.2",
     "lodash.isequal": "^4.5.0",
     "react-popper": "^2.2.4",
@@ -81,6 +80,7 @@
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "add": "^2.0.6",
+    "amazon-chime-sdk-js": "^3.0.0",
     "babel-loader": "^8.1.0",
     "css-loader": "^2.1.1",
     "eslint": "^7.32.0",
@@ -121,6 +121,7 @@
     "webpack-cli": "^3.3.2"
   },
   "peerDependencies": {
+    "amazon-chime-sdk-js": "^3.0.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "styled-components": "^5.0.0",

--- a/src/components/migrationToV3.stories.mdx
+++ b/src/components/migrationToV3.stories.mdx
@@ -22,7 +22,7 @@ npm install --save amazon-chime-sdk-component-library-react@beta amazon-chime-sd
 - `MeetingManager`'s `join()` method no longer takes an `EventReporter` and instead takes an `EventController`.
 - Add `MeetingSessionConfiguration` as a required parameter to `MeetingManager.join()` method. With this change the builders have direct access to `MeetingSessionConfiguration`, this will allow more flexibility to customize the `MeetingSession`.
 - Add `MeetingManagerJoinOptions` as a new interface for the `options` parameter of the `MeetingManager.join` method.
-- Add `deviceLabels`, `eventController`, `logLevel`, `postLoggerConfig`, `logger`, `enableWebAudio`, and `activeSpeakerPolicy` to `MeetingManagerJoinOptions` interface.
+- Add `deviceLabels`, `eventController`, `enableWebAudio`, and `activeSpeakerPolicy` to `MeetingManagerJoinOptions` interface.
 - Remove `MeetingSessionConfiguration` properties from `MeetingProvider` props.
 - Remove `deviceLabels`, `eventController`, `logLevel`, `postLogConfig`, `logger`, `enableWebAudio`, and `activeSpeakerPolicy` from `MeetingProvider` props.
 - Remove `meetingRegion` from `MeetingManager`. Previously we just cache this value from meetingInfo returned by [CreateMeeting](https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateMeeting.html) but it is not used anywhere in the library.
@@ -32,6 +32,7 @@ npm install --save amazon-chime-sdk-component-library-react@beta amazon-chime-sd
 - Rename the `global` property of `DefaultTheme` Interface to `globalStyle` to avoid conflict with reserved keyword `global`.
 - Remove preset device selection options ("None" and "440 Hz" for audio input device. "None", "Blue" and "SMTP Color Bars" for video input device). Remove `appendSampleDevices` from Props of `CameraSelection`, `MicSelection`, `AudioInputControl`, `AudioInputVFcontrol`, and `VideoInputControl`. Remove `DeviceConfig` type. Remove `additionalDevices` from Props of `useAudioInputs` and `useVideoInputs` hook.
 - Revert "Add Observer to select input device error" ([PR #493](https://github.com/aws/amazon-chime-sdk-component-library-react/pull/493)). `useAudioInputs` and `useVideoInputs` hook no longer return `selectDeviceError`. `selectAudioInputDevice`, `selectVideoInputDevice`, and `selectAudioOutputDevice` method of `MeetingManager` now throw error when failed. The device selection methods returned by `useSelectAudioInputDevice`, `useSelectVideoInputDevice`, and `useSelectAudioOutputDevice` hook are built on top of these `MeetingManager` methods, thus now they throw error when failed as well.
+- Add `LoggerProvider` and `useLogger` components to enable unniversal logging in component library.
 
 ### `MeetingProvider` props change
 
@@ -46,9 +47,6 @@ npm install --save amazon-chime-sdk-component-library-react@beta amazon-chime-sd
 - Other props:
 - `deviceLabels`
 - `eventController`
-- `logLevel`
-- `postLogConfig`
-- `logger`
 - `enableWebAudio`
 - `activeSpeakerPolicy`
 
@@ -425,6 +423,10 @@ const MyChild = () => {
   );
 };
 ```
+
+## Enable logging using `useLogger` and `LoggerProvider`
+
+Please check documentation on [`LoggerProvider`](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/story/sdk-providers-loggerprovider--page) for more information on its usage.
 
 ## StyledComponent
 

--- a/src/components/sdk/DeviceSelection/CameraSelection/BackgroundBlurCheckbox.tsx
+++ b/src/components/sdk/DeviceSelection/CameraSelection/BackgroundBlurCheckbox.tsx
@@ -7,6 +7,7 @@ import React, { useState } from 'react';
 import useSelectVideoInputDevice from '../../../../hooks/sdk/useSelectVideoInputDevice';
 import { useBackgroundBlur } from '../../../../providers/BackgroundBlurProvider';
 import { useVideoInputs } from '../../../../providers/DevicesProvider';
+import { useLogger } from '../../../../providers/LoggerProvider';
 import { Checkbox } from '../../../ui/Checkbox';
 import { FormField } from '../../../ui/FormField';
 import { BaseSdkProps } from '../../Base';
@@ -20,6 +21,7 @@ export const BackgroundBlurCheckbox: React.FC<Props> = ({
   label = 'Blur my background',
   ...rest
 }) => {
+  const logger = useLogger();
   const { isBackgroundBlurSupported, createBackgroundBlurDevice } =
     useBackgroundBlur();
   const [isLoading, setIsLoading] = useState(false);
@@ -37,24 +39,26 @@ export const BackgroundBlurCheckbox: React.FC<Props> = ({
 
       if (!isVideoTransformDevice(selectedDevice)) {
         if (!isBackgroundBlurSupported) {
-          console.warn('Background blur processor is not supported yet.');
+          logger.warn('Background blur processor is not supported yet.');
           return;
         }
         current = await createBackgroundBlurDevice(selectedDevice);
-        console.info(
-          'Video filter turned on - selecting video transform device: ' +
-            JSON.stringify(current)
+        logger.info(
+          `Video filter turned on - selecting video transform device: ${JSON.stringify(
+            current
+          )}`
         );
       } else {
         current = await selectedDevice.intrinsicDevice();
-        console.info(
-          'Video filter was turned off - selecting inner device: ' +
-            JSON.stringify(current)
+        logger.info(
+          `Video filter was turned off - selecting inner device: ${JSON.stringify(
+            current
+          )}`
         );
       }
       await selectVideoInput(current);
     } catch (error) {
-      console.error('Failed to toggle Background Blur');
+      logger.error('Failed to toggle Background Blur');
     } finally {
       setIsLoading(false);
     }

--- a/src/components/sdk/DeviceSelection/CameraSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/CameraSelection/index.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import useSelectVideoInputDevice from '../../../../hooks/sdk/useSelectVideoInputDevice';
 import { useVideoInputs } from '../../../../providers/DevicesProvider';
+import { useLogger } from '../../../../providers/LoggerProvider';
 import { BaseSdkProps } from '../../Base';
 import DeviceInput from '../DeviceInput';
 
@@ -20,6 +21,7 @@ export const CameraSelection: React.FC<Props> = ({
   label = 'Camera source',
   ...rest
 }) => {
+  const logger = useLogger();
   const { devices, selectedDevice } = useVideoInputs();
   const selectVideoInput = useSelectVideoInputDevice();
 
@@ -27,7 +29,7 @@ export const CameraSelection: React.FC<Props> = ({
     try {
       await selectVideoInput(deviceId);
     } catch (error) {
-      console.error('CameraSelection failed to select camera');
+      logger.error('CameraSelection failed to select camera');
     }
   };
 

--- a/src/components/sdk/DeviceSelection/MicSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/MicSelection/index.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import { useSelectAudioInputDevice } from '../../../../hooks/sdk/useSelectAudioInputDevice';
 import { useAudioInputs } from '../../../../providers/DevicesProvider';
+import { useLogger } from '../../../../providers/LoggerProvider';
 import { BaseSdkProps } from '../../Base';
 import DeviceInput from '../DeviceInput';
 
@@ -20,6 +21,7 @@ export const MicSelection: React.FC<Props> = ({
   label = 'Microphone source',
   ...rest
 }) => {
+  const logger = useLogger();
   const { devices, selectedDevice } = useAudioInputs();
   const selectAudioInput = useSelectAudioInputDevice();
 
@@ -27,7 +29,7 @@ export const MicSelection: React.FC<Props> = ({
     try {
       await selectAudioInput(deviceId);
     } catch (error) {
-      console.error('MicSelection failed to select mic');
+      logger.error('MicSelection failed to select mic');
     }
   };
 

--- a/src/components/sdk/DeviceSelection/SpeakerSelection/index.tsx
+++ b/src/components/sdk/DeviceSelection/SpeakerSelection/index.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import useSelectAudioOutputDevice from '../../../../hooks/sdk/useSelectAudioOutputDevice';
 import { useAudioOutputs } from '../../../../providers/DevicesProvider';
+import { useLogger } from '../../../../providers/LoggerProvider';
 import { BaseSdkProps } from '../../Base';
 import DeviceInput from '../DeviceInput';
 
@@ -24,6 +25,7 @@ export const SpeakerSelection: React.FC<Props> = ({
   onChange,
   ...rest
 }) => {
+  const logger = useLogger();
   const { devices, selectedDevice } = useAudioOutputs();
   const selectAudioOutput = useSelectAudioOutputDevice();
 
@@ -32,7 +34,7 @@ export const SpeakerSelection: React.FC<Props> = ({
       await selectAudioOutput(deviceId);
       onChange && onChange(deviceId);
     } catch (error) {
-      console.error('SpeakerSelection failed to select speaker');
+      logger.error('SpeakerSelection failed to select speaker');
     }
   };
 

--- a/src/components/sdk/MeetingControls/AudioInputControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioInputControl.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useState } from 'react';
 import useSelectAudioInputDevice from '../../../hooks/sdk/useSelectAudioInputDevice';
 import { useToggleLocalMute } from '../../../hooks/sdk/useToggleLocalMute';
 import { useAudioInputs } from '../../../providers/DevicesProvider';
+import { useLogger } from '../../../providers/LoggerProvider';
 import { isOptionActive } from '../../../utils/device-utils';
 import { ControlBarButton } from '../../ui/ControlBar/ControlBarButton';
 import { Microphone } from '../../ui/icons';
@@ -30,6 +31,7 @@ const AudioInputControl: React.FC<Props> = ({
   unmutedIconTitle,
   ...rest
 }) => {
+  const logger = useLogger();
   const selectAudioInput = useSelectAudioInputDevice();
   const { muted, toggleMute } = useToggleLocalMute();
   const { devices, selectedDevice } = useAudioInputs();
@@ -42,7 +44,7 @@ const AudioInputControl: React.FC<Props> = ({
       try {
         await selectAudioInput(deviceId);
       } catch (error) {
-        console.error('AudioInputControl failed to select audio input device');
+        logger.error('AudioInputControl failed to select audio input device');
       }
     };
 

--- a/src/components/sdk/MeetingControls/AudioInputVFControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioInputVFControl.tsx
@@ -13,6 +13,7 @@ import useSelectAudioInputDevice from '../../../hooks/sdk/useSelectAudioInputDev
 import { useToggleLocalMute } from '../../../hooks/sdk/useToggleLocalMute';
 import { useAudioVideo } from '../../../providers/AudioVideoProvider';
 import { useAudioInputs } from '../../../providers/DevicesProvider';
+import { useLogger } from '../../../providers/LoggerProvider';
 import { useVoiceFocus } from '../../../providers/VoiceFocusProvider';
 import { DeviceType } from '../../../types';
 import { isOptionActive } from '../../../utils/device-utils';
@@ -49,6 +50,7 @@ const AudioInputVFControl: React.FC<Props> = ({
   voiceFocusOffLabel = 'Enable Amazon Voice Focus',
   ...rest
 }) => {
+  const logger = useLogger();
   const audioVideo = useAudioVideo();
   const selectAudioInput = useSelectAudioInputDevice();
   const [isLoading, setIsLoading] = useState(false);
@@ -72,7 +74,7 @@ const AudioInputVFControl: React.FC<Props> = ({
   );
 
   useEffect(() => {
-    console.info(
+    logger.info(
       `Amazon Voice Focus is ${isVoiceFocusEnabled ? 'enabled' : 'disabled'}.`
     );
   }, [isVoiceFocusEnabled]);
@@ -111,9 +113,7 @@ const AudioInputVFControl: React.FC<Props> = ({
           await selectAudioInput(deviceId);
         }
       } catch (error) {
-        console.error(
-          'AudioInputVFControl failed to select audio input device'
-        );
+        logger.error('AudioInputVFControl failed to select audio input device');
       } finally {
         setIsLoading(false);
       }
@@ -181,12 +181,12 @@ const AudioInputVFControl: React.FC<Props> = ({
       try {
         let current = selectedDevice;
         if (isVoiceFocusChecked) {
-          console.info('User turned on Amazon Voice Focus.');
+          logger.info('User turned on Amazon Voice Focus.');
           if (typeof selectedDevice === 'string') {
             current = await addVoiceFocus(selectedDevice);
           }
         } else {
-          console.info(
+          logger.info(
             'Amazon Voice Focus is off by default or user turned off Amazon Voice Focus.'
           );
           if (selectedDevice instanceof VoiceFocusTransformDevice) {
@@ -195,7 +195,7 @@ const AudioInputVFControl: React.FC<Props> = ({
         }
         await selectAudioInput(current);
       } catch (error) {
-        console.error(
+        logger.error(
           'AudioInputVFControl failed to select audio input device onVFCheckboxChange change'
         );
       }

--- a/src/components/sdk/MeetingControls/AudioOutputControl.tsx
+++ b/src/components/sdk/MeetingControls/AudioOutputControl.tsx
@@ -7,6 +7,7 @@ import React, { useEffect, useState } from 'react';
 import useSelectAudioOutputDevice from '../../../hooks/sdk/useSelectAudioOutputDevice';
 import { useAudioOutputs } from '../../../providers/DevicesProvider';
 import { useLocalAudioOutput } from '../../../providers/LocalAudioOutputProvider';
+import { useLogger } from '../../../providers/LoggerProvider';
 import { isOptionActive } from '../../../utils/device-utils';
 import { ControlBarButton } from '../../ui/ControlBar/ControlBarButton';
 import { Sound } from '../../ui/icons';
@@ -22,6 +23,7 @@ const AudioOutputControl: React.FC<Props> = ({
   label = 'Speaker',
   ...rest
 }) => {
+  const logger = useLogger();
   const selectAudioOutput = useSelectAudioOutputDevice();
   const { devices, selectedDevice } = useAudioOutputs();
   const { isAudioOn, toggleAudio } = useLocalAudioOutput();
@@ -35,14 +37,12 @@ const AudioOutputControl: React.FC<Props> = ({
         if (new DefaultBrowserBehavior().supportsSetSinkId()) {
           await selectAudioOutput(deviceId);
         } else {
-          console.error(
+          logger.error(
             'AudioOutputControl cannot select audio output device because browser does not support setSinkId operation.'
           );
         }
       } catch (error) {
-        console.error(
-          'AudioOutputControl failed to select audio output device'
-        );
+        logger.error('AudioOutputControl failed to select audio output device');
       }
     };
 

--- a/src/components/sdk/MeetingControls/VideoInputBackgroundBlurControl.tsx
+++ b/src/components/sdk/MeetingControls/VideoInputBackgroundBlurControl.tsx
@@ -9,6 +9,7 @@ import useSelectVideoInputDevice from '../../../hooks/sdk/useSelectVideoInputDev
 import { useBackgroundBlur } from '../../../providers/BackgroundBlurProvider';
 import { useVideoInputs } from '../../../providers/DevicesProvider';
 import { useLocalVideo } from '../../../providers/LocalVideoProvider';
+import { useLogger } from '../../../providers/LoggerProvider';
 import { DeviceType } from '../../../types';
 import { isOptionActive } from '../../../utils/device-utils';
 import useMemoCompare from '../../../utils/use-memo-compare';
@@ -30,6 +31,7 @@ const VideoInputBackgroundBlurControl: React.FC<Props> = ({
   backgroundBlurLabel = 'Enable Background Blur',
   ...rest
 }) => {
+  const logger = useLogger();
   const selectVideoInput = useSelectVideoInputDevice();
   const { devices, selectedDevice } = useVideoInputs();
   const { isVideoEnabled, toggleVideo } = useLocalVideo();
@@ -58,23 +60,25 @@ const VideoInputBackgroundBlurControl: React.FC<Props> = ({
       if (!isVideoTransformDevice(selectedDevice)) {
         // Enable video transform on the non-transformed device
         current = await createBackgroundBlurDevice(selectedDevice);
-        console.info(
-          'Video filter turned on - selecting video transform device: ' +
-            JSON.stringify(current)
+        logger.info(
+          `Video filter turned on - selecting video transform device: ${JSON.stringify(
+            current
+          )}`
         );
       } else {
         // switch back to the inner device
         current = await selectedDevice.intrinsicDevice();
-        console.info(
-          'Video filter was turned off - selecting inner device: ' +
-            JSON.stringify(current)
+        logger.info(
+          `Video filter was turned off - selecting inner device: ${JSON.stringify(
+            current
+          )}`
         );
       }
       // If we're currently using a video transform device, and a non-video transform device is selected
       // then the video transform device will be stopped automatically
       await selectVideoInput(current);
     } catch (error) {
-      console.error('Failed to toggle Background Blur');
+      logger.error('Failed to toggle Background Blur');
     } finally {
       setIsLoading(false);
     }
@@ -93,14 +97,14 @@ const VideoInputBackgroundBlurControl: React.FC<Props> = ({
               selectedDevice.chooseNewInnerDevice(deviceId);
             await selectVideoInput(transformedDevice);
           } else {
-            console.error('Transform device cannot choose new inner device');
+            logger.error('Transform device cannot choose new inner device');
           }
           setIsLoading(false);
         } else {
           await selectVideoInput(deviceId);
         }
       } catch (error) {
-        console.error('Failed to select video input device');
+        logger.error('Failed to select video input device');
       } finally {
         setIsLoading(false);
       }

--- a/src/components/sdk/MeetingControls/VideoInputControl.tsx
+++ b/src/components/sdk/MeetingControls/VideoInputControl.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useState } from 'react';
 import useSelectVideoInputDevice from '../../../hooks/sdk/useSelectVideoInputDevice';
 import { useVideoInputs } from '../../../providers/DevicesProvider';
 import { useLocalVideo } from '../../../providers/LocalVideoProvider';
+import { useLogger } from '../../../providers/LoggerProvider';
 import { isOptionActive } from '../../../utils/device-utils';
 import { ControlBarButton } from '../../ui/ControlBar/ControlBarButton';
 import { Camera } from '../../ui/icons';
@@ -18,6 +19,7 @@ interface Props extends BaseSdkProps {
 }
 
 const VideoInputControl: React.FC<Props> = ({ label = 'Video', ...rest }) => {
+  const logger = useLogger();
   const selectVideoInput = useSelectVideoInputDevice();
   const { devices, selectedDevice } = useVideoInputs();
   const { isVideoEnabled, toggleVideo } = useLocalVideo();
@@ -30,7 +32,7 @@ const VideoInputControl: React.FC<Props> = ({ label = 'Video', ...rest }) => {
       try {
         await selectVideoInput(deviceId);
       } catch (error) {
-        console.error('VideoInputControl failed to select video input device');
+        logger.error('VideoInputControl failed to select video input device');
       }
     };
 

--- a/src/components/sdk/PreviewVideo/index.tsx
+++ b/src/components/sdk/PreviewVideo/index.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import { useLocalVideo, useVideoInputs } from '../../..';
 import useSelectVideoInputDevice from '../../../hooks/sdk/useSelectVideoInputDevice';
 import { useAudioVideo } from '../../../providers/AudioVideoProvider';
+import { useLogger } from '../../../providers/LoggerProvider';
 import VideoTile from '../../ui/VideoTile';
 import { BaseSdkProps } from '../Base';
 
@@ -20,6 +21,7 @@ const StyledPreview = styled(VideoTile)`
 `;
 
 export const PreviewVideo: React.FC<BaseSdkProps> = (props) => {
+  const logger = useLogger();
   const audioVideo = useAudioVideo();
   const { selectedDevice } = useVideoInputs();
   const videoEl = useRef<HTMLVideoElement>(null);
@@ -48,7 +50,7 @@ export const PreviewVideo: React.FC<BaseSdkProps> = (props) => {
         audioVideo.startVideoPreviewForVideoInput(videoEl.current);
         setIsVideoEnabled(true);
       } catch (error) {
-        console.error('Failed to start video preview');
+        logger.error('Failed to start video preview');
       }
     }
 

--- a/src/components/ui/Modal/ModalButtonGroup.tsx
+++ b/src/components/ui/Modal/ModalButtonGroup.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { FC, HTMLAttributes, ReactElement } from 'react';
+import { useLogger } from '../../../providers/LoggerProvider';
 
 import { BaseProps } from '../Base';
 import { useModalContext } from './ModalContext';
@@ -21,6 +22,7 @@ export const ModalButtonGroup: FC<ModalButtonGroupProps> = ({
   secondaryButtons,
   ...rest
 }) => {
+  const logger = useLogger();
   const context = useModalContext();
 
   const addCloseBehaviorToButton = (button: any) => {
@@ -40,7 +42,7 @@ export const ModalButtonGroup: FC<ModalButtonGroupProps> = ({
       (buttons instanceof Array && buttons.length === 0)
     ) {
       context.dismissible &&
-        console.warn(
+        logger.warn(
           "the 'dismissible prop prevents buttons from closing the modal"
         );
       return buttons;

--- a/src/components/ui/WithTooltip/index.tsx
+++ b/src/components/ui/WithTooltip/index.tsx
@@ -3,6 +3,7 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
+import { useLogger } from '../../../providers/LoggerProvider';
 
 import { StyledTooltip } from './Styled';
 
@@ -38,6 +39,7 @@ export const WithTooltip =
     container_id?: string
   ) =>
   (props: P & ToolTipProps) => {
+    const logger = useLogger();
     const [{ show, bounds }, setShow] =
       useState<WithTooltipState>(initialState);
     const [container, setContainer] = useState<HTMLElement | null>(null);
@@ -70,10 +72,9 @@ export const WithTooltip =
       );
 
       if (!container) {
-        console.warn(`
-        Attempted to use 'WithTooltip' but could not find container element.
-        Pass a valid element ID or add 'Tooltip__container' ID to existing element
-      `);
+        logger.warn(
+          `Attempted to use 'WithTooltip' but could not find container element.Pass a valid element ID or add 'Tooltip__container' ID to existing element`
+        );
         return;
       }
 

--- a/src/hooks/sdk/useSelectAudioOutputDevice.tsx
+++ b/src/hooks/sdk/useSelectAudioOutputDevice.tsx
@@ -3,6 +3,7 @@
 
 import { DefaultBrowserBehavior } from 'amazon-chime-sdk-js';
 import { useCallback } from 'react';
+import { useLogger } from '../../providers/LoggerProvider';
 
 import { useMeetingManager } from '../../providers/MeetingProvider';
 
@@ -10,13 +11,14 @@ export const useSelectAudioOutputDevice = (): ((
   deviceId: string
 ) => Promise<void>) => {
   const meetingManager = useMeetingManager();
+  const logger = useLogger();
 
   const selectDevice = useCallback(
     async (deviceId: string) => {
       if (new DefaultBrowserBehavior().supportsSetSinkId()) {
         await meetingManager.selectAudioOutputDevice(deviceId);
       } else {
-        console.error(
+        logger.error(
           'AudioOutputControl cannot select audio output device because browser does not support setSinkId operation.'
         );
       }

--- a/src/hooks/sdk/useSelectVideoQuality.tsx
+++ b/src/hooks/sdk/useSelectVideoQuality.tsx
@@ -4,11 +4,13 @@
 import { useCallback } from 'react';
 
 import { useAudioVideo } from '../../providers/AudioVideoProvider';
+import { useLogger } from '../../providers/LoggerProvider';
 
 export type VideoQuality = '360p' | '540p' | '720p';
 
 export function useSelectVideoQuality(): (quality: VideoQuality) => void {
   const audioVideo = useAudioVideo();
+  const logger = useLogger();
 
   const selectVideoQuality = useCallback(
     (quality: VideoQuality) => {
@@ -16,7 +18,7 @@ export function useSelectVideoQuality(): (quality: VideoQuality) => void {
         return;
       }
 
-      console.log(`Selecting video quality: ${quality}`);
+      logger.info(`Selecting video quality: ${quality}`);
 
       switch (quality) {
         case '360p':
@@ -32,7 +34,7 @@ export function useSelectVideoQuality(): (quality: VideoQuality) => void {
           audioVideo.setVideoMaxBandwidthKbps(1400);
           break;
         default:
-          console.log(`Unsupported video quality: ${quality}`);
+          logger.warn(`Unsupported video quality: ${quality}`);
       }
     },
     [audioVideo]

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,6 +174,11 @@ export {
   useMeetingEvent,
   MeetingEventProvider,
 } from './providers/MeetingEventProvider';
+export {
+  LoggerProvider,
+  LoggerContext,
+  useLogger,
+} from './providers/LoggerProvider';
 
 // Themes
 export { lightTheme, darkTheme, GlobalStyles, StyledReset } from './theme';

--- a/src/providers/BackgroundBlurProvider/index.tsx
+++ b/src/providers/BackgroundBlurProvider/index.tsx
@@ -24,6 +24,7 @@ import React, {
 import { BaseSdkProps } from '../../components/sdk/Base';
 import { isPrevNextEmpty, isPrevNextUndefined } from '../../utils/device-utils';
 import useMemoCompare from '../../utils/use-memo-compare';
+import { useLogger } from '../LoggerProvider';
 
 interface Props extends BaseSdkProps {
   /** The spec defines the assets that will be used for adding background blur to a frame. For more information, refer to
@@ -46,6 +47,7 @@ const BackgroundBlurProviderContext = createContext<
 >(undefined);
 
 const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
+  const logger = useLogger();
   const [isBackgroundBlurSupported, setIsBackgroundBlurSupported] = useState<
     boolean | undefined
   >(undefined);
@@ -88,7 +90,7 @@ const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
   useEffect(() => {
     initializeBackgroundBlur();
     return () => {
-      console.log(
+      logger.info(
         'Specs or options were changed. Destroying and re-initializing background blur processor.'
       );
       processor?.destroy();
@@ -98,7 +100,11 @@ const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
   async function initializeBackgroundBlur(): Promise<
     BackgroundBlurProcessor | undefined
   > {
-    console.log('Initializing background blur processor with', spec, options);
+    logger.info(
+      `Initializing background blur processor with, spec: ${JSON.stringify(
+        spec
+      )}, options: ${JSON.stringify(options)}`
+    );
 
     try {
       const createdProcessor = await BackgroundBlurVideoFrameProcessor.create(
@@ -110,12 +116,12 @@ const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
       // BackgroundBlurVideoFrameProcessor.create() can also throw an error in case loading
       // the assets are not fetched successfully.
       if (createdProcessor instanceof NoOpVideoFrameProcessor) {
-        console.warn('Initialized NoOpVideoFrameProcessor');
+        logger.warn('Initialized NoOpVideoFrameProcessor');
         setProcessor(undefined);
         setIsBackgroundBlurSupported(false);
         return undefined;
       } else {
-        console.log(
+        logger.info(
           `Initialized background blur processor: ${JSON.stringify(
             createdProcessor
           )}`
@@ -125,9 +131,8 @@ const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
         return createdProcessor;
       }
     } catch (error) {
-      console.error(
-        `Error creating a background blur video frame processor device`,
-        error
+      logger.error(
+        `Error creating a background blur video frame processor device ${error}`
       );
       setProcessor(undefined);
       setIsBackgroundBlurSupported(false);
@@ -138,7 +143,7 @@ const BackgroundBlurProvider: FC<Props> = ({ spec, options, children }) => {
   const createBackgroundBlurDevice = async (
     selectedDevice: Device
   ): Promise<DefaultVideoTransformDevice> => {
-    console.log(
+    logger.info(
       `Calling createBackgroundBlurDevice with device: ${JSON.stringify(
         selectedDevice
       )}`

--- a/src/providers/BackgroundReplacementProvider/index.tsx
+++ b/src/providers/BackgroundReplacementProvider/index.tsx
@@ -24,6 +24,7 @@ import React, {
 import { BaseSdkProps } from '../../components/sdk/Base';
 import { isPrevNextEmpty, isPrevNextUndefined } from '../../utils/device-utils';
 import useMemoCompare from '../../utils/use-memo-compare';
+import { useLogger } from '../LoggerProvider';
 
 interface Props extends BaseSdkProps {
   /** The spec defines the assets that will be used for adding background replacement to a frame. For more information, refer to
@@ -50,6 +51,7 @@ const BackgroundReplacementProvider: FC<Props> = ({
   options,
   children,
 }) => {
+  const logger = useLogger();
   const [
     isBackgroundReplacementSupported,
     setIsBackgroundReplacementSupported,
@@ -95,7 +97,7 @@ const BackgroundReplacementProvider: FC<Props> = ({
   useEffect(() => {
     initializeBackgroundReplacement();
     return () => {
-      console.log(
+      logger.info(
         'Specs or options were changed. Destroying and re-initializing background replacement processor.'
       );
       processor?.destroy();
@@ -105,10 +107,10 @@ const BackgroundReplacementProvider: FC<Props> = ({
   async function initializeBackgroundReplacement(): Promise<
     BackgroundReplacementProcessor | undefined
   > {
-    console.log(
-      'Initializing background replacement processor with ',
-      spec,
-      options
+    logger.info(
+      `Initializing background replacement processor with, ${JSON.stringify(
+        spec
+      )}, ${JSON.stringify(options)}`
     );
 
     try {
@@ -122,12 +124,12 @@ const BackgroundReplacementProvider: FC<Props> = ({
       // BackgroundReplacementVideoFrameProcessor.create() can also throw an error in case loading
       // the assets are not fetched successfully.
       if (createdProcessor instanceof NoOpVideoFrameProcessor) {
-        console.warn('Initialized NoOpVideoFrameProcessor');
+        logger.warn('Initialized NoOpVideoFrameProcessor');
         setProcessor(undefined);
         setIsBackgroundReplacementSupported(false);
         return undefined;
       } else {
-        console.log(
+        logger.info(
           `Initialized background replacement processor: ${JSON.stringify(
             createdProcessor
           )}`
@@ -137,9 +139,8 @@ const BackgroundReplacementProvider: FC<Props> = ({
         return createdProcessor;
       }
     } catch (error) {
-      console.error(
-        `Error creating a background replacement video frame processor device.`,
-        error
+      logger.error(
+        `Error creating a background replacement video frame processor device. ${error}`
       );
       setProcessor(undefined);
       setIsBackgroundReplacementSupported(false);
@@ -150,7 +151,7 @@ const BackgroundReplacementProvider: FC<Props> = ({
   const createBackgroundReplacementDevice = async (
     selectedDevice: Device
   ): Promise<DefaultVideoTransformDevice> => {
-    console.log(
+    logger.info(
       `Calling createBackgroundReplacementDevice with device: ${JSON.stringify(
         selectedDevice
       )}`

--- a/src/providers/DevicesProvider/AudioInputProvider.tsx
+++ b/src/providers/DevicesProvider/AudioInputProvider.tsx
@@ -16,6 +16,7 @@ import React, {
 
 import { AudioInputContextType } from '../../types';
 import { useAudioVideo } from '../AudioVideoProvider';
+import { useLogger } from '../LoggerProvider';
 import { useMeetingManager } from '../MeetingProvider';
 
 interface Props {
@@ -31,6 +32,7 @@ const AudioInputProvider: React.FC<Props> = ({
   children,
   onDeviceReplacement,
 }) => {
+  const logger = useLogger();
   const meetingManager = useMeetingManager();
   const audioVideo = useAudioVideo();
   const [audioInputs, setAudioInputs] = useState<MediaDeviceInfo[]>([]);
@@ -67,7 +69,7 @@ const AudioInputProvider: React.FC<Props> = ({
 
     const observer: DeviceChangeObserver = {
       audioInputsChanged: async (newAudioInputs: MediaDeviceInfo[]) => {
-        console.log('AudioInputProvider - audio inputs updated');
+        logger.info('AudioInputProvider - audio inputs updated');
 
         const hasSelectedDevice = newAudioInputs.some(
           (device) => device.deviceId === selectedInputRef.current
@@ -79,7 +81,7 @@ const AudioInputProvider: React.FC<Props> = ({
           !hasSelectedDevice &&
           newAudioInputs.length
         ) {
-          console.log(
+          logger.info(
             'Previously selected audio input lost. Selecting a default device.'
           );
           nextInput = newAudioInputs[0].deviceId;
@@ -87,7 +89,7 @@ const AudioInputProvider: React.FC<Props> = ({
           // Safari and Firefox don't have this "default" as device Id
           // Only Chrome have this "default" device
         } else if (selectedInputRef.current === 'default') {
-          console.log(
+          logger.info(
             `Audio devices updated and "default" device is selected. Reselecting input.`
           );
         }
@@ -96,7 +98,7 @@ const AudioInputProvider: React.FC<Props> = ({
         try {
           await meetingManager.selectAudioInputDevice(nextDevice);
         } catch (e) {
-          console.error(
+          logger.error(
             `Failed to select audio input device on audioInputsChanged: ${e}`
           );
         }

--- a/src/providers/DevicesProvider/AudioOutputProvider.tsx
+++ b/src/providers/DevicesProvider/AudioOutputProvider.tsx
@@ -12,11 +12,13 @@ import React, {
 
 import { AudioOutputContextType } from '../../types';
 import { useAudioVideo } from '../AudioVideoProvider';
+import { useLogger } from '../LoggerProvider';
 import { useMeetingManager } from '../MeetingProvider';
 
 const AudioOutputContext = createContext<AudioOutputContextType | null>(null);
 
 const AudioOutputProvider: React.FC = ({ children }) => {
+  const logger = useLogger();
   const audioVideo = useAudioVideo();
   const [audioOutputs, setAudioOutputs] = useState<MediaDeviceInfo[]>([]);
   const meetingManager = useMeetingManager();
@@ -41,7 +43,7 @@ const AudioOutputProvider: React.FC = ({ children }) => {
 
     const observer: DeviceChangeObserver = {
       audioOutputsChanged: (newAudioOutputs: MediaDeviceInfo[]) => {
-        console.log('AudioOutputProvider - audio outputs updated');
+        logger.info('AudioOutputProvider - audio outputs updated');
         setAudioOutputs(newAudioOutputs);
       },
     };

--- a/src/providers/DevicesProvider/VideoInputProvider.tsx
+++ b/src/providers/DevicesProvider/VideoInputProvider.tsx
@@ -12,11 +12,13 @@ import React, {
 
 import { VideoInputContextType } from '../../types';
 import { useAudioVideo } from '../AudioVideoProvider';
+import { useLogger } from '../LoggerProvider';
 import { useMeetingManager } from '../MeetingProvider';
 
 const Context = createContext<VideoInputContextType | null>(null);
 
 const VideoInputProvider: React.FC = ({ children }) => {
+  const logger = useLogger();
   const audioVideo = useAudioVideo();
   const [videoInputs, setVideoInputs] = useState<MediaDeviceInfo[]>([]);
   const meetingManager = useMeetingManager();
@@ -41,7 +43,7 @@ const VideoInputProvider: React.FC = ({ children }) => {
 
     const observer: DeviceChangeObserver = {
       videoInputsChanged: (newVideoInputs: MediaDeviceInfo[]) => {
-        console.log('VideoInputProvider - video inputs updated');
+        logger.info('VideoInputProvider - video inputs updated');
         setVideoInputs(newVideoInputs);
       },
     };

--- a/src/providers/LocalAudioOutputProvider/index.tsx
+++ b/src/providers/LocalAudioOutputProvider/index.tsx
@@ -13,10 +13,12 @@ import React, {
 
 import { LocalAudioOutputContextType } from '../../types';
 import { useAudioVideo } from '../AudioVideoProvider';
+import { useLogger } from '../LoggerProvider';
 
 const Context = createContext<LocalAudioOutputContextType | null>(null);
 
 const LocalAudioOutputProvider: React.FC = ({ children }) => {
+  const logger = useLogger();
   const audioVideo = useAudioVideo();
   const [isAudioOn, setIsAudioOn] = useState(true);
   const audioRef = useRef<HTMLAudioElement>(null);
@@ -31,7 +33,7 @@ const LocalAudioOutputProvider: React.FC = ({ children }) => {
         try {
           await audioVideo.bindAudioElement(element);
         } catch (e) {
-          console.error('Failed to bind audio element.', e);
+          logger.error(`Failed to bind audio element. ${e}`);
         }
       })(audioRef.current);
     }
@@ -53,7 +55,7 @@ const LocalAudioOutputProvider: React.FC = ({ children }) => {
         try {
           await audioVideo?.bindAudioElement(element);
         } catch (e) {
-          console.error('Failed to bind audio element.', e);
+          logger.error(`Failed to bind audio element. ${e}`);
         }
       })(audioRef.current);
     }

--- a/src/providers/LocalVideoProvider/index.tsx
+++ b/src/providers/LocalVideoProvider/index.tsx
@@ -14,11 +14,13 @@ import React, {
 import { LocalVideoContextType } from '../../types';
 import { useAudioVideo } from '../AudioVideoProvider';
 import { useVideoInputs } from '../DevicesProvider';
+import { useLogger } from '../LoggerProvider';
 import { useMeetingManager } from '../MeetingProvider';
 
 const Context = createContext<LocalVideoContextType | null>(null);
 
 const LocalVideoProvider: React.FC = ({ children }) => {
+  const logger = useLogger();
   const meetingManager = useMeetingManager();
   const audioVideo = useAudioVideo();
   const { selectedDevice } = useVideoInputs();
@@ -42,9 +44,8 @@ const LocalVideoProvider: React.FC = ({ children }) => {
         } else {
           setHasReachedVideoLimit(false);
         }
-        console.log(
-          'video availability changed: canStartLocalVideo ',
-          availability.canStartLocalVideo
+        logger.info(
+          `video availability changed: canStartLocalVideo ${availability.canStartLocalVideo}`
         );
       },
     };
@@ -58,7 +59,7 @@ const LocalVideoProvider: React.FC = ({ children }) => {
 
   useEffect(() => {
     if (hasReachedVideoLimit) {
-      console.warn('Reach the number of maximum active videos');
+      logger.warn('Reach the number of maximum active videos');
     }
   }, [hasReachedVideoLimit]);
 
@@ -66,7 +67,7 @@ const LocalVideoProvider: React.FC = ({ children }) => {
     try {
       if (isVideoEnabled || !selectedDevice) {
         if (!selectedDevice) {
-          console.warn('There is no input video device chosen!');
+          logger.warn('There is no input video device chosen!');
         }
         await audioVideo?.stopVideoInput();
         setIsVideoEnabled(false);
@@ -75,12 +76,10 @@ const LocalVideoProvider: React.FC = ({ children }) => {
         audioVideo?.startLocalVideoTile();
         setIsVideoEnabled(true);
       } else {
-        console.error(
-          'Video limit is reached and can not turn on more videos!'
-        );
+        logger.error('Video limit is reached and can not turn on more videos!');
       }
     } catch (error) {
-      console.error('Failed to toggle video');
+      logger.error('Failed to toggle video');
     }
   }, [audioVideo, isVideoEnabled, hasReachedVideoLimit, selectedDevice]);
 

--- a/src/providers/LoggerProvider/index.tsx
+++ b/src/providers/LoggerProvider/index.tsx
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ConsoleLogger, Logger, LogLevel } from 'amazon-chime-sdk-js';
+import React, { useContext } from 'react';
+
+const consoleLogger: Logger = new ConsoleLogger(
+  'ChimeSDKReactComponent',
+  LogLevel.INFO
+);
+export const LoggerContext = React.createContext<Logger>(consoleLogger);
+
+interface Props {
+  logger: Logger;
+}
+
+export const LoggerProvider: React.FC<Props> = ({ logger, children }) => {
+  return (
+    <LoggerContext.Provider value={logger}>{children}</LoggerContext.Provider>
+  );
+};
+
+export const useLogger = (): Logger => {
+  const logger = useContext(LoggerContext);
+  return logger;
+};

--- a/src/providers/MeetingProvider/index.tsx
+++ b/src/providers/MeetingProvider/index.tsx
@@ -10,6 +10,7 @@ import { DevicesProvider } from '../DevicesProvider';
 import { FeaturedVideoTileProvider } from '../FeaturedVideoTileProvider';
 import { LocalAudioOutputProvider } from '../LocalAudioOutputProvider';
 import { LocalVideoProvider } from '../LocalVideoProvider';
+import { useLogger } from '../LoggerProvider';
 import { MeetingEventProvider } from '../MeetingEventProvider';
 import { RemoteVideoTileProvider } from '../RemoteVideoTileProvider';
 import { RosterProvider } from '../RosterProvider';
@@ -34,8 +35,9 @@ export const MeetingProvider: React.FC<Props> = ({
   meetingManager: meetingManagerProp,
   children,
 }) => {
+  const logger = useLogger();
   const [meetingManager] = useState(
-    () => meetingManagerProp || new MeetingManager()
+    () => meetingManagerProp || new MeetingManager(logger)
   );
 
   return (

--- a/src/providers/MeetingProvider/types.ts
+++ b/src/providers/MeetingProvider/types.ts
@@ -20,9 +20,6 @@ export enum DevicePermissionStatus {
 export interface MeetingManagerJoinOptions {
   deviceLabels?: DeviceLabels | DeviceLabelTrigger;
   eventController?: EventController;
-  logLevel?: LogLevel;
-  postLoggerConfig?: PostLoggerConfig;
-  logger?: Logger;
   enableWebAudio?: boolean;
   activeSpeakerPolicy?: ActiveSpeakerPolicy;
 }
@@ -35,7 +32,6 @@ export interface AttendeeResponse {
 export type ParsedJoinParams = {
   deviceLabels: DeviceLabels | DeviceLabelTrigger;
   eventController: EventController | undefined;
-  logger: Logger;
   enableWebAudio: boolean;
   activeSpeakerPolicy: ActiveSpeakerPolicy;
 };
@@ -49,10 +45,3 @@ export type FullDeviceInfoType = {
   videoInputDevices: MediaDeviceInfo[] | null;
 };
 
-export interface PostLoggerConfig {
-  name: string;
-  batchSize: number;
-  intervalMs: number;
-  url: string;
-  logLevel: LogLevel;
-}

--- a/src/providers/VoiceFocusProvider/index.tsx
+++ b/src/providers/VoiceFocusProvider/index.tsx
@@ -12,6 +12,7 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 
 import { JoinMeetingInfo } from '../../types';
 import useMemoCompare from '../../utils/use-memo-compare';
+import { useLogger } from '../LoggerProvider';
 
 interface Props {
   /** Determines how you want Amazon Voice Focus to behave. This spec is used to derive a runtime configuration when a transformer is created. */
@@ -42,6 +43,7 @@ const VoiceFocusProvider: React.FC<Props> = ({
   createMeetingResponse,
   children,
 }) => {
+  const logger = useLogger();
   const [isVoiceFocusSupported, setIsVoiceFocusSupported] = useState<
     boolean | undefined
   >(undefined);
@@ -85,14 +87,13 @@ const VoiceFocusProvider: React.FC<Props> = ({
   const addVoiceFocus = async (
     device: Device
   ): Promise<Device | VoiceFocusTransformDevice> => {
-    console.info(
-      'Add Amazon Voice Focus to the following audio input device',
-      device
+    logger.info(
+      `Add Amazon Voice Focus to the following audio input device ${device}`
     );
 
     if (voiceFocusDevice) {
       const vf = await voiceFocusDevice.chooseNewInnerDevice(device);
-      console.info(
+      logger.info(
         'Re-used the same internal state to create an Amazon Voice Focus transform device.'
       );
       setVoiceFocusDevice(vf);
@@ -100,7 +101,7 @@ const VoiceFocusProvider: React.FC<Props> = ({
     }
 
     if (!isVoiceFocusSupported) {
-      console.debug('Not supported, not creating device.');
+      logger.debug('Not supported, not creating device.');
       return device;
     }
 
@@ -108,12 +109,12 @@ const VoiceFocusProvider: React.FC<Props> = ({
       const transformer = await getVoiceFocusDeviceTransformer();
       const vf = await transformer?.createTransformDevice(device);
       if (vf) {
-        console.info('Created a new Amazon Voice Focus transform device.');
+        logger.info('Created a new Amazon Voice Focus transform device.');
         setVoiceFocusDevice(vf);
         return vf;
       }
     } catch (e) {
-      console.warn('Amazon Voice Focus is not supported.', e);
+      logger.error(`Amazon Voice Focus is not supported. ${e}`);
     }
 
     return device;
@@ -213,17 +214,16 @@ const VoiceFocusProvider: React.FC<Props> = ({
     }
 
     if (isVoiceFocusSupported) {
-      console.info('Amazon Voice Focus is supported.');
+      logger.info('Amazon Voice Focus is supported.');
     } else {
-      console.warn('Amazon Voice Focus is not supported.');
+      logger.warn('Amazon Voice Focus is not supported.');
     }
   }, [isVoiceFocusSupported]);
 
   useEffect(() => {
     if (voiceFocusDevice) {
-      console.info(
-        'Current Amazon Voice Focus transform device: ',
-        voiceFocusDevice
+      logger.info(
+        `Current Amazon Voice Focus transform device: ${voiceFocusDevice}`
       );
     }
   }, [voiceFocusDevice]);

--- a/tst/hooks/sdk/useActiveSpeakersState.test.tsx
+++ b/tst/hooks/sdk/useActiveSpeakersState.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { renderHook } from '@testing-library/react-hooks';
-import { LogLevel } from 'amazon-chime-sdk-js';
+import { ConsoleLogger } from 'amazon-chime-sdk-js';
 import React from 'react';
 
 import useActiveSpeakersState from '../../../src/hooks/sdk/useActiveSpeakersState';
@@ -32,7 +32,7 @@ describe('useActiveSpeakersState', () => {
     const { result, unmount } = renderHook(() => useActiveSpeakersState(), {
       wrapper: ({ children }) => (
         <MeetingContext.Provider
-          value={ new MeetingManager() }
+          value={ new MeetingManager(new ConsoleLogger('MeetingManager')) }
         >
           {children}
         </MeetingContext.Provider>

--- a/tst/providers/LoggerProvider/index.test.tsx
+++ b/tst/providers/LoggerProvider/index.test.tsx
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { ConsoleLogger, LogLevel } from 'amazon-chime-sdk-js';
+import {
+  LoggerProvider,
+  useLogger,
+} from '../../../src/providers/LoggerProvider';
+
+describe('useLogger', () => {
+  it('should provide logger if LoggerProvider is used', () => {
+    const logger = new ConsoleLogger('SDK', LogLevel.ERROR);
+    const { result } = renderHook(() => useLogger(), {
+      wrapper: ({ children }) => (
+        <LoggerProvider logger={logger}>{children}</LoggerProvider>
+      ),
+    });
+    expect(result.current.getLogLevel()).toBe(LogLevel.ERROR);
+  });
+
+  it('should provide default ConsoleLogger with INFO log level if LoggerProvider is not used', () => {
+    const { result } = renderHook(() => useLogger());
+    expect(result.current.getLogLevel()).toBe(LogLevel.INFO);
+  });
+});

--- a/tst/providers/MeetingProvider/MeetingManager.test.ts
+++ b/tst/providers/MeetingProvider/MeetingManager.test.ts
@@ -8,10 +8,7 @@ import {
   DefaultActiveSpeakerPolicy,
   DefaultDeviceController,
   DefaultMeetingSession,
-  LogLevel,
   MeetingSessionConfiguration,
-  // MeetingSessionPOSTLogger,
-  MultiLogger,
 } from 'amazon-chime-sdk-js';
 
 import { MeetingManager } from '../../../src/providers/MeetingProvider/MeetingManager';
@@ -28,16 +25,7 @@ describe('Meeting Manager', () => {
     // @ts-ignore
     MeetingSessionConfiguration = jest.fn().mockImplementation(() => {});
     mockMeetingSessionConfiguration = new MeetingSessionConfiguration();
-    mockMeetingManagerJoinOptions = {
-      logLevel: LogLevel.WARN,
-    };
-    meetingManager = new MeetingManager();
-    // @ts-ignore
-    ConsoleLogger = jest.fn().mockReturnValue({});
-    // @ts-ignore 
-    MultiLogger = jest.fn().mockReturnValue({});
-    // @ts-ignore
-    // MeetingSessionPOSTLogger = jest.fn().mockReturnValue({});
+    meetingManager = new MeetingManager(new ConsoleLogger('MeetingManager'));
     // @ts-ignore
     DefaultDeviceController = jest.fn().mockReturnValue({});
     // @ts-ignore
@@ -68,67 +56,6 @@ describe('Meeting Manager', () => {
   });
 
   describe('join', () => {
-    it('should call MeetingSessionPOSTLogger with PostLogConfig', async () => {
-      mockMeetingManagerJoinOptions = {
-        logLevel: LogLevel.ERROR,
-        postLoggerConfig: {
-          name: 'Test',
-          batchSize: 20,
-          intervalMs: 100,
-          url: 'http://test-url.com',
-          logLevel: LogLevel.INFO,
-        }
-      }
-      await meetingManager.join(mockMeetingSessionConfiguration, mockMeetingManagerJoinOptions);
-    //   expect(MeetingSessionPOSTLogger).toHaveBeenCalledWith(
-    //     'Test',
-    //     mockMeetingSessionConfiguration,
-    //     20,
-    //     100,
-    //     'http://test-url.com',
-    //     LogLevel.INFO,
-    // );
-    //   expect(MeetingSessionPOSTLogger).toHaveBeenCalledTimes(1);
-    });
-
-    it('should call MultiLogger if PostLoggerConfig is passed', async () => {
-      mockMeetingManagerJoinOptions = {
-        logLevel: LogLevel.ERROR,
-        postLoggerConfig: {
-          name: 'Test',
-          batchSize: 20,
-          intervalMs: 100,
-          url: 'http://test-url.com',
-          logLevel: LogLevel.INFO,
-        }
-      }
-      await meetingManager.join(mockMeetingSessionConfiguration, mockMeetingManagerJoinOptions);
-      expect(ConsoleLogger).toHaveBeenCalledWith(
-        'SDK',
-        LogLevel.ERROR,
-      );
-      // expect(MeetingSessionPOSTLogger).toHaveBeenCalledWith(
-      //   'Test',
-      //   mockMeetingSessionConfiguration,
-      //   20,
-      //   100,
-      //   'http://test-url.com',
-      //   LogLevel.INFO,
-      // );
-      // expect(MultiLogger).toHaveBeenCalledWith(
-      //   new ConsoleLogger('SDK', LogLevel.ERROR),
-      //   new MeetingSessionPOSTLogger(
-      //     'Test',
-      //     mockMeetingSessionConfiguration,
-      //     20,
-      //     100,
-      //     'http://test-url.com',
-      //     LogLevel.INFO,
-      //   ),
-      // );
-      expect(MultiLogger).toHaveBeenCalledTimes(1);
-    });
-
     it('should call subscribeToActiveSpeakerDetector with new DefaultActiveSpeakerPolicy if one is not passed via MeetinManagerJoinOptions', async () => {
       await meetingManager.join(mockMeetingSessionConfiguration, mockMeetingManagerJoinOptions);
       expect(meetingManager?.audioVideo?.subscribeToActiveSpeakerDetector).toHaveBeenCalledWith(

--- a/tst/providers/MeetingProvider/index.test.tsx
+++ b/tst/providers/MeetingProvider/index.test.tsx
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  ConsoleLogger,
   DefaultEventController,
   EventAttributes,
   EventName,
-  LogLevel,
   MeetingSessionConfiguration,
   MeetingSessionCredentials,
   MeetingSessionURLs,
@@ -48,10 +48,9 @@ describe('Meeting Provider', () => {
       new NoOpDebugLogger(),
       );
     let meetingManagerJoinOptions: MeetingManagerJoinOptions = {
-      logLevel: LogLevel.OFF,
       eventController: eventController,
     };
-    let meetingManager = new MeetingManager();
+    let meetingManager = new MeetingManager(new ConsoleLogger('MeetingManager'));
     await meetingManager.join(new MeetingSessionConfiguration(joinData.meetingInfo, joinData.attendeeInfo),
       meetingManagerJoinOptions,
     );


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
- Add `LoggerProvider` and `useLogger`.
- Update console.log|info|warn|error usages to use `logger` from `useLogger`.
- Add unit test and update existing tests for the change.
- Meeting Demo update PR depending on this change: https://github.com/aws-samples/amazon-chime-sdk/pull/184

**Testing**
1. Have you successfully run `npm run build:release` locally?
- Yes.

3. How did you test these changes?
- Updated the React meeting demo in AWS Samples.
- Deployed it and checked whether we get console logs as well as logs in AWS CloudWatch in the deployed account.
- If `LoggerProvider` is not mounted, only console logger will work as it is provided by default.

5. If you made changes to the component library, have you provided corresponding documentation changes?
- yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
