### PR TITLE
Add `MeetingStatus.Reconnecting` and `audioVideoDidStartConnecting` observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Applications depending on Chime SDK component library currently do not have a out of the box `MeetingStatus` to tell whether the JS SDK is in reconnection. Thus, add `audioVideoDidStartConnecting` with a new `MeetingStatus.Reconnecting` to aid such a use case.
+
 ### Removed
 
 ### Changed
@@ -18,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - When audio inputs change in a meeting, `AudioInputProvider` will only automatically select a new audio input device if a meeting is joined with `DeviceLabels.Audio` or `DeviceLabels.AudioAndVideo` device labels.
+- Publish `MeetingStatus.Failed` only when a non-terminal failure is encountered. Currently, some Amazon Chime SDK for JavaScript meeting session statuses pass both the `sessionStatus.isFailure()` as well as `sessionStatus.isTerminal()` in JS SDK, thus, for a status if it is in both, it will be considered as non-terminal failure and `MeetingStatus.TerminalFailure` will never get set for such statuses. Check [MeetingSessionStatus](https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingsession/MeetingSessionStatus.ts) file for more information on both methods in JS SDK.
 
 ## [3.5.0] - 2022-10-25
 

--- a/integration/utils/config.js
+++ b/integration/utils/config.js
@@ -27,6 +27,11 @@ const config = {
         // order of below two args is important for tests to pass.
         '--use-fake-device-for-media-stream',
         '--use-fake-ui-for-media-stream',
+        // copying over from JS SDK  per SauceLabs suggestion.
+        'disable-infobars',
+        'ignore-gpu-blacklist',
+        'test-type',
+        'disable-gpu'
       ],
     },
   },

--- a/src/hooks/sdk/docs/useMeetingStatus.stories.mdx
+++ b/src/hooks/sdk/docs/useMeetingStatus.stories.mdx
@@ -12,7 +12,8 @@ enum MeetingStatus {
   Ended,
   JoinedFromAnotherDevice,
   Left,
-  TerminalFailure
+  TerminalFailure,
+  Reconnecting,
 }
 ```
 

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -238,6 +238,16 @@ export class MeetingManager implements AudioVideoObserver {
     this.publishMeetingStatus();
   };
 
+  audioVideoDidStartConnecting = (reconnecting: boolean): void => {
+    if (this.meetingStatus === MeetingStatus.Reconnecting) {
+      return;
+    }
+    if (reconnecting) {
+      this.meetingStatus = MeetingStatus.Reconnecting;
+      this.publishMeetingStatus();
+    }
+  }
+
   audioVideoDidStop = (sessionStatus: MeetingSessionStatus): void => {
     const sessionStatusCode = sessionStatus.statusCode();
     switch (sessionStatusCode) {
@@ -261,7 +271,7 @@ export class MeetingManager implements AudioVideoObserver {
         break;
       default:
         // The following status codes are Failures according to MeetingSessionStatus
-        if (sessionStatus.isFailure()) {
+        if (sessionStatus.isFailure() && !sessionStatus.isTerminal()) {
           console.log(
             `[MeetingManager audioVideoDidStop] Non-Terminal failure occurred: ${sessionStatusCode}`
           );
@@ -290,6 +300,7 @@ export class MeetingManager implements AudioVideoObserver {
 
     this.audioVideoObservers = {
       audioVideoDidStart: this.audioVideoDidStart,
+      audioVideoDidStartConnecting: this.audioVideoDidStartConnecting,
       audioVideoDidStop: this.audioVideoDidStop,
     };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,6 +53,7 @@ export enum MeetingStatus {
   JoinedFromAnotherDevice,
   Left,
   TerminalFailure,
+  Reconnecting,
 }
 
 export type RosterAttendeeType = {


### PR DESCRIPTION
**Issue #:** 
NA

**Description of changes:**

- `audioVideoDidStartConnecting` helps in listening to whether JS SDK is reconnecting.

- Applications depending on Chime SDK component library currently do not have a out of the box `MeetingStatus` to tell whether the JS SDK is in reconnection. Thus, add `audioVideoDidStartConnecting` with a new `MeetingStatus.Reconnecting` to aid such a use case.

- Fix: Publish `MeetingStatus.Failed` only when a non-terminal failure is encountered. Currently, some statuses pass both the `sessionStatus.isFailure()` as well as `sessionStatus.isTerminal()` in JS SDK, thus, for a status if it is in both, then it will be considered as failure and `MeetingStatus.TerminalFailure` will never get set. Check below file for more information on both methods in JS SDK: https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingsession/MeetingSessionStatus.ts

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes.

2. How did you test these changes?

   1. Start the demo
   2. Join a meeting
   3. Monitor notifications show for meeting loading and start succeeding once you go into the meeting screen.
   4. Turn off Wifi and check for reconnecting status.
   5. Turn on Wifi and check for meeting start succeeding status again.

I will create the PR for testing this in the component library meeting demo app, once the change is merged in this repo. But here is a recording of a new `MeetingStatusIndicator` component that I will add in meeting demo to showcase the meeting status.

https://user-images.githubusercontent.com/61809205/227061511-99469436-504f-40d4-a1a7-baf59027f152.mov


3. If you made changes to the component library, have you provided corresponding documentation changes? Yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
