### PR TITLE
Revert change to replace markdown links with HTML <a> tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix command line sample to install latest node dependencies in migration guides.
-- Fix the broken markdown URLs due to this [storybook issue](https://github.com/storybookjs/storybook/issues/9005) by replacing markdown links with HTML `<a>` tag.
 - Clarify `setIsVideoEnabled` usage in `LocalVideoProvider` and `useLocalVideo` docs.
 
 ## [3.0.0] - 2022-03-17

--- a/src/components/introduction.stories.mdx
+++ b/src/components/introduction.stories.mdx
@@ -20,8 +20,8 @@ For the majority of use cases, an Amazon Chime application consists of **a serve
 
 The server application and client application could be hosted either locally or in the cloud (serverless).
 
-- For hosting locally, see the <a target="_blank" href="https://github.com/aws-samples/amazon-chime-sdk/tree/main/apps/meeting/src">client application</a> and <a target="_blank" href="https://github.com/aws-samples/amazon-chime-sdk/blob/main/apps/meeting/server.js">server application</a>.
-- For hosting in the cloud, see the <a target="_blank" href="https://github.com/aws-samples/amazon-chime-sdk/tree/main/apps/meeting/serverless">serverless example</a>.
+- For hosting locally, see the [client application](https://github.com/aws-samples/amazon-chime-sdk/tree/main/apps/meeting/src) and [server application](https://github.com/aws-samples/amazon-chime-sdk/blob/main/apps/meeting/server.js).
+- For hosting in the cloud, see the [serverless example](https://github.com/aws-samples/amazon-chime-sdk/tree/main/apps/meeting/serverless).
 
 ## Getting Started
 
@@ -61,14 +61,14 @@ To join a meeting, you need to do the following sub steps:
 
 - Create and join the meeting
 
-First, you need to fetch the meeting and attendee data from Chime's <a target="_blank" href="https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateAttendee.html">CreateAttendee</a> and <a target="_blank" href="https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateMeeting.html">CreateMeeting</a> APIs.
+First, you need to fetch the meeting and attendee data from Chime's [CreateAttendee](https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateAttendee.html) and [CreateMeeting](https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateMeeting.html) APIs.
 
-- Check the <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-js#getting-responses-from-your-server-application">Getting responses from your server application</a> for details.
-- Check the <a target="_blank" href="https://github.com/aws-samples/amazon-chime-sdk/blob/main/apps/meeting/src/containers/MeetingForm/index.tsx">MeetingForm component</a>, the <a target="_blank" href="https://github.com/aws-samples/amazon-chime-sdk/blob/main/apps/meeting/src/utils/api.ts">API calls</a>, and <a target="_blank" href="https://github.com/aws-samples/amazon-chime-sdk/blob/main/apps/meeting/server.js">server application</a> in our <a target="_blank" href="https://github.com/aws-samples/amazon-chime-sdk/tree/main/apps/meeting">React meeting demo</a> as examples.
+- Check the [Getting responses from your server application](https://github.com/aws/amazon-chime-sdk-js#getting-responses-from-your-server-application) for details.
+- Check the [MeetingForm component](https://github.com/aws-samples/amazon-chime-sdk/blob/main/apps/meeting/src/containers/MeetingForm/index.tsx), the [API calls](https://github.com/aws-samples/amazon-chime-sdk/blob/main/apps/meeting/src/utils/api.ts), and [server application](https://github.com/aws-samples/amazon-chime-sdk/blob/main/apps/meeting/server.js) in our [React meeting demo](https://github.com/aws-samples/amazon-chime-sdk/tree/main/apps/meeting) as examples.
 
 Then, initialize `MeetingSessionConfiguration` with the meeting and attendee data from the last step. You can choose to modify the `MeetingSessionConfiguration` properties to customize the meeting to your preference.
 
-Updating the `MeetingSessionConfiguration` props is an optional step. You can learn more about the available props here: <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html">MeetingSessionConfiguration</a>
+Updating the `MeetingSessionConfiguration` props is an optional step. You can learn more about the available props here: [MeetingSessionConfiguration](https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html)
 
 Lastly, pass the `MeetingSessionConfiguration` to the `join` method to create a meeting session. You can now start the meeting session and join the meeting.
 
@@ -117,7 +117,7 @@ const MyMeetingView = () => {
 };
 ```
 
-For more common use cases, please review our <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/story/quick-starts--page">Quick Starts</a> guide.
+For more common use cases, please review our [Quick Starts](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/story/quick-starts--page) guide.
 
 ## FAQ
 

--- a/src/components/migrationToV2.stories.mdx
+++ b/src/components/migrationToV2.stories.mdx
@@ -150,6 +150,6 @@ change it to something like this:
 
 ### Other Changes
 
-The `ChatBubbleContainer` and `Textarea` components now includes the use of `React.forwardRef` and may have a new backwards-incompatible signature. <a target="_blank" href="https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers">Link to source</a>.
+The `ChatBubbleContainer` and `Textarea` components now includes the use of `React.forwardRef` and may have a new backwards-incompatible signature. [Link to source](https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers).
 
 The `Roster` component has been changed from rendering as a `div` to a more semantic `aside` element.

--- a/src/components/migrationToV3.stories.mdx
+++ b/src/components/migrationToV3.stories.mdx
@@ -21,7 +21,7 @@ npm install --save amazon-chime-sdk-component-library-react@3 amazon-chime-sdk-j
 
 Amazon Chime SDK React Components Library v3 includes major improvements for component style customization, `MeetingProvider/MeetingManager` configuration, device management, WebRTC metrics and logger.
 
-- **Component style customization**: Improve components for easier customization of style. Check out our <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/story/styling-guide--page">styling guide</a> for more information.
+- **Component style customization**: Improve components for easier customization of style. Check out our [styling guide](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/story/styling-guide--page) for more information.
 - **`MeetingProvider/MeetingManager` configuration**: Improve `MeetingProvider`, `MeetingManager` and `MeetingManager.join()` API to allow configuring a meeting session right before joining a meeting instead of when `MeetingProvider` mounts.
 - **Device management**: Improve `types` for device selection components to better support basic and transformed devices. Remove `useSelectAudioInputDevice`, `useSelectVideoInputDevice`, and `useSelectAudioOutputDevice` hooks to standardize device selection through `MeetingManager` and throw error when selection fails.
 - **WebRTC metrics**: Publish the standardized WebRTC metrics for all supported browsers. Deprecate `useBandwidthMetrics` hook in favor of `useMediaStreamMetrics` hook.
@@ -254,7 +254,7 @@ const MyApp = () => {
 
 ### `MeetingManager` `join` method parameter change
 
-In V3, `MeetingManager`'s `join` method takes `MeetingSessionConfiguraiton` and `options` as parameter.
+In V3, `MeetingManager`'s `join` method takes `MeetingSessionConfiguration` and `options` as parameter.
 `meetingInfo` and `attendeeInfo` parameters are removed from the interface and are rather passed to the constructor of `MeetingSessionConfiguration`.
 
 Before in 2.x:
@@ -436,25 +436,25 @@ When you implement your own theme, you need to use `globalStyle` instead of `glo
 
 In V3, some of device management APIs, hooks and types have been renamed for more accurate description. To migrate, use new names summarized in table below.
 
-| Before in 2.x                                               | After in 3.x                                               |
-| ----------------------------------------------------------- | ---------------------------------------------------------- |
-| `DevicePermissionStatus`                                    | `DeviceLabelTriggerStatus`                                 |
-| `DevicePermissionStatus.UNSET`                              | `DevicePermissionStatus.UNTRIGGERED`                       |
-| `useDevicePermissionStatus`                                 | `useDeviceLabelTriggerStatus`                              |
-|                                                             |                                                            |
-| `MeetingManager.devicePermissionStatus`                     | `MeetingManager.deviceLabelTriggerStatus`                  |
-|                                                             |                                                            |
-| `MeetingManager.selectAudioInputDevice()`                   | `MeetingManager.startAudioInputDevice()`                   |
-| `MeetingManager.selectAudioOutputDevice()`                  | `MeetingManager.startAudioOutputDevice()`                  |
-| `MeetingManager.selectVideoInputDevice()`                   | `MeetingManager.startVideoInputDevice()`                   |
-|                                                             |                                                            |
-| `MeetingManager.devicePermissionsObservers`                 | `MeetingManager.deviceLabelTriggerStatusObservers`         |
-| `MeetingManager.subscribeToDevicePermissionStatus()`        | `MeetingManager.subscribeToDeviceLabelTriggerStatus()`     |
-| `MeetingManager.unsubscribeFromDevicePermissionStatus()`    | `MeetingManager.unsubscribeFromDeviceLabelTriggerStatus()` |
-|                                                             |                                                            |
-| `MeetingManager.deviceLabelTriggerChangeObservers`          | `MeetingManager.deviceLabelTriggerObservers`               |
-| `MeetingManageer.subscribeToDeviceLabelTriggerChange()`     | `MeetingManageer.subscribeToDeviceLabelTrigger()`          |
-| `MeetingManageer.unsubscribeFromDeviceLabelTriggerChange()` | `MeetingManageer.unsubscribeFromDeviceLabelTrigger()`      |
+| Before in 2.x                                                         | After in 3.x                                                          |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| <code>DevicePermissionStatus</code>                                   | <code>DeviceLabelTriggerStatus</code>                                 |
+| <code>DevicePermissionStatus.UNSET</code>                             | <code>DevicePermissionStatus.UNTRIGGERED</code>                       |
+| <code>useDevicePermissionStatus</code>                                | <code>useDeviceLabelTriggerStatus</code>                              |
+|                                                                       |                                                                       |
+| <code>MeetingManager.devicePermissionStatus</code>                    | <code>MeetingManager.deviceLabelTriggerStatus</code>                  |
+|                                                                       |                                                                       |
+| <code>MeetingManager.selectAudioInputDevice()</code>                  | <code>MeetingManager.startAudioInputDevice()</code>                   |
+| <code>MeetingManager.selectAudioOutputDevice()</code>                 | <code>MeetingManager.startAudioOutputDevice()</code>                  |
+| <code>MeetingManager.selectVideoInputDevice()</code>                  | <code>MeetingManager.startVideoInputDevice()</code>                   |
+|                                                                       |                                                                       |
+| <code>MeetingManager.devicePermissionsObserver</code>                 | <code>MeetingManager.deviceLabelTriggerStatusObservers</code>         |
+| <code>MeetingManager.subscribeToDevicePermissionStatus()</code>       | <code>MeetingManager.subscribeToDeviceLabelTriggerStatus()</code>     |
+| <code>MeetingManager.unsubscribeFromDevicePermissionStatus()</code>   | <code>MeetingManager.unsubscribeFromDeviceLabelTriggerStatus()</code> |
+|                                                                       |                                                                       |
+| <code>MeetingManager.deviceLabelTriggerChangeObservers</code>         | <code>MeetingManager.deviceLabelTriggerObservers</code>               |
+| <code>MeetingManager.subscribeToDeviceLabelTriggerChange()</code>     | <code>MeetingManager.subscribeToDeviceLabelTrigger()</code>           |
+| <code>MeetingManager.unsubscribeFromDeviceLabelTriggerChange()</code> | <code>MeetingManager.unsubscribeFromDeviceLabelTrigger()</code>       |
 
 #### New API for Handling Video Input Device Switching
 
@@ -532,7 +532,6 @@ const MyChild = () => {
 };
 ```
 
-
 ### Update Type of Selected Device in MeetingManager
 
 In V3, we have improved the `type` for selected device in `MeetingManager` and corresponding components and hooks.
@@ -540,15 +539,15 @@ In V3, we have improved the `type` for selected device in `MeetingManager` and c
 #### MeetingManager Properties Change
 
 ```ts
-// Before in 2.x  
-selectedAudioOutputDevice: string | null
-selectedAudioInputDevice: string | null
-selectedVideoInputDevice: string | null
+// Before in 2.x
+selectedAudioOutputDevice: string | null;
+selectedAudioInputDevice: string | null;
+selectedVideoInputDevice: string | null;
 
 // After in 3.x
-selectedAudioOutputDevice: string | null
-selectedAudioInputDevice: AudioInputDevice | undefined
-selectedVideoInputDevice: VideoInputDevice | undefined
+selectedAudioOutputDevice: string | null;
+selectedAudioInputDevice: AudioInputDevice | undefined;
+selectedVideoInputDevice: VideoInputDevice | undefined;
 ```
 
 ```ts
@@ -556,27 +555,28 @@ type Device = string | MediaTrackConstraints | MediaStream;
 type AudioInputDevice = Device | AudioTransformDevice | null;
 type VideoInputDevice = Device | VideoTransformDevice;
 ```
+
 #### Hooks Return Values Change
 
 Before in 2.x
 
 ```js
-// Selected audio output deivce. The type is `string | null`
+// Selected audio output device. The type is `string | null`
 const { selectedDevice } = useAudioOutputs();
-// Selected audio input deivce. The type is `string | null`
+// Selected audio input device. The type is `string | null`
 const { selectedDevice } = useAudioInputs();
-// Selected video input deivce. The type is `string | null`
+// Selected video input device. The type is `string | null`
 const { selectedDevice } = useVideoInputs();
 ```
 
 After in 3.x
 
 ```js
-// Selected audio output deivce. The type is `string | null`
+// Selected audio output device. The type is `string | null`
 const { selectedDevice } = useAudioOutputs();
-// Selected audio input deivce. The type is `AudioInputDevice | undefined`
+// Selected audio input device. The type is `AudioInputDevice | undefined`
 const { selectedDevice } = useAudioInputs();
-// Selected video input deivce. The type is `VideoInputDevice | undefined`
+// Selected video input device. The type is `VideoInputDevice | undefined`
 const { selectedDevice } = useVideoInputs();
 ```
 

--- a/src/components/quickStarts.stories.mdx
+++ b/src/components/quickStarts.stories.mdx
@@ -4,14 +4,14 @@
 
 This section explains how to use the Amazon Chime SDK React Components Library for some common use cases.
 
-Before getting started, make sure you have followed the <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/story/introduction--page">Introduction</a> section.
+Before getting started, make sure you have followed the [Introduction](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/story/introduction--page) section.
 
 ## Join a Meeting in View-Only Mode
 
 To implement a view-only experience, you just need to:
 
 1. On the basis of normal meeting join, pass an additional `deviceLabels` parameter `DeviceLabels.None` to `join()`
-    * See the <a target="_blank" href="https://github.com/aws-samples/amazon-chime-sdk/blob/daefd28611a577877146a46aa189958c5bd0234b/apps/meeting/src/containers/MeetingForm/index.tsx#L72-L85">join in view-only mode example</a>
+    * See the [join in view-only mode example](https://github.com/aws-samples/amazon-chime-sdk/blob/daefd28611a577877146a46aa189958c5bd0234b/apps/meeting/src/containers/MeetingForm/index.tsx#L72-L85)
 
 > **Note:** The view-only mode doesn't impact the ability to view content or listen to audio in your meeting experience.
 
@@ -50,7 +50,7 @@ const MyApp = () => {
 };
 ```
 
-> **Note:** Joining a meeting in view-only mode may result in attendees not being able to join the meeting successfully. This results in an issue where the roster remains empty and the attendee cannot receive audio and video feeds from others. Check the <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-js/issues/474">GitHub Issue</a> for details.
+> **Note:** Joining a meeting in view-only mode may result in attendees not being able to join the meeting successfully. This results in an issue where the roster remains empty and the attendee cannot receive audio and video feeds from others. Check the [GitHub Issue](https://github.com/aws/amazon-chime-sdk-js/issues/474) for details.
 >
 > The Amazon Chime SDK for JavaScript uses the attendee's audio signal to determine whether or not this attendee has joined a meeting. However, the browser's autoplay policy sometimes prohibits this audio signal from being played automatically. You could fix this issue by enabling the autoplay policy:
 >
@@ -226,8 +226,8 @@ Result:
 
 To invoke device permission:
 
-1. Call `invokeDeviceProvider()` method with a parameter of `DeviceLabels` type
-    * See the <a target="_blank" href="https://github.com/aws-samples/amazon-chime-sdk/blob/daefd28611a577877146a46aa189958c5bd0234b/apps/meeting/src/containers/DevicePermissionControl/DevicePermissionControl.tsx">invoke device permission example</a>
+1. Call invokeDeviceProvider() method with a parameter of DeviceLabels type
+    * See the [invoke device permission example](https://github.com/aws-samples/amazon-chime-sdk/blob/daefd28611a577877146a46aa189958c5bd0234b/apps/meeting/src/containers/DevicePermissionControl/DevicePermissionControl.tsx)
 
 For example, a simple App that joins a meeting without invoking device permission prompt, and request the permission for camera and microphone later.
 
@@ -287,15 +287,15 @@ Check out [useDeviceLabelTriggerStatus](?path=/story/sdk-hooks-usedevicelabeltri
 
 ## Enable Camera and Display the Video Stream in the Grid
 
-The <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/docs/sdk-components-videotilegrid--page">`VideoTileGrid`</a> component renders all meeting session video tiles in a responsive grid layout. This includes the local tile, remote tiles, and content share tile. By default a user joins without video, so in order to see the `VideoTileGrid`, there must be at least one video tile being shared.
+The [`VideoTileGrid`](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/docs/sdk-components-videotilegrid--page) component renders all meeting session video tiles in a responsive grid layout. This includes the local tile, remote tiles, and content share tile. By default a user joins without video, so in order to see the `VideoTileGrid`, there must be at least one video tile being shared.
 
 To enable your camera and display the stream:
 
 1. Use `VideoTileGrid` in SDK components to render your camera stream
-2. Use the `toggleVideo()` function returned by <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/docs/sdk-hooks-uselocalvideo--page">`useLocalVideo`</a> hook to enable your camera
+2. Use the `toggleVideo()` function returned by [`useLocalVideo`](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/docs/sdk-hooks-uselocalvideo--page) hook to enable your camera
 
-    * You could also use <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/docs/sdk-components-meetingcontrols-videoinputcontrol--page">`VideoInputControl`</a> component which is also dependent on `useLocalVideo` hook
-        * See the <a target="_blank" href="https://github.com/aws-samples/amazon-chime-sdk/blob/daefd28611a577877146a46aa189958c5bd0234b/apps/meeting/src/containers/MeetingControls/index.tsx#L46">`VideoInputControl` usage example</a>
+    * You could also use [`VideoInputControl`](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/docs/sdk-components-meetingcontrols-videoinputcontrol--page) component which is also dependent on `useLocalVideo` hook
+        * See the [`VideoInputControl` usage example](https://github.com/aws-samples/amazon-chime-sdk/blob/daefd28611a577877146a46aa189958c5bd0234b/apps/meeting/src/containers/MeetingControls/index.tsx#L46)
 
 For example, a simple component to enable the camera and display the video stream.
 
@@ -318,8 +318,8 @@ const MeetingView = () => {
 To use the features of Chime JS SDK in React SDK:
 
 1. Use `useMeetingManager` hook to get the instance of `MeetingManager`
-2. Use <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/interfaces/meetingsession.html">`meetingSession`</a> property of this instance to access the features of Chime JS SDK
-    * You could use <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/docs/sdk-hooks-useaudiovideo--page">`useAudioVideo`</a> to directly access the <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html">`audioVideo`</a> of current `MeetingSession` as well
+2. Use [`meetingSession`](https://aws.github.io/amazon-chime-sdk-js/interfaces/meetingsession.html) property of this instance to access the features of Chime JS SDK
+    * You could use [`useAudioVideo`](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/docs/sdk-hooks-useaudiovideo--page) to directly access the [`audioVideo`](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html) of current `MeetingSession` as well
 
 For example, to enable camera and display the video stream, in addition to using the `toggleVideo()` method returned by `useLocalVideo` hook, you can directly use the `audioVideo` of the Chime JS SDK to achieve the same effect.
 
@@ -391,33 +391,33 @@ const App = () => {
 
 You can use `useMediaStreamMetrics` hook to get video and audio stream quality metrics.
 
-You can find examples and usage of the hook from <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/docs/sdk-hooks-usemediastreammetrics--page">`useMediaStreamMetrics` storybook</a>.
+You can find examples and usage of the hook from [`useMediaStreamMetrics` storybook](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/docs/sdk-hooks-usemediastreammetrics--page).
 
-For UI implementation, check the <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-component-library-react/blob/de22a537d6437073f72d69da30f1703ef4cf40b3/demo/meeting/src/containers/LocalMediaStreamMetrics/index.tsx#L22-L28">`LocalMediaStreamMetrics`</a> and <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-component-library-react/blob/de22a537d6437073f72d69da30f1703ef4cf40b3/demo/meeting/src/containers/VideoStreamMetrics/index.tsx#L27">`VideoStreamMetrics`</a> components in meeting demo for more details.
+For UI implementation, check the [`LocalMediaStreamMetrics`](https://github.com/aws/amazon-chime-sdk-component-library-react/blob/de22a537d6437073f72d69da30f1703ef4cf40b3/demo/meeting/src/containers/LocalMediaStreamMetrics/index.tsx#L22-L28) and [`VideoStreamMetrics`](https://github.com/aws/amazon-chime-sdk-component-library-react/blob/de22a537d6437073f72d69da30f1703ef4cf40b3/demo/meeting/src/containers/VideoStreamMetrics/index.tsx#L27) components in meeting demo for more details.
 
 ## Enable Background Blur and Replacement
 
 You can enable background blur and replacement on your video stream by using the providers called `BackgroundBlurProvider` and `BackgroundReplacementProvider`. The `BackgroundBlurProvider` and `BackgroundReplacementProvider` provides
 a `createBackgroundBlurDevice` and `createBackgroundReplacementDevice` functions that takes in a `Device` type and returns a `VideoTransformDevice`. Once you have the `VideoTransformDevice`,
 you may call `meetingManager.startVideoInputDevice(videoTransformedDevice)` with the `VideoTransformDevice` just as you would with a regular device. Please note that users would also need to call `DefaultVideoTransformDevice.stop` when constructing a new 
-`DefaultVideoTransformDevice` with new video processors. For more information, refer to <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/10_Video_Processor.md#stopping-videotransformdevice">Video Processing APIs</a>.
+`DefaultVideoTransformDevice` with new video processors. For more information, refer to [Video Processing APIs](https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/10_Video_Processor.md#stopping-videotransformdevice).
 
 Optionally, you may use the `VideoInputBackgroundBlurControl` component - it is similar to the `VideoInputControl` component, except it has an
-additional button to enable background blur. If you'd like to create your own background blur control component, you may look at the <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-component-library-react/blob/main/src/components/sdk/MeetingControls/VideoInputBackgroundBlurControl.tsx">`VideoInputBackgroundBlurControl`</a>
+additional button to enable background blur. If you'd like to create your own background blur control component, you may look at the [`VideoInputBackgroundBlurControl`](https://github.com/aws/amazon-chime-sdk-component-library-react/blob/main/src/components/sdk/MeetingControls/VideoInputBackgroundBlurControl.tsx)
 as an example.
 
 One thing to note is that calling `meetingManager.startVideoInputDevice()` with a `Device` type while the current selected video input device is a `VideoTransformDevice`
 will automatically stop any video processor that was previously running. Lastly, make sure to construct a new `DefaultVideoTransformDevice` using `createBackgroundBlurDevice` or `createBackgroundReplacementDevice` if
 the Props of the provider were changed.
 
-You may also refer to the storybook documentation for other examples on how to use <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/docs/sdk-providers-backgroundblurprovider--page">`BackgroundBlurProvider`</a> 
-and <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/docs/sdk-providers-backgroundreplacementprovider--page">`BackgroundReplacementProvider`</a>.
+You may also refer to the storybook documentation for other examples on how to use [`BackgroundBlurProvider`](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/docs/sdk-providers-backgroundblurprovider--page) 
+and [`BackgroundReplacementProvider`](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/docs/sdk-providers-backgroundreplacementprovider--page).
 
-For more documentation on creating a `VideoTransformDevice`, you can refer to the <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-js/blob/master/guides/15_Background_Filter_Video_Processor.md">Background Filter Video Processor Guide</a>.
+For more documentation on creating a `VideoTransformDevice`, you can refer to the [Background Filter Video Processor Guide](https://github.com/aws/amazon-chime-sdk-js/blob/master/guides/15_Background_Filter_Video_Processor.md).
 
 ## Create a Callback Function to Get the Attendee Name
 
-Amazon Chime SDK React Components Library does not include attendee names when building the meeting roster or the video grid. You need to provide a callback function that returns the name of the attendee for a given `chimeAttendeeId` and `externalUserId` to `meetingManager.getAttendee`. See the <a target="_blank" href="https://docs.aws.amazon.com/chime/latest/APIReference/API_GetAttendee.html">GetAttendee</a> for API details. See `createGetAttendeeCallback` function in this <a target="_blank" href="https://github.com/aws-samples/amazon-chime-sdk/blob/main/apps/meeting/src/utils/api.ts">file</a> as an example.
+Amazon Chime SDK React Components Library does not include attendee names when building the meeting roster or the video grid. You need to provide a callback function that returns the name of the attendee for a given `chimeAttendeeId` and `externalUserId` to `meetingManager.getAttendee`. See the [GetAttendee](https://docs.aws.amazon.com/chime/latest/APIReference/API_GetAttendee.html) for API details. See `createGetAttendeeCallback` function in this [file](https://github.com/aws-samples/amazon-chime-sdk/blob/main/apps/meeting/src/utils/api.ts) as an example.
 
 ```jsx
 import { useMeetingManager } from 'amazon-chime-sdk-component-library-react';
@@ -440,10 +440,10 @@ const MyApp = () => {
 
 ## How to Enable a Meeting to Post Logs to a URL?
 
-You can enable posting your logs to a URL by using Amazon Chime SDK for JavaScript <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/classes/postlogger.html">`PostLogger`</a>.
-You have to wrap your components under <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/story/sdk-providers-loggerprovider--page">LoggerProvider</a> and provide a `POSTLogger` object as a `prop` to `LoggerProvider`.
+You can enable posting your logs to a URL by using Amazon Chime SDK for JavaScript [`PostLogger`](https://aws.github.io/amazon-chime-sdk-js/classes/postlogger.html).
+You have to wrap your components under [LoggerProvider](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/story/sdk-providers-loggerprovider--page) and provide a `POSTLogger` object as a `prop` to `LoggerProvider`.
 
-Check JS SDK <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/modules/migrationto_3_0.html#meetingsessionpostlogger-to-postlogger">POSTLogger migration doc</a> for more information on customizing `POSTLogger` object.
+Check JS SDK [POSTLogger migration doc](https://aws.github.io/amazon-chime-sdk-js/modules/migrationto_3_0.html#meetingsessionpostlogger-to-postlogger) for more information on customizing `POSTLogger` object.
 
 ```jsx
 import { LoggerProvider, MeetingProvider } from 'amazon-chime-sdk-component-library-react';
@@ -466,13 +466,13 @@ const Root = () => (
 );
 ```
 
-> The component library's <a target="_blank" href="https://github.com/aws-samples/amazon-chime-sdk/tree/main/apps/meeting/src/meetingConfig.ts">meeting demo</a> showcases above example.
+> The component library's [meeting demo](https://github.com/aws-samples/amazon-chime-sdk/tree/main/apps/meeting/src/meetingConfig.ts) showcases above example.
 > We post the JS SDK logs to AWS CloudWatch once the demo is deployed.
 
 ## Opt-Out of Client Event Ingestion
 
 The Amazon Chime SDK for JavaScript sends meeting events to the Amazon Chime backend to analyze meeting health trends or identify common failures.
-This helps to improve your meeting experience. For more information, check the <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/modules/clientevent_ingestion.html">client event ingestion guide</a> in the Amazon Chime SDK for JavaScript guides.
+This helps to improve your meeting experience. For more information, check the [client event ingestion guide](https://aws.github.io/amazon-chime-sdk-js/modules/clientevent_ingestion.html) in the Amazon Chime SDK for JavaScript guides.
 
 To opt-out of event ingestion from the Amazon Chime SDK for JavaScript, provide a `DefaultEventController` with a `NoOpEventReporter` as the `eventReporter` while joining the meeting.
 
@@ -547,9 +547,9 @@ const MeetingEventReceiver = () => {
 
 The Data Messages feature allows attendees to send small data messages (no larger than 2KB) to other attendees. It can be used to notify attendees of changes in the meeting state or to develop custom collaboration features. Each message is sent on a particular topic, which allows you to tag messages according to their function to make it easier to handle messages of different types.
 
-To learn more, check <a target="_blank" href="https://aws.amazon.com/about-aws/whats-new/2020/05/amazon-chime-sdk-data-messages-real-time-signaling/">Amazon Data Message</a>.
+To learn more, check [Amazon Data Message](https://aws.amazon.com/about-aws/whats-new/2020/05/amazon-chime-sdk-data-messages-real-time-signaling/).
 
-There are two corresponding APIs: <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetoreceivedatamessage">`realtimeSubscribeToReceiveDataMessage`</a> and <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribefromreceivedatamessage">`realtimeUnsubscribeFromReceiveDataMessage`</a>. To use them, you could use either <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/story/sdk-hooks-usemeetingmanager--page">`useMeetingManager`</a> hook or <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/story/sdk-hooks-useaudiovideo--page">`useAudioVideo`</a> hook.
+There are two corresponding APIs: [`realtimeSubscribeToReceiveDataMessage`](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetoreceivedatamessage) and [`realtimeUnsubscribeFromReceiveDataMessage`](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribefromreceivedatamessage). To use them, you could use either [`useMeetingManager`](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/story/sdk-hooks-usemeetingmanager--page) hook or [`useAudioVideo`](https://aws.github.io/amazon-chime-sdk-component-library-react/?path=/story/sdk-hooks-useaudiovideo--page) hook.
 
 ```ts
 const audioVideo = useAudioVideo();

--- a/src/components/sdk/RemoteVideo/RemoteVideo.stories.mdx
+++ b/src/components/sdk/RemoteVideo/RemoteVideo.stories.mdx
@@ -7,7 +7,7 @@ import { RemoteVideo } from './';
 
 The `RemoteVideo` component renders a `VideoTile` and connects the video to the associated tileId.
 
-**Note** - The binding occurs any time the passed tileId changes. If you are working with a list of tiles, make sure to give each item a <a target="_blank" href="https://reactjs.org/docs/lists-and-keys.html">key</a> of the tileId to avoid binding the video unecessarily.
+**Note** - The binding occurs any time the passed tileId changes. If you are working with a list of tiles, make sure to give each item a [key](https://reactjs.org/docs/lists-and-keys.html) of the tileId to avoid binding the video unecessarily.
 
 ## Importing
 

--- a/src/components/stylingGuide.stories.mdx
+++ b/src/components/stylingGuide.stories.mdx
@@ -6,11 +6,11 @@ The Amazon Chime SDK React Component Library is comprised of Providers, Hooks, U
 Each component has some basic styling applied to it, but you can add or override your own styles to the component by using stylesheets,
 `styled-components` or other styling frameworks.
 
-The Amazon Chime SDK React Component Library uses <a target="_blank" href="https://styled-components.com/docs">`styled-components`</a> to attach base styles to all of the components. You must install the peer dependency on `styled-components` to use the library.
+The Amazon Chime SDK React Component Library uses [`styled-components`](https://styled-components.com/docs) to attach base styles to all of the components. You must install the peer dependency on `styled-components` to use the library.
 
 # Base Styles
 
-Every component extends either the <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-component-library-react/blob/61464e15175b0f88d141f968790524c5443ea5d1/src/components/sdk/Base/index.tsx">BaseSdkProps</a> props or <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-component-library-react/blob/61464e15175b0f88d141f968790524c5443ea5d1/src/components/ui/Base/index.ts">BaseProps</a>, which include the `css` and `className` props.
+Every component extends either the [BaseSdkProps](https://github.com/aws/amazon-chime-sdk-component-library-react/blob/61464e15175b0f88d141f968790524c5443ea5d1/src/components/sdk/Base/index.tsx) props or [BaseProps](https://github.com/aws/amazon-chime-sdk-component-library-react/blob/61464e15175b0f88d141f968790524c5443ea5d1/src/components/ui/Base/index.ts), which include the `css` and `className` props.
 
 # Override base styles on a component
 
@@ -24,7 +24,7 @@ In order to select these DOM elements in your stylesheets, you can refer to the 
 The first method is to use the `className` prop and apply your own classes to the top level DOM element that, in some cases, contain child DOM elements.
 This is the preferred method if you are making more than a couple styling changes to the component.
 
-The base styles were designed to hold a low specificity, however due to <a target="_blank" href="https://styled-components.com/docs/advanced#issues-with-specificity">this caveat</a> with using `styled-components`, when you select DOM elements in your own stylesheet, you'll need
+The base styles were designed to hold a low specificity, however due to [this caveat](https://styled-components.com/docs/advanced#issues-with-specificity) with using `styled-components`, when you select DOM elements in your own stylesheet, you'll need
 to use a higher specificity than just one class selector, otherwise the base styles applied by `styled-components` will override your styles.
 
 ```jsx
@@ -42,7 +42,7 @@ Then, in your stylesheet, you need to specify the class name:
 }
 ```
 
-The reason for having to specify the class selector twice is due to <a target="_blank" href="https://styled-components.com/docs/advanced#issues-with-specificity">this caveat</a> with `styled-components`.
+The reason for having to specify the class selector twice is due to [this caveat](https://styled-components.com/docs/advanced#issues-with-specificity) with `styled-components`.
 
 ## 2. Override styles using `styled-components`
 
@@ -93,7 +93,7 @@ Example of `./style.scss`:
 }
 ```
 
-The reason for having to specify the class selector twice is due to <a target="_blank" href="https://styled-components.com/docs/advanced#issues-with-specificity">this caveat</a> with `styled-components`.
+The reason for having to specify the class selector twice is due to [this caveat](https://styled-components.com/docs/advanced#issues-with-specificity) with `styled-components`.
 
 ## 2. Using `styled-components`
 

--- a/src/hooks/sdk/docs/useActiveSpeakersState.stories.mdx
+++ b/src/hooks/sdk/docs/useActiveSpeakersState.stories.mdx
@@ -4,7 +4,7 @@
 
 The `useActiveSpeakersState` hook returns a list of attendee IDs of active speaker.
 
-The list is sorted from most 'active' to least. See the <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/interfaces/activespeakerdetector.html">Chime SDK's ActiveSpeakerDetector</a> for more details.
+The list is sorted from most 'active' to least. See the [Chime SDK's ActiveSpeakerDetector](https://aws.github.io/amazon-chime-sdk-js/interfaces/activespeakerdetector.html) for more details.
 
 This hook is updated often and causes frequent rendering. You should try to use it at or near the "leaf" components of your application.
 

--- a/src/hooks/sdk/docs/useDeviceLabelTriggerStatus.stories.mdx
+++ b/src/hooks/sdk/docs/useDeviceLabelTriggerStatus.stories.mdx
@@ -2,7 +2,7 @@
 
 # useDeviceLabelTriggerStatus
 
-The `useDeviceLabelTriggerStatus` hook returns the <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-js/blob/bec0e13331ee1ff9198070dd2a6bb1bd289dd14e/src/devicecontroller/DeviceControllerFacade.ts#L25-L37">`DeviceLabelTrigger`</a> status from the enum below.
+The `useDeviceLabelTriggerStatus` hook returns the [DeviceLabelTrigger](https://github.com/aws/amazon-chime-sdk-js/blob/bec0e13331ee1ff9198070dd2a6bb1bd289dd14e/src/devicecontroller/DeviceControllerFacade.ts#L25-L37) status from the enum below.
 
 It tracks if application has triggered the `DeviceLabelTrigger` to request device permission from browser, and if the request is granted or denied.
 

--- a/src/providers/AudioVideoProvider/docs/AudioVideoProvider.stories.mdx
+++ b/src/providers/AudioVideoProvider/docs/AudioVideoProvider.stories.mdx
@@ -2,7 +2,7 @@
 
 # AudioVideoProvider
 
-The `AudioVideoProvider` provides <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html">AudioVideo instance</a> of the meeting session to your application.
+The `AudioVideoProvider` provides [AudioVideo instance](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html) of the meeting session to your application.
 
 This instance is used internally by our components and hooks, but is also available if you need to set up your own observers to the Chime JS SDK.
 
@@ -35,7 +35,7 @@ const MyChild = () => {
 
 ## Usage without MeetingProvider
 
-If you opt out of using MeetingProvider, you can provide the audioVideo instance yourself so that dependent providers, components, hooks can still be used. Refer to the <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/index.html#setup">Chime JS docs</a> for creating your meeting session.
+If you opt out of using MeetingProvider, you can provide the audioVideo instance yourself so that dependent providers, components, hooks can still be used. Refer to the [Chime JS docs](https://aws.github.io/amazon-chime-sdk-js/index.html#setup) for creating your meeting session.
 
 ```jsx
 import React from 'react';

--- a/src/providers/AudioVideoProvider/docs/useAudioVideo.stories.mdx
+++ b/src/providers/AudioVideoProvider/docs/useAudioVideo.stories.mdx
@@ -2,7 +2,7 @@
 
 # useAudioVideo
 
-The `useAudioVideo` hook returns the <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html">AudioVideo instance</a> of a meeting session.
+The `useAudioVideo` hook returns the [AudioVideo instance](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html) of a meeting session.
 
 ### Return Value
 

--- a/src/providers/BackgroundBlurProvider/docs/BackgroundBlurProvider.stories.mdx
+++ b/src/providers/BackgroundBlurProvider/docs/BackgroundBlurProvider.stories.mdx
@@ -27,13 +27,13 @@ when mounted, which may impact performance.
 
 You should see either "processor is supported" or "processor is not supported" in your browser developer tools based on whether or not
 background blur is supported on your device and browser version. For more information on if background blur is supported, refer
-to <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/15_Background_Filter_Video_Processor.md#integrating-background-filters-into-your-amazon-chime-sdk-for-javascript-application">Integrating background filters into your Amazon Chime SDK for JavaScript application</a>.
+to [Integrating background filters into your Amazon Chime SDK for JavaScript application](https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/15_Background_Filter_Video_Processor.md#integrating-background-filters-into-your-amazon-chime-sdk-for-javascript-application).
 
 You can check whether or not the processor has been loaded correctly by checking the state of `isBackgroundBlurSupported`.
 `createBackgroundBlurDevice` may throw an error if the processor was not loaded. You should check whether or not the processor has been loaded correctly by checking the state of `isBackgroundBlurSupported`
 before calling `createBackgroundBlurDevice`. Calling `createBackgroundBlurDevice` will create a new `DefaultVideoTransformDevice`. Users would also need to call `DefaultVideoTransformDevice.stop` when constructing a new
 `DefaultVideoTransformDevice` with `createBackgroundBlurDevice` in order to destroy the processors running previously. Once you call `DefaultVideoTransformDevice.stop`, you should discard the old `DefaultVideoTransformDevice`.
-For more information, refer to <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/10_Video_Processor.md#stopping-videotransformdevice">Video Processing APIs</a>.
+For more information, refer to [Video Processing APIs](https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/10_Video_Processor.md#stopping-videotransformdevice).
 
 One thing to note is that calling `meetingManager.startVideoInputDevice()` with a `Device` type while the current selected video input device is a `VideoTransformDevice`
 will automatically stop any video processor that was previously running. Lastly, make sure to construct a new `DefaultVideoTransformDevice` using `createBackgroundBlurDevice`.

--- a/src/providers/BackgroundBlurProvider/docs/useBackgroundBlur.stories.mdx
+++ b/src/providers/BackgroundBlurProvider/docs/useBackgroundBlur.stories.mdx
@@ -10,12 +10,12 @@ state called `isBackgroundBlurSupported` which indicates whether or not backgrou
 
 You should see either "processor is supported" or "processor is not supported" in your browser developer tools based on whether or not
 background blur is supported on your device and browser version. For more information on if background blur is supported, refer
-to <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/15_Background_Filter_Video_Processor.md#integrating-background-filters-into-your-amazon-chime-sdk-for-javascript-application">Amazon Chime SDK for JavaScript Background blur Guide</a>.
+to [Amazon Chime SDK for JavaScript Background blur Guide](https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/15_Background_Filter_Video_Processor.md#integrating-background-filters-into-your-amazon-chime-sdk-for-javascript-application).
 
 You can check whether or not the processor has been loaded correctly by checking the state of `isBackgroundBlurSupported`.
 `createBackgroundBlurDevice` may throw an error if the processor was not loaded. You should check whether or not the processor has been loaded correctly by checking the state of `isBackgroundBlurSupported`
 before calling `createBackgroundBlurDevice`. Calling `createBackgroundBlurDevice` will create a new processor. Users would also need to stop previously created `DeafultVideoTransformDevice` by calling `DefaultVideoTransformDevice.stop` when constructing a new
-`DefaultVideoTransformDevice` with new video processors. For more information, refer to <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/10_Video_Processor.md#stopping-videotransformdevice">Video Processing APIs</a>.
+`DefaultVideoTransformDevice` with new video processors. For more information, refer to [Video Processing APIs](https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/10_Video_Processor.md#stopping-videotransformdevice).
 Lastly, make sure to construct a new `DefaultVideoTransformDevice` using `createBackgroundBlurDevice` and use it as input if the `Props` of the provider were changed.
 
 Background blur related logs can be found in the browser developer tools when the `BackgroundBlurProvider` is used within the app component tree.

--- a/src/providers/BackgroundReplacementProvider/docs/BackgroundReplacementProvider.stories.mdx
+++ b/src/providers/BackgroundReplacementProvider/docs/BackgroundReplacementProvider.stories.mdx
@@ -27,13 +27,13 @@ when mounted, which may impact performance.
 
 You should see either "processor is supported" or "processor is not supported" in your browser developer tools based on whether or not
 background replacement is supported on your device and browser version. For more information on if background replacement is supported, refer
-to <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/15_Background_Filter_Video_Processor.md#integrating-background-filters-into-your-amazon-chime-sdk-for-javascript-application">Integrating background filters into your Amazon Chime SDK for JavaScript application</a>.
+to [Integrating background filters into your Amazon Chime SDK for JavaScript application](https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/15_Background_Filter_Video_Processor.md#integrating-background-filters-into-your-amazon-chime-sdk-for-javascript-application).
 
 You can check whether or not the processor has been loaded correctly by checking the state of `isBackgroundReplacementSupported`.
 `createBackgroundReplacementDevice` may throw an error if the processor was not loaded. You should check whether or not the processor has been loaded correctly by checking the state of `isBackgroundReplacementSupported`
 before calling `createBackgroundReplacementDevice`. Calling `createBackgroundReplacementDevice` will create a `DefaultVideoTransformDevice`. Users would also need to call `DefaultVideoTransformDevice.stop` when constructing a new
 `DefaultVideoTransformDevice` with `createBackgroundReplacementDevice` in order to destroy the processors running previously. Once you call `DefaultVideoTransformDevice.stop`, you should discard the old `DefaultVideoTransformDevice`.
-For more information, refer to <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/10_Video_Processor.md#stopping-videotransformdevice">Video Processing APIs</a>.
+For more information, refer to [Video Processing APIs](https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/10_Video_Processor.md#stopping-videotransformdevice).
 
 One thing to note is that calling `meetingManager.startVideoInputDevice()` with a `Device` type while the current selected video input device is a `VideoTransformDevice`
 will automatically stop any processors running within a `DefaultVideoTransformDevice` that was previously running. Lastly, make sure to construct a new `DefaultVideoTransformDevice` using `createBackgroundReplacementDevice`.

--- a/src/providers/BackgroundReplacementProvider/docs/useBackgroundReplacement.stories.mdx
+++ b/src/providers/BackgroundReplacementProvider/docs/useBackgroundReplacement.stories.mdx
@@ -10,12 +10,12 @@ state called `isBackgroundReplacementSupported` which indicates whether or not b
 
 You should see either "processor is supported" or "processor is not supported" in your browser developer tools based on whether or not
 background replacement is supported on your device and browser version. For more information on if background replacement is supported, refer
-to <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/15_Background_Filter_Video_Processor.md#integrating-background-filters-into-your-amazon-chime-sdk-for-javascript-application">Amazon Chime SDK for JavaScript Background replacement Guide</a>.
+to [Amazon Chime SDK for JavaScript Background replacement Guide](https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/15_Background_Filter_Video_Processor.md#integrating-background-filters-into-your-amazon-chime-sdk-for-javascript-application).
 
 You can check whether or not the processor has been loaded correctly by checking the state of `isBackgroundReplacementSupported`.
 `createBackgroundReplacementDevice` may throw an error if the processor was not loaded. You should check whether or not the processor has been loaded correctly by checking the state of `isBackgroundReplacementSupported`
 before calling `createBackgroundReplacementDevice`. Calling `createBackgroundReplacementDevice` will create a new processor. Users would also need to stop previously created `DeafultVideoTransformDevice` by calling `DefaultVideoTransformDevice.stop` when constructing a new
-`DefaultVideoTransformDevice` with new video processors. For more information, refer to <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/10_Video_Processor.md#stopping-videotransformdevice">Video Processing APIs</a>;
+`DefaultVideoTransformDevice` with new video processors. For more information, refer to [Video Processing APIs](https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/10_Video_Processor.md#stopping-videotransformdevice);
 Lastly, make sure to construct a new `DefaultVideoTransformDevice` using `createBackgroundReplacementDevice` and use it as input if the `Props` of the provider were changed.
 
 Background replacement related logs can be found in the browser developer tools when the `BackgroundReplacementProvider` is used within the app component tree.

--- a/src/providers/DevicesProvider/docs/AudioOutputProvider.stories.mdx
+++ b/src/providers/DevicesProvider/docs/AudioOutputProvider.stories.mdx
@@ -4,7 +4,7 @@
 
 The `AudioOutputProvider` provides a list of the user's available audio output devices and the currently selected audio output device identified by its `deviceId`.
 
-> Please note that, in Firefox and Safari, the browser does not list the 'audiooutput' media devices yet. We have an <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/modules/faqs.html#i-am-unable-to-select-an-audio-output-device-in-some-browsers-is-this-a-known-issue">FAQ</a> in
+> Please note that, in Firefox and Safari, the browser does not list the 'audiooutput' media devices yet. We have an [FAQ](https://aws.github.io/amazon-chime-sdk-js/modules/faqs.html#i-am-unable-to-select-an-audio-output-device-in-some-browsers-is-this-a-known-issue) in
 > `amazon-chime-sdk-js` with more information on respective bugs for Firefox and Safari browser.
 
 ## State

--- a/src/providers/DevicesProvider/docs/useAudioOutputs.stories.mdx
+++ b/src/providers/DevicesProvider/docs/useAudioOutputs.stories.mdx
@@ -7,7 +7,7 @@ import { useAudioOutputs } from '../';
 
 The `useAudioOutputs` hook returns a list of the user's available audio output devices and the currently selected audio output device identified by its `deviceId`
 
-> Please note that, in Firefox and Safari, the browser does not list the `audiooutput` media devices yet. We have an <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/modules/faqs.html#i-am-unable-to-select-an-audio-output-device-in-some-browsers-is-this-a-known-issue">FAQ</a> in
+> Please note that, in Firefox and Safari, the browser does not list the `audiooutput` media devices yet. We have an [FAQ](https://aws.github.io/amazon-chime-sdk-js/modules/faqs.html#i-am-unable-to-select-an-audio-output-device-in-some-browsers-is-this-a-known-issue) in
 > `amazon-chime-sdk-js` with more information on respective bugs for Firefox and Safari browser.
 
 ## Return Value

--- a/src/providers/LocalVideoProvider/docs/LocalVideoProvider.stories.mdx
+++ b/src/providers/LocalVideoProvider/docs/LocalVideoProvider.stories.mdx
@@ -4,7 +4,7 @@
 
 The `LocalVideoProvider` provides `tileId` of video tile associated with the local video, `isVideoEnabled` specifying the local video state, `setIsVideoEnabled` function to set the value of `isVideoEnabled`, `hasReachedVideoLimit` specifying whether or not video limit is reached, and `toggleVideo()` to toggle local video.
 
-> Note: `setIsVideoEnabled` is a workaround for <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-component-library-react/issues/529">GitHub Issue 529</a> to synchronize the state of `PreviewVideo` and `LocalVideo` internally. This function does not change the actual state of `LocalVideo` and `PreviewVideo`. Don't use this in your application.
+> Note: `setIsVideoEnabled` is a workaround for [GitHub Issue 529](https://github.com/aws/amazon-chime-sdk-component-library-react/issues/529) to synchronize the state of `PreviewVideo` and `LocalVideo` internally. This function does not change the actual state of `LocalVideo` and `PreviewVideo`. Don't use this in your application.
 
 The React SDK depends on the Amazon Chime SDK for JavaScript, wherein, a single video stream is attached to a video element at a time. Hence, if `PreviewVideo` and `LocalVideo` component both are rendered on the same page and if both are enabled, stopping the video preview in `PreviewVideo` component will result into disconnecting the video stream for `LocalVideo` as well showing a black screen.
 

--- a/src/providers/LocalVideoProvider/docs/useLocalVideo.stories.mdx
+++ b/src/providers/LocalVideoProvider/docs/useLocalVideo.stories.mdx
@@ -4,7 +4,7 @@
 
 The `useLocalVideo` hook returns `tileId` of video tile associated with the local video, `isVideoEnabled` specifying the local video state, `setIsVideoEnabled` function to set the value of `isVideoEnabled`, `hasReachedVideoLimit` specifying whether or not video limit is reached, and `toggleVideo()` to toggle local video.
 
-> Note: `setIsVideoEnabled` is a workaround for <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-component-library-react/issues/529">GitHub Issue 529</a> to synchronize the state of `PreviewVideo` and `LocalVideo` internally. This function does not change the actual state of `LocalVideo` and `PreviewVideo`. Don't use this in your application.
+> Note: `setIsVideoEnabled` is a workaround for [GitHub Issue 529](https://github.com/aws/amazon-chime-sdk-component-library-react/issues/529) to synchronize the state of `PreviewVideo` and `LocalVideo` internally. This function does not change the actual state of `LocalVideo` and `PreviewVideo`. Don't use this in your application.
 
 The React SDK depends on the Amazon Chime SDK for JavaScript, wherein, a single video stream is attached to a video element at a time. Hence, if `PreviewVideo` and `LocalVideo` component both are rendered on the same page and if both are enabled, stopping the video preview in `PreviewVideo` component will result into disconnecting the video stream for `LocalVideo` as well showing a black screen.
 

--- a/src/providers/LoggerProvider/docs/LoggerProvider.stories.mdx
+++ b/src/providers/LoggerProvider/docs/LoggerProvider.stories.mdx
@@ -5,11 +5,11 @@ import { LoggerProvider } from '../';
 
 # LoggerProvider
 
-The `LoggerProvider` takes in a class implementing <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/interfaces/logger.html">Logger</a> interface from Amazon Chime SDK for JavaScript as a required `prop` and provides it to
+The `LoggerProvider` takes in a class implementing [Logger](https://aws.github.io/amazon-chime-sdk-js/interfaces/logger.html) interface from Amazon Chime SDK for JavaScript as a required `prop` and provides it to
 children components wrapped under `LoggerProvider`.
 
 Children components can use `useLogger` custom hook which returns the `logger` object for logging.
-This custom hook provides <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/classes/consolelogger.html">`ConsoleLogger`</a> as the default logger, if not overriden by `LoggerProvider` `logger` prop.
+This custom hook provides [`ConsoleLogger`](https://aws.github.io/amazon-chime-sdk-js/classes/consolelogger.html) as the default logger, if not overriden by `LoggerProvider` `logger` prop.
 
 ## Props
 

--- a/src/providers/MeetingEventProvider/docs/MeetingEventProvider.stories.mdx
+++ b/src/providers/MeetingEventProvider/docs/MeetingEventProvider.stories.mdx
@@ -7,7 +7,7 @@ import { MeetingEventProvider } from '../';
 
 The `MeetingEventProvider` is responsible for providing the latest meeting event posted by Amazon Chime SDK for JavaScript.
 Please note that the `MeetingEventProvider` provides only the latest meeting event posted, therefore older events will be overridden when a new event is received.
-For more information on meeting events, please check <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/modules/meetingevents.html">Amazon Chime SDK meeting events guide</a>.
+For more information on meeting events, please check [Amazon Chime SDK meeting events guide](https://aws.github.io/amazon-chime-sdk-js/modules/meetingevents.html).
 
 You can access the provided meeting event with the [useMeetingEvent](/story/sdk-hooks-usemeetingevent--page) hook.
 

--- a/src/providers/MeetingEventProvider/docs/useMeetingEvent.stories.mdx
+++ b/src/providers/MeetingEventProvider/docs/useMeetingEvent.stories.mdx
@@ -8,7 +8,7 @@ Please note that the `MeetingEventProvider` provides only the latest meeting eve
 ### Return Value
 
 Return value will be `undefined` unless any Amazon Chime SDK meeting event is received.
-> Note: <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/globals.html#eventname">EventName</a> and <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/interfaces/eventattributes.html">EventAttributes</a> are types from <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-js">Amazon Chime SDK for JavaScript</a>.
+> Note: [EventName](https://aws.github.io/amazon-chime-sdk-js/globals.html#eventname) and [EventAttributes](https://aws.github.io/amazon-chime-sdk-js/interfaces/eventattributes.html) are types from [Amazon Chime SDK for JavaScript](https://github.com/aws/amazon-chime-sdk-js).
 
 ```typescript
 {

--- a/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
+++ b/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
@@ -12,7 +12,7 @@ You can access the `MeetingManager` instance with the `useMeetingManager` hook.
 
 ## Constructor
 
-You need to pass a class implementing <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/interfaces/logger.html">Logger</a> interface as a required property to construct a `MeetingManager` object.
+You need to pass a class implementing [Logger](https://aws.github.io/amazon-chime-sdk-js/interfaces/logger.html) interface as a required property to construct a `MeetingManager` object.
 
 ```js
 const logger = new ConsoleLogger('LoggerName');
@@ -156,7 +156,7 @@ const MyApp = () => {
 
 With V3 of the Amazon Chime SDK for JavaScript, builders now have the option of updating the properties of `MeetingSessionConfiguration`. `MeetingSessionConfiguration` is a class that allows the users to configure the meeting session.
 
-The class contains several properties like `videoUplinkBandwidthPolicy`, `videoDownlinkBandwidthPolicy`, `attendeePresenceTimeoutMs` etc. You can learn more about the available properties at <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html">MeetingSessionConfiguration</a>
+The class contains several properties like `videoUplinkBandwidthPolicy`, `videoDownlinkBandwidthPolicy`, `attendeePresenceTimeoutMs` etc. You can learn more about the available properties at [MeetingSessionConfiguration](https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html)
 in the SDK documentation. The following code example shows a `MeetingSessionConfiguration` where the default value of the properties are overridden to cusomize the meeting session.
 
 ```jsx
@@ -204,10 +204,10 @@ const MyApp = () => {
 **IMPORTANT NOTE**
 This approach has limitations. This should be used only in very specific cases where you want to share the meeting manager instance
 variable values and you will not use video, roster and audio at both places. Still, the hooks and providers may not work as expected as `MeetingProvider` wraps all the other providers.
-The video will not work at both places due to limitations of JS SDK to bind a video stream to a single video tile only. Please check <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-component-library-react/issues/492#issuecomment-846317339">this</a> issue for more details.
+The video will not work at both places due to limitations of JS SDK to bind a video stream to a single video tile only. Please check [this](https://github.com/aws/amazon-chime-sdk-component-library-react/issues/492#issuecomment-846317339) issue for more details.
 
 Please make sure your app calls `meetingManager.join()` only once with the same `attendeeInfo`.
-Otherwise, the previous attendee who joined the meeting will leave the meeting with <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/enums/meetingsessionstatuscode.html#audiojoinedfromanotherdevice">AudioJoinedFromAnotherDevice</a>.
+Otherwise, the previous attendee who joined the meeting will leave the meeting with [AudioJoinedFromAnotherDevice](https://aws.github.io/amazon-chime-sdk-js/enums/meetingsessionstatuscode.html#audiojoinedfromanotherdevice).
 
 You can create a new `MeetingManager` instance and then pass it as a prop to your `MeetingProvider`s. If not passed,
 a new `MeetingManager` instance will be created internally with each `MeetingProvider` when rendered; and,
@@ -235,7 +235,7 @@ const Root = () => {
 ### Opt-out of client event ingestion.
 
 The Amazon Chime SDK for JavaScript sends meeting events to the Amazon Chime backend to analyze meeting health trends or identify common failures.
-This helps to improve your meeting experience. For more information, check the <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/modules/clientevent_ingestion.html">client event ingestion guide</a> in the Amazon Chime SDK for JavaScript guides.
+This helps to improve your meeting experience. For more information, check the [client event ingestion guide](https://aws.github.io/amazon-chime-sdk-js/modules/clientevent_ingestion.html) in the Amazon Chime SDK for JavaScript guides.
 
 To opt-out of event ingestion from the Amazon Chime SDK for JavaScript, provide a `DefaultEventController` with a `NoOpEventReporter` as the `eventReporter` while joining the meeting.
 

--- a/src/providers/MeetingProvider/docs/MeetingProvider.stories.mdx
+++ b/src/providers/MeetingProvider/docs/MeetingProvider.stories.mdx
@@ -35,10 +35,10 @@ const App = () => (
 **IMPORTANT NOTE**
 This approach has limitations. This should be used only in very specific cases where you want to share the meeting manager instance
 variable values or you will not use video, roster and audio at both places. Still, the hooks and providers may not work as expected as `MeetingProvider` wraps all the other providers.
-The video will not work due to limitations of JS SDK to bind a video stream to a single video tile only. Please check <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-component-library-react/issues/492#issuecomment-846317339">this</a> issue for more details.
+The video will not work due to limitations of JS SDK to bind a video stream to a single video tile only. Please check [this](https://github.com/aws/amazon-chime-sdk-component-library-react/issues/492#issuecomment-846317339) issue for more details.
 
 Please make sure your app calls `meetingManager.join(meetingSessionConfiguration)` only once. The `join` method needs `MeetingSessionConfiguration` as a required parameter. `MeetingSessionConfiguration` should be created with the same `attendeeInfo`.
-Otherwise, the previous attendee who joined the meeting will leave the meeting with <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/enums/meetingsessionstatuscode.html#audiojoinedfromanotherdevice">AudioJoinedFromAnotherDevice</a>.
+Otherwise, the previous attendee who joined the meeting will leave the meeting with [AudioJoinedFromAnotherDevice](https://aws.github.io/amazon-chime-sdk-js/enums/meetingsessionstatuscode.html#audiojoinedfromanotherdevice).
 
 ```jsx
 import { ConsoleLogger } from 'amazon-chime-sdk-js';
@@ -82,7 +82,7 @@ you will get the `MeetingManager` instance associated with that particular `Meet
 
 This approach has limitations. This should be used only in very specific cases where you want to share the meeting manager instance
 variable values and you will not use video, roster and audio at both places. Still, the hooks and providers may not work as expected as `MeetingProvider` wraps all the other providers.
-The video will not work due to limitations of JS SDK to bind a video stream to a single video tile only. Please check <a target="_blank" href="https://github.com/aws/amazon-chime-sdk-component-library-react/issues/492#issuecomment-846317339">this</a> issue for more details.
+The video will not work due to limitations of JS SDK to bind a video stream to a single video tile only. Please check [this](https://github.com/aws/amazon-chime-sdk-component-library-react/issues/492#issuecomment-846317339) issue for more details.
 
 Please make sure your app calls `meetingManager.join()` only once with the same `attendeeInfo`.
-Otherwise, the previous attendee who joined the meeting will leave the meeting with <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/enums/meetingsessionstatuscode.html#audiojoinedfromanotherdevice">AudioJoinedFromAnotherDevice</a>.
+Otherwise, the previous attendee who joined the meeting will leave the meeting with [AudioJoinedFromAnotherDevice](https://aws.github.io/amazon-chime-sdk-js/enums/meetingsessionstatuscode.html#audiojoinedfromanotherdevice).

--- a/src/providers/VoiceFocusProvider/docs/VoiceFocusProvider.stories.mdx
+++ b/src/providers/VoiceFocusProvider/docs/VoiceFocusProvider.stories.mdx
@@ -26,7 +26,7 @@ as any component which relies on `VoiceFocusProvider` is nested within `VoiceFoc
 
 You should see either "Amazon Voice Focus is supported." or "Amazon Voice Focus is not supported." in your browser developer tools based on whether
 Amazon Voice Focus is supported on your device and browser. For more information, please check Amazon Chime SDK for JavaScript's Amazon Voice Focus
-<a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/modules/amazonvoice_focus.html#can-i-use-amazon-voice-focus-in-my-application">guide</a>.
+[guide](https://aws.github.io/amazon-chime-sdk-js/modules/amazonvoice_focus.html#can-i-use-amazon-voice-focus-in-my-application).
 
 You can access the state by using the [useVoiceFocus](/docs/sdk-hooks-usevoicefocus--page) hook.
 

--- a/src/providers/introduction.stories.mdx
+++ b/src/providers/introduction.stories.mdx
@@ -57,7 +57,7 @@ const MyApp = () => {
 
 3. Join a meeting
 
-To join a meeting, you will need to pass the meeting and attendee data from Chime's <a target="_blank" href="https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateAttendee.html">CreateAttendee</a> and <a target="_blank" href="https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateMeeting.html">CreateMeeting</a> APIs. <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/modules/gettingstarted.html#meeting-service">Read this for more details</a>.
+To join a meeting, you will need to pass the meeting and attendee data from Chime's [CreateAttendee](https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateAttendee.html) and [CreateMeeting](https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateMeeting.html) APIs. [Read this for more details](https://aws.github.io/amazon-chime-sdk-js/modules/gettingstarted.html#meeting-service).
 
 Once you have your meeting and attendee data, you can call `meetingManager.join` to join the meeting.
 
@@ -108,7 +108,7 @@ The attendee should be in the meeting, and able to receive audio/video. Check ou
 6. _Optional_ - Opt-out of client event ingestion
 
 The Amazon Chime SDK for JavaScript sends meeting events to the Amazon Chime backend to analyze meeting health trends or identify common failures.
-This helps to improve your meeting experience. For more information, check the <a target="_blank" href="https://aws.github.io/amazon-chime-sdk-js/modules/clientevent_ingestion.html">client event ingestion guide</a> in the Amazon Chime SDK for JavaScript guides.
+This helps to improve your meeting experience. For more information, check the [client event ingestion guide](https://aws.github.io/amazon-chime-sdk-js/modules/clientevent_ingestion.html) in the Amazon Chime SDK for JavaScript guides.
 
 To opt-out of event ingestion from the Amazon Chime SDK for JavaScript, provide a `DefaultEventController` with a `NoOpEventReporter` as the `eventReporter` while joining the meeting.
 


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
* Revert changes in `5605a007c98059758d5f3fb5d719ddc84aeeabbb`.
* Fix several typos.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Run storybook locally and confirm it works as expected.

3. If you made changes to the component library, have you provided corresponding documentation changes?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
