### PR TITLE
Use pass in logger for ml modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change to use loggers from `LoggerProvider` as default when initialize background blur/replacement processor.
+
 ### Fixed
 
 ## [3.9.0] - 2024-04-12

--- a/src/providers/BackgroundBlurProvider/index.tsx
+++ b/src/providers/BackgroundBlurProvider/index.tsx
@@ -6,10 +6,8 @@ import {
   BackgroundBlurProcessor,
   BackgroundBlurVideoFrameProcessor,
   BackgroundFilterSpec,
-  ConsoleLogger,
   DefaultVideoTransformDevice,
   Device,
-  LogLevel,
   NoOpVideoFrameProcessor,
 } from 'amazon-chime-sdk-js';
 import React, {
@@ -51,7 +49,8 @@ export const BackgroundBlurProvider: FC<React.PropsWithChildren<Props>> = ({
   options,
   children,
 }) => {
-  const logger = useLogger();
+  let logger = useLogger();
+  logger = options?.logger || logger;
   const [isBackgroundBlurSupported, setIsBackgroundBlurSupported] = useState<
     boolean | undefined
   >(undefined);
@@ -158,9 +157,6 @@ export const BackgroundBlurProvider: FC<React.PropsWithChildren<Props>> = ({
     );
     const currentProcessor = await initializeBackgroundBlur();
     try {
-      const logger =
-        options?.logger ||
-        new ConsoleLogger('BackgroundBlurProvider', LogLevel.INFO);
       if (currentProcessor) {
         const chosenVideoTransformDevice = new DefaultVideoTransformDevice(
           logger,

--- a/src/providers/BackgroundReplacementProvider/index.tsx
+++ b/src/providers/BackgroundReplacementProvider/index.tsx
@@ -6,10 +6,8 @@ import {
   BackgroundReplacementOptions,
   BackgroundReplacementProcessor,
   BackgroundReplacementVideoFrameProcessor,
-  ConsoleLogger,
   DefaultVideoTransformDevice,
   Device,
-  LogLevel,
   NoOpVideoFrameProcessor,
 } from 'amazon-chime-sdk-js';
 import React, {
@@ -52,7 +50,8 @@ const BackgroundReplacementProviderContext = createContext<
 export const BackgroundReplacementProvider: FC<
   React.PropsWithChildren<Props>
 > = ({ spec, options, children }) => {
-  const logger = useLogger();
+  let logger = useLogger();
+  logger = options?.logger || logger;
   const [
     isBackgroundReplacementSupported,
     setIsBackgroundReplacementSupported,
@@ -160,9 +159,6 @@ export const BackgroundReplacementProvider: FC<
     );
     const currentProcessor = await initializeBackgroundReplacement();
     try {
-      const logger =
-        options?.logger ||
-        new ConsoleLogger('BackgroundReplacementProvider', LogLevel.INFO);
       if (currentProcessor) {
         const chosenVideoTransformDevice = new DefaultVideoTransformDevice(
           logger,


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Default to logger from logger provider when initiate bgBlur, bgReplacement processors

**Testing**
1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? Test using react meeting demo

3. If you made changes to the component library, have you provided corresponding documentation changes? 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
