### PR TITLE
Update README to mention build first and then start the storybook

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,6 @@ git clone https://github.com/aws/amazon-chime-sdk-component-library-react.git
 npm install
 ```
 
-### To run the Storybook server locally
-
-```
-npm start
-```
-
 ### Build
 
 ```
@@ -75,6 +69,14 @@ npm run build
 ```
 
 Once you build, check and resolve any warnings you may get like unresolved dependencies or circular dependencies. Remove these as it will help in bundling the library warning/error free.
+
+### To run the Storybook server locally
+
+`amazon-chime-sdk-component-library-react` uses [Storybook](https://storybook.js.org/) for documentation.
+
+```
+npm start
+```
 
 ### Test
 


### PR DESCRIPTION
**Issue #:** 
#900 

**Description of changes:**
README update to mention `npm run build` first and then `npm start` so that storybook builds successfully.

**Testing**
1. Have you successfully run `npm run build:release` locally? NA just README update.

2. How did you test these changes? Locally previewing in the VS code.

3. If you made changes to the component library, have you provided corresponding documentation changes? NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
