### PR TITLE
Revert "Version bump for amazon-chime-sdk-component-library-react@3.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.11.0] - 2025-01-15
-
-### Added
-
-### Removed
-
-### Changed
-
-### Fixed
-
 ## [3.10.0] - 2024-08-08
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-chime-sdk-component-library-react",
-  "version": "3.11.0",
+  "version": "3.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-chime-sdk-component-library-react",
-      "version": "3.11.0",
+      "version": "3.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@popperjs/core": "^2.2.2",
@@ -53,7 +53,7 @@
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
         "add": "^2.0.6",
-        "amazon-chime-sdk-js": "^3.26.0",
+        "amazon-chime-sdk-js": "^3.23.0",
         "babel-loader": "^8.1.0",
         "css-loader": "^6.7.1",
         "eslint": "^7.32.0",
@@ -98,7 +98,7 @@
         "npm": "^8 || ^9 || ^10"
       },
       "peerDependencies": {
-        "amazon-chime-sdk-js": "^3.26.0",
+        "amazon-chime-sdk-js": "^3.23.0",
         "react": "^17.0.1 || ^18.0.0",
         "react-dom": "^17.0.1 || ^18.0.0",
         "styled-components": "^5.0.0",
@@ -13396,9 +13396,9 @@
       }
     },
     "node_modules/amazon-chime-sdk-js": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-3.26.0.tgz",
-      "integrity": "sha512-6VV2SS3Qc5LI4WgE3KLSJPTrG8iIHtC/Mr2PjufYgoYq2kD/6SWA9ya4j/j4aHe471n0pArRUSRdTQc754HCSw==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-3.23.0.tgz",
+      "integrity": "sha512-iEQrzphamKI2gLnGIM+vqKnqhVQAVEVnDKxsPFYh/G8IkxL4PduclPGSc5RdY4OHKZy9dUrY4TMtDgXd3B6peA==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "^2.0.1",
@@ -45597,9 +45597,9 @@
       "requires": {}
     },
     "amazon-chime-sdk-js": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-3.26.0.tgz",
-      "integrity": "sha512-6VV2SS3Qc5LI4WgE3KLSJPTrG8iIHtC/Mr2PjufYgoYq2kD/6SWA9ya4j/j4aHe471n0pArRUSRdTQc754HCSw==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-3.23.0.tgz",
+      "integrity": "sha512-iEQrzphamKI2gLnGIM+vqKnqhVQAVEVnDKxsPFYh/G8IkxL4PduclPGSc5RdY4OHKZy9dUrY4TMtDgXd3B6peA==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-js": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-component-library-react",
-  "version": "3.11.0",
+  "version": "3.10.0",
   "description": "Amazon Chime SDK Component Library - React",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",
@@ -85,7 +85,7 @@
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "add": "^2.0.6",
-    "amazon-chime-sdk-js": "^3.26.0",
+    "amazon-chime-sdk-js": "^3.23.0",
     "babel-loader": "^8.1.0",
     "css-loader": "^6.7.1",
     "eslint": "^7.32.0",
@@ -126,7 +126,7 @@
     "webpack-cli": "^4.9.2"
   },
   "peerDependencies": {
-    "amazon-chime-sdk-js": "^3.26.0",
+    "amazon-chime-sdk-js": "^3.23.0",
     "react": "^17.0.1 || ^18.0.0",
     "react-dom": "^17.0.1 || ^18.0.0",
     "styled-components": "^5.0.0",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -97,7 +97,7 @@ const checkNPMDepsInstall = () => {
   }
   process.chdir(path.join(__dirname, '../../dependency-check-app'));
   spawnOrFail('npm', ['init -y']);
-  spawnOrFail('npm', ['install react@18 react-dom@18']);
+  spawnOrFail('npm', ['install react react-dom']);
 
   // As of June 5, 2023, running `npm install styled-components` fails due to this issue.
   // https://github.com/styled-components/styled-components/issues/3998


### PR DESCRIPTION

This reverts commit 2eb6e5dfbcaa1e159c7b9ca42cea424625f243eb.

**Issue #:** 

**Description of changes:**


**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes?

3. If you made changes to the component library, have you provided corresponding documentation changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
