### PR TITLE
Fix npm install command line in migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix command line sample to install latest node dependencies in migration guides.
+
 ## [3.0.0] - 2022-03-17
 
 Amazon Chime SDK React Components Library v3 is here !! 🎉🎉🎉

--- a/src/components/migrationToV2.stories.mdx
+++ b/src/components/migrationToV2.stories.mdx
@@ -23,7 +23,7 @@ Installation involves adjusting your package.json to depend on version 2.x.x and
 
 ```
 npm uninstall amazon-chime-sdk-js
-npm install --save amazon-chime-sdk-component-library-react@2 amazon-chime-sdk-js
+npm install --save amazon-chime-sdk-component-library-react@2 amazon-chime-sdk-js@2
 ```
 
 ## What's New

--- a/src/components/migrationToV3.stories.mdx
+++ b/src/components/migrationToV3.stories.mdx
@@ -14,7 +14,7 @@ Installation involves adjusting your package.json to depend on version 3.x.x
 
 ```
 npm uninstall amazon-chime-sdk-component-library-react amazon-chime-sdk-js
-npm install --save amazon-chime-sdk-component-library-react@beta amazon-chime-sdk-js@beta
+npm install --save amazon-chime-sdk-component-library-react@3 amazon-chime-sdk-js@3
 ```
 
 ## What's New
@@ -421,7 +421,7 @@ const MyChild = () => {
 
 ## Enable logging using `useLogger` and `LoggerProvider`
 
-Please check documentation on [`LoggerProvider`](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/story/sdk-providers-loggerprovider--page) for more information on its usage.
+Please check documentation on [LoggerProvider](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/story/sdk-providers-loggerprovider--page) for more information on its usage.
 
 ## StyledComponent
 


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
* Fix command line sample to install v2, v3 dependencies in migration guide

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
N/A
3. If you made changes to the component library, have you provided corresponding documentation changes?
N/A
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
