### PR TITLE
Change LocalAudioOutputProvider to not bind an audio element on startup when isAudioOn set is false

### DIFF
--- a/src/providers/LocalAudioOutputProvider/index.tsx
+++ b/src/providers/LocalAudioOutputProvider/index.tsx
@@ -30,7 +30,7 @@ export const LocalAudioOutputProvider: React.FC<
       return;
     }
 
-    if (audioRef.current) {
+    if (audioRef.current && isAudioOn) {
       (async (element: HTMLAudioElement) => {
         try {
           await audioVideo.bindAudioElement(element);


### PR DESCRIPTION

**Issue #: 964** 

**Description of changes:**
Updated LocalAudioOutputProvider to check the value of isAudioOn when hooked on to `audioVideo` being initialized. It now won't bind the audio if it's already been disabled before startup.


**Testing**
1. Have you successfully run `npm run build:release` locally?
No - it immediately drops out with `Didn't find any new commit. Exiting process.`

Guessing it's because I've already pushed to my fork? Wasn't mentioned in CONTRIBUTING.md so I didn't attempt to run it until creating the PR. Regular `npm run build` runs fine though.

2. How did you test these changes?
Unit tests rerun fine - no tests exist for this component, and not sure how to hook them up given the need to bind audio etc.

Testing locally by installing the dev version into our application. See issue for reproduction steps.

3. If you made changes to the component library, have you provided corresponding documentation changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.