### PR TITLE
Remove tarball after installing it in demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tst/snapshots/**/__diff_output__
 integration/logs
 storybook-static
 src/versioning/version.ts
+*.tgz

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -47,6 +47,7 @@ const deployDemo = (version) => {
   updateDependency(`amazon-chime-sdk-js@${latestNPMJSSdkVersion}`);
   process.chdir(path.join(__dirname, '../../amazon-chime-sdk/apps/meeting'));
   updateDependency('amazon-chime-sdk-component-library-react', `../../../amazon-chime-sdk-component-library-react/amazon-chime-sdk-component-library-react-${version}.tgz`);
+  spawnOrFail('rm', [`-rf ../../../amazon-chime-sdk-component-library-react/amazon-chime-sdk-component-library-react-${version}.tgz`]);
 
   process.chdir(path.join(__dirname, '../../amazon-chime-sdk/apps/meeting/serverless'));
   const formattedVersion = version.replace(/\./g, '-');
@@ -88,7 +89,7 @@ const checkNPMDepsInstall = () => {
   // Creates a new React test app, install component and sdk and build the test app to ensure no peer dependency warnings, errors or build issues
   logger.log('Install amazon-chime-sdk-component-library-react and amazon-chime-sdk-js sdk as dependencies, check if there is peer dependency warning for amazon-chime-sdk-component-library-react');
   process.chdir(path.join(__dirname, '../..'));
-  if (!fs.existsSync('dependency-check-app')){
+  if (!fs.existsSync('dependency-check-app')) {
     spawnOrFail('mkdir', ['dependency-check-app']);
   } else {
     spawnOrFail('rm', ['-rf dependency-check-app']);
@@ -102,7 +103,7 @@ const checkNPMDepsInstall = () => {
   checkWarning('npm', [`install -q ../amazon-chime-sdk-component-library-react/amazon-chime-sdk-component-library-react-${currentVersion}.tgz`], null, 'amazon-chime-sdk-component-library-react');
   process.chdir(path.join(__dirname, '..'));
   spawnOrFail('rm', ['-rf ../dependency-check-app']);
-}
+};
 
 const cleanUp = (remoteBranch) => {
   logger.warn(`Warning: Resetting HEAD${remoteBranch ? ` to ${remoteBranch}` : ''}.\nAll current staged and local changes will be lost.`);


### PR DESCRIPTION
**Issue #:** 
Our release script didn't remove react sdk tarball after installing it when deploying the demo. So when raising version bump PR, the tarball is included in the commit.

**Description of changes:**
* Simply run `rm -rf <path_to_tarball>` after installing tarball.
* Add `*.tgz` to `.gitignore`.

**Testing**
1. Have you successfully run `npm run build:release` locally?
N/A, just script change.

2. How did you test these changes?
Test the release script and confirm the tarball is deleted.

3. If you made changes to the component library, have you provided corresponding documentation changes?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
