### PR TITLE
Clean up the wrong statement in stories of LocalVideoProvider and useLocalVideo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix command line sample to install latest node dependencies in migration guides.
 - Fix the broken markdown URLs due to this [storybook issue](https://github.com/storybookjs/storybook/issues/9005) by replacing markdown links with HTML `<a>` tag.
+- Clarify `setIsVideoEnabled` usage in `LocalVideoProvider` and `useLocalVideo` docs.
 
 ## [3.0.0] - 2022-03-17
 

--- a/src/providers/LocalVideoProvider/docs/LocalVideoProvider.stories.mdx
+++ b/src/providers/LocalVideoProvider/docs/LocalVideoProvider.stories.mdx
@@ -2,9 +2,9 @@
 
 # LocalVideoProvider
 
-The `LocalVideoProvider` provides `tileId` of video tile associated with the local video, `isVideoEnabled` specifying the local video state, `hasReachedVideoLimit` specifying whether or not video limit is reached, and `toggleVideo()` to toggle local video.
+The `LocalVideoProvider` provides `tileId` of video tile associated with the local video, `isVideoEnabled` specifying the local video state, `setIsVideoEnabled` function to set the value of `isVideoEnabled`, `hasReachedVideoLimit` specifying whether or not video limit is reached, and `toggleVideo()` to toggle local video.
 
-The state of the `LocalVideo` component and the state of the `PreviewVideo` component are independent.
+> Note: `setIsVideoEnabled` is a workaround for <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-component-library-react/issues/529">GitHub Issue 529</a> to synchronize the state of `PreviewVideo` and `LocalVideo` internally. This function does not change the actual state of `LocalVideo` and `PreviewVideo`. Don't use this in your application.
 
 The React SDK depends on the Amazon Chime SDK for JavaScript, wherein, a single video stream is attached to a video element at a time. Hence, if `PreviewVideo` and `LocalVideo` component both are rendered on the same page and if both are enabled, stopping the video preview in `PreviewVideo` component will result into disconnecting the video stream for `LocalVideo` as well showing a black screen.
 

--- a/src/providers/LocalVideoProvider/docs/useLocalVideo.stories.mdx
+++ b/src/providers/LocalVideoProvider/docs/useLocalVideo.stories.mdx
@@ -2,9 +2,9 @@
 
 # useLocalVideo
 
-The `useLocalVideo` hook returns `tileId` of video tile associated with the local video, `isVideoEnabled` specifying the local video state, `hasReachedVideoLimit` specifying whether or not video limit is reached, and `toggleVideo()` to toggle local video.
+The `useLocalVideo` hook returns `tileId` of video tile associated with the local video, `isVideoEnabled` specifying the local video state, `setIsVideoEnabled` function to set the value of `isVideoEnabled`, `hasReachedVideoLimit` specifying whether or not video limit is reached, and `toggleVideo()` to toggle local video.
 
-The state of the `LocalVideo` component and the state of the `PreviewVideo` component are independent.
+> Note: `setIsVideoEnabled` is a workaround for <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-component-library-react/issues/529">GitHub Issue 529</a> to synchronize the state of `PreviewVideo` and `LocalVideo` internally. This function does not change the actual state of `LocalVideo` and `PreviewVideo`. Don't use this in your application.
 
 The React SDK depends on the Amazon Chime SDK for JavaScript, wherein, a single video stream is attached to a video element at a time. Hence, if `PreviewVideo` and `LocalVideo` component both are rendered on the same page and if both are enabled, stopping the video preview in `PreviewVideo` component will result into disconnecting the video stream for `LocalVideo` as well showing a black screen.
 
@@ -70,9 +70,9 @@ const MyChild = () => {
     <p>
       {hasReachedVideoLimit ? 'Video limit reached' : 'Video limit not reached'}
     </p>
-    
+
     <button onClick={toggleVideo}>
-      {isVideoEnabled ? 'Stop your video' : hasReachedVideoLimit ? 
+      {isVideoEnabled ? 'Stop your video' : hasReachedVideoLimit ?
       'Has reached the video limit, can not turn on video' : 'Start your video'}
     </button>
   );


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**

* Clean up the wrong statement of preview video state and local video state in stories of `LocalVideoProvider` and `useLocalVideo`.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Run storybook locally and verify it works.

3. If you made changes to the component library, have you provided corresponding documentation changes?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
