### PR TITLE
Add await for toggleContentShare

### DIFF
--- a/src/providers/ContentShareProvider/index.tsx
+++ b/src/providers/ContentShareProvider/index.tsx
@@ -128,11 +128,11 @@ export const ContentShareProvider: React.FC<
         audioVideo.stopContentShare();
       } else {
         if (source && typeof source === 'string') {
-          audioVideo.startContentShareFromScreenCapture(source);
-        } else if (source instanceof MediaStream) {
-          audioVideo.startContentShare(source);
+          await audioVideo.startContentShareFromScreenCapture(source);
+        } else if (source && source instanceof MediaStream) {
+          await audioVideo.startContentShare(source);
         } else {
-          audioVideo.startContentShareFromScreenCapture();
+          await audioVideo.startContentShareFromScreenCapture();
         }
         dispatch({ type: ContentActionType.STARTING });
       }

--- a/tst/providers/ContentShareProvider/index.test.tsx
+++ b/tst/providers/ContentShareProvider/index.test.tsx
@@ -1,0 +1,55 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import {
+  ContentShareProvider,
+  useContentShareControls,
+} from '../../../src/providers/ContentShareProvider';
+
+// Mock audioVideo object
+const mockAudioVideo = {
+    startContentShareFromScreenCapture: jest.fn(),
+    startContentShare: jest.fn(),
+    stopContentShare: jest.fn(),
+    addObserver: jest.fn(),
+    removeObserver: jest.fn(),
+    addContentShareObserver: jest.fn(),
+    removeContentShareObserver: jest.fn()
+ };
+ // Mock the module containing useAudioVideo hook
+jest.mock('../../../src/providers/AudioVideoProvider', () => ({
+    useAudioVideo: () => mockAudioVideo
+}));
+
+describe('toggleContentShare', () => {
+  it('Should call startContentShareFromScreenCapture', async () => {
+    const { result } = renderHook(() => useContentShareControls(), {
+      wrapper: ({ children }) => (
+        <ContentShareProvider>{children}</ContentShareProvider>
+      ),
+    });
+    await act(async () => {
+      await result.current.toggleContentShare();
+    });
+    expect(mockAudioVideo.startContentShareFromScreenCapture).toHaveBeenCalledTimes(1);
+  });
+
+  it('Can catch error from startContentShareFromScreenCapture', async () => {
+    mockAudioVideo.startContentShareFromScreenCapture = jest.fn(() => Promise.reject(new Error('startContentShare error')));
+    const { result } = renderHook(() => useContentShareControls(), {
+      wrapper: ({ children }) => (
+        <ContentShareProvider>{children}</ContentShareProvider>
+      ),
+    });
+    await expect(async () => { 
+      await act(async () => {
+        await result.current.toggleContentShare();
+    });
+    }).rejects.toThrow('startContentShare error');
+    // expect(() => {
+    //     result.current.toggleContentShare();
+    //   }).toThrow('startContentShare error');
+  });
+});


### PR DESCRIPTION
**Issue #:** 
Currently in `toggleContentShare` we do not await for the JS SDK API thus, if the APIs fail, callers would not be able to handle it.

**Description of changes:**


**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Add unit tests
3. If you made changes to the component library, have you provided corresponding documentation changes? N/A
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
