### PR TITLE
Skip listing and selecting devices as part joinmethod call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `skipDeviceSelection` option on the `MeetingManager.join` API. The `MeetingManager.join` by default lists and selects audio input, output and video input devices. Use `skipDeviceSelection` flag to skip this default device selection. This is helpful when builders want to fully control device selection as part of meeting initialization. This also avoids no-audio issues in Safari which happens due to listing and selecting devices multiple times.
+
 ### Removed
 
 ### Changed

--- a/integration/utils/config.js
+++ b/integration/utils/config.js
@@ -31,7 +31,8 @@ const config = {
         'disable-infobars',
         'ignore-gpu-blacklist',
         'test-type',
-        'disable-gpu'
+        'disable-gpu',
+        '--disable-features=EnableEphemeralFlashPermission'
       ],
     },
   },

--- a/src/providers/MeetingProvider/MeetingManager.ts
+++ b/src/providers/MeetingProvider/MeetingManager.ts
@@ -148,6 +148,7 @@ export class MeetingManager implements AudioVideoObserver {
       eventController,
       enableWebAudio,
       activeSpeakerPolicy,
+      skipDeviceSelection
     } = this.parseJoinParams(options);
     this.meetingSessionConfiguration = meetingSessionConfiguration;
     this.meetingId = this.meetingSessionConfiguration.meetingId;
@@ -172,7 +173,11 @@ export class MeetingManager implements AudioVideoObserver {
 
     this.setupAudioVideoObservers();
     this.setupDeviceLabelTrigger(deviceLabels);
-    await this.listAndSelectDevices(deviceLabels);
+    if (!skipDeviceSelection) {
+      this.logger.info('[MeetingManager.join] listing and selecting devices');
+      await this.listAndSelectDevices(deviceLabels);
+    }
+    
     this.publishAudioVideo();
     this.setupActiveSpeakerDetection(activeSpeakerPolicy);
     this.meetingStatus = MeetingStatus.Loading;
@@ -189,12 +194,14 @@ export class MeetingManager implements AudioVideoObserver {
     const enableWebAudio: boolean = options?.enableWebAudio || false;
     const activeSpeakerPolicy: ActiveSpeakerPolicy =
       options?.activeSpeakerPolicy || new DefaultActiveSpeakerPolicy();
+    const skipDeviceSelection = options?.skipDeviceSelection || false;
 
     return {
       deviceLabels,
       eventController,
       enableWebAudio,
       activeSpeakerPolicy,
+      skipDeviceSelection
     };
   }
 

--- a/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
+++ b/src/providers/MeetingProvider/docs/MeetingManager.stories.mdx
@@ -59,6 +59,16 @@ options?: {
   // The `ActiveSpeakerPolicy` object that you want to be used in the meeting session.
   // For more information on `ActiveSpeakerPolicy`, check Amazon Chime SDK for JavaScript ActiveSpeakerPolicy (https://aws.github.io/amazon-chime-sdk-js/interfaces/activespeakerpolicy.html).
   activeSpeakerPolicy?: ActiveSpeakerPolicy;
+
+  /*
+    The `meetingManager.join` API by default lists and selects the first available audio input, output and video input device.
+    The audio and video devices listing and selection is needed for a successful meeting session start using `meetingManager.start` API following the `meetingManager.join` API call and then to start a video.
+    In cases where you want to control the devices listing and selection on your side before joining a meeting, you can set `skipDeviceSelection` to `true`.
+    With `skipDeviceSelection` being true`, the `meetingManager.join` API will not do any default devices listing and selection and it will be your responsibility to select the devices.
+    Default is `false`.
+    Note: Audio output device selection is only available in browsers that support `setSinkId`.
+  */
+  skipDeviceSelection?: boolean;
 }
 ```
 

--- a/src/providers/MeetingProvider/types.ts
+++ b/src/providers/MeetingProvider/types.ts
@@ -10,6 +10,7 @@ export interface MeetingManagerJoinOptions {
   eventController?: EventController;
   enableWebAudio?: boolean;
   activeSpeakerPolicy?: ActiveSpeakerPolicy;
+  skipDeviceSelection?: boolean;
 }
 
 export interface AttendeeResponse {
@@ -22,6 +23,7 @@ export type ParsedJoinParams = {
   eventController: EventController | undefined;
   enableWebAudio: boolean;
   activeSpeakerPolicy: ActiveSpeakerPolicy;
+  skipDeviceSelection: boolean;
 };
 
 export type FullDeviceInfoType = {


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
- Skip listing and selecting devices as part join method call
- Add `skipDeviceSelection` flag to meetingManager.join API options
- Add corresponding documentation update.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
I created a new component to test in the demo and tested both ways enabling and disabling the `skipDeviceSelection` flag and verified that the devices were correctly selected + the attendee appeared in the roster. I tested in Firefox. The PR for that will be raised once this change merges in.

3. If you made changes to the component library, have you provided corresponding documentation changes?
Yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
