### PR TITLE
Fix conditions where BackgroundReplacementProvider needs to be re-rendered, Fix to not log the entire options object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change to use loggers from `LoggerProvider` as default when initialize background blur/replacement processor.
+- Change to not log the entire stringified `options` object in background blur/replacement processor.
 
 ### Fixed
+
+- Fix conditions where `BackgroundReplacementProvider` needs to be re-rendered.
 
 ## [3.9.0] - 2024-04-12
 

--- a/src/providers/BackgroundBlurProvider/index.tsx
+++ b/src/providers/BackgroundBlurProvider/index.tsx
@@ -110,7 +110,11 @@ export const BackgroundBlurProvider: FC<React.PropsWithChildren<Props>> = ({
     logger.info(
       `Initializing background blur processor with, spec: ${JSON.stringify(
         spec
-      )}, options: ${JSON.stringify(options)}`
+      )}, options: { blurStrength: ${
+        options?.blurStrength
+      }, filterCPUUtilization: ${
+        options?.filterCPUUtilization
+      }, reportingPeriodMillis: ${options?.reportingPeriodMillis} }`
     );
 
     try {

--- a/src/providers/BackgroundReplacementProvider/index.tsx
+++ b/src/providers/BackgroundReplacementProvider/index.tsx
@@ -82,8 +82,7 @@ export const BackgroundReplacementProvider: FC<
         return true;
       }
       if (
-        prev?.imageBlob?.size === next?.imageBlob?.size ||
-        prev?.filterCPUUtilization === next?.filterCPUUtilization ||
+        prev?.filterCPUUtilization !== next?.filterCPUUtilization ||
         prev?.logger !== next?.logger ||
         prev?.reportingPeriodMillis !== next?.reportingPeriodMillis
       ) {
@@ -111,7 +110,11 @@ export const BackgroundReplacementProvider: FC<
     logger.info(
       `Initializing background replacement processor with, ${JSON.stringify(
         spec
-      )}, ${JSON.stringify(options)}`
+      )}, options: { filterCPUUtilization: ${
+        options?.filterCPUUtilization
+      }, reportingPeriodMillis: ${
+        options?.reportingPeriodMillis
+      }}`
     );
 
     try {

--- a/tst/providers/BackgroundBlurProvider/index.test.tsx
+++ b/tst/providers/BackgroundBlurProvider/index.test.tsx
@@ -63,7 +63,7 @@ describe.only('BackgroundBlurProvider', () => {
     expect(loggerInfoMock).toHaveBeenCalledWith(
       `Initializing background blur processor with, spec: ${JSON.stringify(
         undefined
-      )}, options: ${JSON.stringify(blurOptions)}`
+      )}, options: { blurStrength: ${blurOptions.blurStrength}, filterCPUUtilization: ${blurOptions.filterCPUUtilization}, reportingPeriodMillis: ${blurOptions.reportingPeriodMillis} }`
     );
     expect(loggerInfoMock).toHaveBeenCalledWith(
       'Specs or options were changed. Destroying and re-initializing background blur processor.'


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
1. Fix the conditions where `BackgroundReplacementProvider` needs to be re-rendered. Remove the image size comparison because now it supports dynamically change replacement image in an active processor. The processor recreation when image changes will cost to fetch assets again.
2. Avoid to log the entire `options` props in `BackgroundReplacementProvider`, the optional `logger` prop could potentially be nested JSON.


**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

3. How did you test these changes?
4. Locally and private build tested by QA

5. If you made changes to the component library, have you provided corresponding documentation changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
