### PR TITLE
Expose ability to pass specific MediaStream to toggleContentShare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Refactor `toggleContentShare` function to allow specifying a `MediaStream` to share. This can be used to share non-screen share content.
+
 ### Removed
 
 ### Changed

--- a/src/providers/ContentShareProvider/docs/useContentShareControls.stories.mdx
+++ b/src/providers/ContentShareProvider/docs/useContentShareControls.stories.mdx
@@ -14,8 +14,10 @@ The `useContentShareControls` hook returns the state and functionality around st
   // A function to toggle content share.
   // If the user is sharing, it will stop the content share.
   // If a user is not sharing, it will start the content share workflow.
-  // You can also provide a sourceId to share a specific screen.
-  toggleContentShare: (sourceId?: string) => Promise<void>;
+  //
+  // You can also provide a string ID to share a specific screen or a specific media stream to
+  // share (e.g. a file being played to a video element).
+  toggleContentShare: (source?: string | MediaStream) => Promise<void>;
 
   // A function to toggle the local user's content share's pause status.
   togglePauseContentShare: () => void;
@@ -50,6 +52,41 @@ const MyChild = () => {
 
   return <button onClick={toggleContentShare}>Toggle content share</button>;
 };
+```
+
+## Usage With Custom Media Stream
+
+If non-screen content (or transformed screen content) is desired to be shared, you can provide a `MediaStream` directly to the toggle function. You can use classes from `amazon-chime-
+sdk-js` to help accomplish this task, see [this section in the Video Processing guide for more information](https://github.com/aws/amazon-chime-sdk-js/blob/main/guides/10_Video_Process
+or.md#custom-video-processor-usage-for-content-share).
+
+```jsx
+import React from 'react';
+import {
+  MeetingProvider,
+  useContentShareControls,
+} from 'amazon-chime-sdk-component-library-react';
+
+const MyChild = () => {
+  const { toggleContentShare } = useContentShareControls();
+
+  const toggleContentShareCustom = async () => {
+    const mediaStream = await navigator.mediaDevices.getDisplayMedia({
+      video: true,
+      audio: true,
+    });
+    toggleContentShare(mediaStream);
+  };
+
+  return <button onClick={toggleContentShareCustom}>Toggle content share</button>;
+};
+
+const App = () => (
+  <MeetingProvider>
+    <MyChild />
+  </MeetingProvider>
+);
+
 ```
 
 ### Dependencies

--- a/src/providers/ContentShareProvider/index.tsx
+++ b/src/providers/ContentShareProvider/index.tsx
@@ -117,7 +117,7 @@ const ContentShareProvider: React.FC = ({ children }) => {
   }, [isLocalShareLoading]);
 
   const toggleContentShare = useCallback(
-    async (sourceId?: string): Promise<void> => {
+    async (source?: string | MediaStream): Promise<void> => {
       if (!audioVideo) {
         return;
       }
@@ -125,8 +125,10 @@ const ContentShareProvider: React.FC = ({ children }) => {
       if (isLocalUserSharing || isLocalShareLoading) {
         audioVideo.stopContentShare();
       } else {
-        if (sourceId && typeof sourceId === 'string') {
-          audioVideo.startContentShareFromScreenCapture(sourceId);
+        if (source && typeof source === 'string') {
+          audioVideo.startContentShareFromScreenCapture(source);
+        } else if (source instanceof MediaStream) {
+          audioVideo.startContentShare(source);
         } else {
           audioVideo.startContentShareFromScreenCapture();
         }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,7 +41,7 @@ export type LocalVideoContextType = {
 
 export type ContentShareControlContextType = {
   paused: boolean;
-  toggleContentShare: (sourceId?: string) => Promise<void>;
+  toggleContentShare: (source?: string | MediaStream) => Promise<void>;
   togglePauseContentShare: () => void;
 };
 


### PR DESCRIPTION
**Issue #:**  None. Though technically addresses https://github.com/aws/amazon-chime-sdk-component-library-react/issues/313  .

**Description of changes:**  Continuation of https://github.com/aws/amazon-chime-sdk-js/pull/2467 . This exposes the ability to pass specific `MediaStream` to `toggleContentShare` to address use cases like file share, or transformed content share.

**Testing**
1. Have you successfully run `npm run build:release` locally?
y
2. How did you test these changes?
I hacked in a change similar to that in storybook into the meeting demo and confirmed it works as expected.

3. If you made changes to the component library, have you provided corresponding documentation changes?
I think so?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
