### PR TITLE
Add warning for unnamed saucelabs tunnel and bump up chromedriver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.15.0] - 2022-02-03
 
 ### Fixed
+
 - Fix a bug in `BackgroundBlurProvider` and `BackgroundReplacementProvider` where the options objects are updated and causing re-rendering and destroying previous processor.
 - Fix a bug in `PreviewVideo` where the PreviewVideo component did not start when `audioVideo` changed.
 
@@ -28,16 +29,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Amazon Chime Echo Reduction feature. Allow builders to supply the response from a `CreateMeeting` or `CreateMeetingWithAttendees` call when adding a `VoiceFocusProvider` to the component tree. This enables optional features like Amazon Chime Echo Reduction to be added to devices when turning on Amazon Voice Focus.
 - Add `videoAvailabilityDidChange` as an audio observer in `LocalVideoProvider` and a new state `hasReachedVideoLimit` to disable the video button when the video limit is reached.
 - Add `keepLastFrameWhenPaused` as an optional parameter to allow to keep the last frame of the video when a remote video is paused via the pauseVideoTile.
+
 ### Changed
 
 ### Removed
 
 ## [2.14.0] - 2022-01-20
 
-
 ### Fixed
 
 ### Added
+
 - Add `BackgroundReplacementProvider` provider to support background replacement.
 
 ### Changed
@@ -49,9 +51,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Added
+
 - Add `activeSpeakerPolicy` and `videoUplinkBandwidthPolicy` to `MeetingProvider` props.
 
 ### Changed
+
 - Change `additionalDevices` to a prop in `AudioInputControl`, `VideoInputControl`, `AudioInputVFControl`, `MicSelection`, and `CameraSelection` components to allow option to turn off that configuration.
 - Add `reconnectTimeoutMs` as an optional parameter to `MeetingManagerConfig` to manage the timeout for reconnection.
 
@@ -60,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.12.0] - 2021-11-19
 
 ### Fixed
+
 - Fix the issue that Amazon Voice Focus does not get applied on new devices mid-meeting.
 
 ### Added

--- a/integration/README.md
+++ b/integration/README.md
@@ -158,6 +158,8 @@ Last, you need to [setup the Sauce Connect Proxy](https://docs.saucelabs.com/sec
 3. From your command line terminal, launch a tunnel with the below commands.
 
    > Note: The default tunnel name in `config.js` is "test-tunnel". it's recommended to use this tunnel name when you **test or debug the test suites locally** so you don't need to change anything there.
+   >
+   > If you don't assign value for `--tunnel-name` parameter, an unnamed tunnel will be created. **DO NOT create any unnamed tunnel. This operation will break our integration tests and trigger alerts.** According to [Sauce Labs documentation](https://docs.saucelabs.com/secure-connections/sauce-connect/setup-configuration/basic-setup/#using-tunnel-names), unnamed tunnel will automatically be used for all tests. This will cause all tests to come to this unnamed tunnel, queue up for execution and eventually fail due to timeouts. Also the active Sauce Labs session may exceed the limit.
 
    ```plaintext
    ./sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY --region $SAUCE_DC --tunnel-name {TUNNEL_NAME}

--- a/integration/package-lock.json
+++ b/integration/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "chromedriver": "^98.0.1",
+        "chromedriver": "^101.0.0",
         "fs-extra": "^10.0.0",
         "geckodriver": "^3.0.1",
         "minimist": "^1.2.5",
@@ -370,9 +370,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "98.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-98.0.1.tgz",
-      "integrity": "sha512-/04KkHHE/K/lfwdPTQr5fxi1dWvM83p8T/IkYbyGK2PBlH7K49Dd71A9jrS+aWgXlZYkuHhbwiy2PA2QqZ5qQw==",
+      "version": "101.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-101.0.0.tgz",
+      "integrity": "sha512-LkkWxy6KM/0YdJS8qBeg5vfkTZTRamhBfOttb4oic4echDgWvCU1E8QcBbUBOHqZpSrYMyi7WMKmKMhXFUaZ+w==",
       "hasInstallScript": true,
       "dependencies": {
         "@testim/chrome-version": "^1.1.2",
@@ -2132,9 +2132,9 @@
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
     },
     "chromedriver": {
-      "version": "98.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-98.0.1.tgz",
-      "integrity": "sha512-/04KkHHE/K/lfwdPTQr5fxi1dWvM83p8T/IkYbyGK2PBlH7K49Dd71A9jrS+aWgXlZYkuHhbwiy2PA2QqZ5qQw==",
+      "version": "101.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-101.0.0.tgz",
+      "integrity": "sha512-LkkWxy6KM/0YdJS8qBeg5vfkTZTRamhBfOttb4oic4echDgWvCU1E8QcBbUBOHqZpSrYMyi7WMKmKMhXFUaZ+w==",
       "requires": {
         "@testim/chrome-version": "^1.1.2",
         "axios": "^0.24.0",

--- a/integration/package.json
+++ b/integration/package.json
@@ -8,7 +8,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "chromedriver": "^98.0.1",
+    "chromedriver": "^101.0.0",
     "fs-extra": "^10.0.0",
     "geckodriver": "^3.0.1",
     "minimist": "^1.2.5",


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**

1. Add warning for unnamed saucelabs usage in the readme of integration test
2. Bump up the `chromedriver` to latest verison to support Chrome 101.
3. Format CHANGELOG a little bit.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

3. How did you test these changes?
N/A

5. If you made changes to the component library, have you provided corresponding documentation changes?
N/A
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
