### PR TITLE
screen-splits-on-single-stream-slim

### DIFF
--- a/src/components/ui/VideoGrid/Styled.tsx
+++ b/src/components/ui/VideoGrid/Styled.tsx
@@ -24,7 +24,7 @@ const sortedRatios: AspectRatio[] = [
 
 const ratioStyles = {
   '1': 'grid-template: 1fr / 1fr;',
-  '1.slim': 'grid-template: repeat(2, 1fr) / 1fr;',
+  '1.slim': 'grid-template: repeat(1, 1fr) / 1fr;',
   '1.r2by3': 'grid-template: 1fr / 1fr;',
 
   '1.featured': `grid-template: "ft" 1fr / 1fr;`,


### PR DESCRIPTION
**Issue #:** 
When having a gridSize of 1 and a 'slim' aspect ratio, the videoTileGrid (using videogrid) adds too many grid rows.

**Description of changes:**

Changing the styles to only include a single grid row.

**Testing**
1. Have you successfully run `npm run build:release` locally?
yes
2. How did you test these changes?
Implementing it in my own app.
3. If you made changes to the component library, have you provided corresponding documentation changes?
No
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Yes