### PR TITLE
Add support for styled-components v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for styled-components v6. This change is compatible with both styled-components v5 and v6. styled-components v6 introduces various breaking changes. One major difference is that styled-components v6 omits automatic vendor prefixing by default. If you prefer the v5 behavior, refer to the [styled-components v6 migration guide](https://styled-components.com/docs/faqs#what-do-i-need-to-do-to-migrate-to-v6) for details.
+
 ### Removed
 
 ### Changed
@@ -74,9 +76,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Changed
+
 - Updated `ContentShare` to have optional nameplate prop.
+
 ### Fixed
-- Fix a bug where the `isVideoEnabled` is still true even when the video device is unplugged. 
+
+- Fix a bug where the `isVideoEnabled` is still true even when the video device is unplugged.
 
 - When audio inputs change in a meeting, `AudioInputProvider` will only automatically select a new audio input device if a meeting is joined with `DeviceLabels.Audio` or `DeviceLabels.AudioAndVideo` device labels.
 - Publish `MeetingStatus.Failed` only when a non-terminal failure is encountered. Currently, some Amazon Chime SDK for JavaScript meeting session statuses pass both the `sessionStatus.isFailure()` as well as `sessionStatus.isTerminal()` in JS SDK, thus, for a status if it is in both, it will be considered as non-terminal failure and `MeetingStatus.TerminalFailure` will never get set for such statuses. Check [MeetingSessionStatus](https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingsession/MeetingSessionStatus.ts) file for more information on both methods in JS SDK.
@@ -85,18 +90,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Add support for Node.js 18.
+- Add support for Node.js 18.
 
 ### Removed
 
 ### Changed
+
 - Updated `VoiceFocusProvider` to destroy the Voice Focus worker thread on unmount.
 - Reverted changes to `BackgroundBlurProvider` and `BackgroundReplacemenProvider` to fix bug related to `isBackgroundBlurSupported` and `isBackgroundReplacementSupported` returning false.
 
 ### Fixed
 
-* Update the documentation to use `GlobalStyles` along with `ThemeProvider`.
-
+- Update the documentation to use `GlobalStyles` along with `ThemeProvider`.
 
 ## [3.4.0] - 2022-09-13
 
@@ -171,7 +176,7 @@ Below is a list of all changes in Amazon Chime SDK React Components Library v3. 
 - Remove preset device selection options ("None" and "440 Hz" for audio input device. "None", "Blue", and "SMTP Color Bars" for video input device). Remove `appendSampleDevices` from Props of `CameraSelection`, `MicSelection`, `AudioInputControl`, `AudioInputVFcontrol`, and `VideoInputControl`. Remove `DeviceConfig` type. Remove `additionalDevices` from Props of `useAudioInputs` and `useVideoInputs` hook.
 - Remove `useSelectAudioInputDevice`, `useSelectAudioOutputDevice` and `useSelectVideoInputDevice` hook.
 - Remove use of the deprecated `enableUnifiedPlanForChromiumBasedBrowsers` configuration variable.
-- Remove all deprecated `MeetingSessionStatusCode`.  
+- Remove all deprecated `MeetingSessionStatusCode`.
 - Remove legacy metrics `videoDownstreamGoogFrameHeight`, `videoDownstreamGoogFrameWidth`, `videoUpstreamGoogFrameHeight` and `videoUpstreamGoogFrameWidth` from the `videoStreamMetrics` returned by the `useMediaStreamMetrics` hook to adopt to Amazon Chime SDK for JavaScript V3 changes ([aws/amazon-chime-sdk-js#2086](https://github.com/aws/amazon-chime-sdk-js/pull/2086)).
 - Remove `MeetingSessionConfiguration` properties from `MeetingProvider` props.
 - Remove `deviceLabels`, `eventController`, `logLevel`, `postLogConfig`, `logger`, `enableWebAudio`, and `activeSpeakerPolicy` from `MeetingProvider` props.
@@ -217,7 +222,7 @@ Below is a list of all changes in Amazon Chime SDK React Components Library v3. 
 ### Removed
 
 - Remove use of the deprecated `enableUnifiedPlanForChromiumBasedBrowsers` configuration variable.
-- Remove all deprecated `MeetingSessionStatusCode`.  
+- Remove all deprecated `MeetingSessionStatusCode`.
 - Remove legacy metrics `videoDownstreamGoogFrameHeight`, `videoDownstreamGoogFrameWidth`, `videoUpstreamGoogFrameHeight` and `videoUpstreamGoogFrameWidth` from the `videoStreamMetrics` returned by the `useMediaStreamMetrics` hook to adopt to Amazon Chime SDK for JavaScript V3 changes ([aws/amazon-chime-sdk-js#2086](https://github.com/aws/amazon-chime-sdk-js/pull/2086)).
 - Deprecate `useBandwidthMetrics` hook as we already have `useMediaStreamMetrics`.
 - Remove `MeetingSessionConfiguration` properties from `MeetingProvider` props.

--- a/integration/app/test-demo/package-lock.json
+++ b/integration/app/test-demo/package-lock.json
@@ -12,14 +12,14 @@
         "amazon-chime-sdk-component-library-react": "file:../../..",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "styled-components": "^5.3.3",
-        "styled-system": "^5.1.5"
+        "styled-components": "^6.1.15",
+        "styled-system": "^5.1.5",
+        "stylis": "^4.3.6"
       },
       "devDependencies": {
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.4",
         "@types/react-router-dom": "^5.3.0",
-        "@types/styled-components": "^5.1.15",
         "aws-sdk": "^2.1354.0",
         "compression": "^1.7.4",
         "concurrently": "^6.4.0",
@@ -73,7 +73,6 @@
         "@types/react-dom": "^18.0.11",
         "@types/react-test-renderer": "^18.0.0",
         "@types/resize-observer-browser": "^0.1.3",
-        "@types/styled-components": "^5.1.26",
         "@types/styled-system": "^5.1.16",
         "@types/testing-library__react": "^10.2.0",
         "@types/throttle-debounce": "^2.1.0",
@@ -110,11 +109,12 @@
         "rollup": "^2.26.3",
         "rollup-plugin-peer-deps-external": "^2.2.2",
         "rollup-plugin-typescript2": "^0.27.1",
-        "start-server-and-test": "^1.14.0",
+        "start-server-and-test": "^2.0.8",
         "storybook": "^7.0.2",
         "style-loader": "^0.23.1",
-        "styled-components": "^5.3.9",
+        "styled-components": "^6.1.15",
         "styled-system": "^5.1.5",
+        "stylis": "^4.3.6",
         "ts-jest": "^26.5.2",
         "ts-loader": "^6.0.2",
         "typescript": "^4.2.1",
@@ -129,395 +129,8 @@
         "amazon-chime-sdk-js": "^3.23.0",
         "react": "^17.0.1 || ^18.0.0",
         "react-dom": "^17.0.1 || ^18.0.0",
-        "styled-components": "^5.0.0",
+        "styled-components": "^5.0.0 || ^6.0.0",
         "styled-system": "^5.1.5"
-      }
-    },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
-      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
-      "dependencies": {
-        "@babel/highlight": "^7.24.2",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/compat-data": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.4.tgz",
-      "integrity": "sha512-vg8Gih2MLK+kOkHJp4gBEIkyaIi00jgWot2D9QOmmfLC8jINSOzmCLta6Bvz/JSBCqnegV0L80jhxkol5GWNfQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.4.tgz",
-      "integrity": "sha512-MBVlMXP+kkl5394RBLSxxk/iLTeVGuXTV3cIDXavPpMMqnSnt6apKgan/U8O3USWZCWZT/TbgfEpKa4uMgN4Dg==",
-      "peer": true,
-      "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.24.2",
-        "@babel/generator": "^7.24.4",
-        "@babel/helper-compilation-targets": "^7.23.6",
-        "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.24.4",
-        "@babel/parser": "^7.24.4",
-        "@babel/template": "^7.24.0",
-        "@babel/traverse": "^7.24.1",
-        "@babel/types": "^7.24.0",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/core/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "peer": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@babel/core/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "peer": true
-    },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.4.tgz",
-      "integrity": "sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==",
-      "dependencies": {
-        "@babel/types": "^7.24.0",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^2.5.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
-      "integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
-      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
-      "peer": true,
-      "dependencies": {
-        "@babel/compat-data": "^7.23.5",
-        "@babel/helper-validator-option": "^7.23.5",
-        "browserslist": "^4.22.2",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "peer": true,
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "peer": true
-    },
-    "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-      "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.24.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
-      "integrity": "sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
-      "dependencies": {
-        "@babel/types": "^7.24.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
-      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-module-imports": "^7.22.15",
-        "@babel/helper-simple-access": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.20"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz",
-      "integrity": "sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-simple-access": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
-      "peer": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
-      "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
-      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
-      "peer": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.4.tgz",
-      "integrity": "sha512-FewdlZbSiwaVGlgT1DPANDuCHaDMiOo+D/IDYRFYjHOuv66xMSJ7fQwwODwRNAPkADIO/z1EoF/l2BCWlWABDw==",
-      "peer": true,
-      "dependencies": {
-        "@babel/template": "^7.24.0",
-        "@babel/traverse": "^7.24.1",
-        "@babel/types": "^7.24.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
-      "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.4.tgz",
-      "integrity": "sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==",
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.1.tgz",
-      "integrity": "sha512-2eCtxZXf+kbkMIsXS4poTvT4Yu5rXiRa+9xGVT56raghjmBTKMpFNc9R4IDiB4emao9eO22Ox7CxuJG7BgExqA==",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -527,73 +140,6 @@
       "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
-      "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
-      "dependencies": {
-        "@babel/code-frame": "^7.23.5",
-        "@babel/parser": "^7.24.0",
-        "@babel/types": "^7.24.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.1.tgz",
-      "integrity": "sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==",
-      "dependencies": {
-        "@babel/code-frame": "^7.24.1",
-        "@babel/generator": "^7.24.1",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.24.1",
-        "@babel/types": "^7.24.0",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/@babel/types": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -609,32 +155,28 @@
       }
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.2.tgz",
-      "integrity": "sha512-3QnhqeL+WW88YjYbQL5gUIkthuMw7a0NGbZ7wfFVk2kg/CK5w8w5FFa0RzWjyY1+sujN0NWbtSHH6OJmWHtJpQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
       "dependencies": {
-        "@emotion/memoize": "^0.7.4"
+        "@emotion/memoize": "^0.8.1"
       }
     },
     "node_modules/@emotion/memoize": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
-      "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
-    },
-    "node_modules/@emotion/stylis": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
     },
     "node_modules/@emotion/unitless": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -648,6 +190,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -656,6 +199,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -673,12 +217,14 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -885,16 +431,6 @@
       "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
       "dev": true
     },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-      "dev": true,
-      "dependencies": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -1020,16 +556,10 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/styled-components": {
-      "version": "5.1.25",
-      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.25.tgz",
-      "integrity": "sha512-fgwl+0Pa8pdkwXRoVPP9JbqF0Ivo9llnmsm+7TCI330kbPIFd9qv1Lrhr37shf4tnxCOSu+/IgqM7uJXLWZZNQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/hoist-non-react-statics": "*",
-        "@types/react": "*",
-        "csstype": "^3.0.2"
-      }
+    "node_modules/@types/stylis": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
+      "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
@@ -1433,21 +963,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/babel-plugin-styled-components": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
-      "integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-module-imports": "^7.22.5",
-        "@babel/plugin-syntax-jsx": "^7.22.5",
-        "lodash": "^4.17.21",
-        "picomatch": "^2.3.1"
-      },
-      "peerDependencies": {
-        "styled-components": ">= 2"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1575,6 +1090,7 @@
       "version": "4.24.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
       "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -1658,14 +1174,18 @@
       }
     },
     "node_modules/camelize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001680",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001680.tgz",
       "integrity": "sha512-rPQy70G6AGUMnbwS1z6Xg+RkHYPAi18ihs47GH0jcxIG7wArmPgY3XbS2sRdBbxJljp3thdT8BIqv9ccCypiPA==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -1923,12 +1443,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "peer": true
-    },
     "node_modules/cookie": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
@@ -1967,7 +1481,7 @@
     "node_modules/css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
       "engines": {
         "node": ">=4"
       }
@@ -1989,9 +1503,9 @@
       }
     },
     "node_modules/css-to-react-native": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
-      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
       "dependencies": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -2011,10 +1525,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
-      "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==",
-      "dev": true
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/date-fns": {
       "version": "2.28.0",
@@ -2202,7 +1715,8 @@
     "node_modules/electron-to-chromium": {
       "version": "1.5.57",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.57.tgz",
-      "integrity": "sha512-xS65H/tqgOwUBa5UmOuNSLuslDo7zho0y/lgQw35pnrqiZh7UOWHCeL/Bt6noJATbA6tpQJGCifsFsIRZj1Fqg=="
+      "integrity": "sha512-xS65H/tqgOwUBa5UmOuNSLuslDo7zho0y/lgQw35pnrqiZh7UOWHCeL/Bt6noJATbA6tpQJGCifsFsIRZj1Fqg==",
+      "dev": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2284,6 +1798,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2293,14 +1808,6 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
@@ -2642,15 +2149,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "peer": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2728,14 +2226,6 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
-    },
-    "node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/gopd": {
       "version": "1.0.1",
@@ -2862,19 +2352,6 @@
       "dependencies": {
         "@babel/runtime": "^7.7.6"
       }
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hpack.js": {
       "version": "2.1.6",
@@ -3382,17 +2859,6 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
-    "node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -3404,18 +2870,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "peer": true,
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -3450,7 +2904,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -3627,6 +3082,23 @@
         "multicast-dns": "cli.js"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -3664,7 +3136,8 @@
     "node_modules/node-releases": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+      "dev": true
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -3913,6 +3386,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -3960,6 +3434,33 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
+    },
+    "node_modules/postcss": {
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
@@ -4099,12 +3600,6 @@
       "peerDependencies": {
         "react": "^18.2.0"
       }
-    },
-    "node_modules/react-is": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.0.0.tgz",
-      "integrity": "sha512-yUcBYdBBbo3QiPsgYDcfQcIkGZHfxOaoE6HLSnr1sPzMhdyxusbfKOSUbSd/ocGi32dxcj366PsTj+5oggeKKw==",
-      "peer": true
     },
     "node_modules/react-router": {
       "version": "6.3.0",
@@ -4607,6 +4102,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -4773,24 +4276,22 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
-      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
-      "hasInstallScript": true,
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.15.tgz",
+      "integrity": "sha512-PpOTEztW87Ua2xbmLa7yssjNyUF9vE7wdldRfn1I2E6RTkqknkBYpj771OxM/xrvRGinLy2oysa7GOd7NcZZIA==",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/traverse": "^7.4.5",
-        "@emotion/is-prop-valid": "^1.1.0",
-        "@emotion/stylis": "^0.8.4",
-        "@emotion/unitless": "^0.7.4",
-        "babel-plugin-styled-components": ">= 1.12.0",
-        "css-to-react-native": "^3.0.0",
-        "hoist-non-react-statics": "^3.0.0",
-        "shallowequal": "^1.1.0",
-        "supports-color": "^5.5.0"
+        "@emotion/is-prop-valid": "1.2.2",
+        "@emotion/unitless": "0.8.1",
+        "@types/stylis": "4.2.5",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.1.3",
+        "postcss": "8.4.49",
+        "shallowequal": "1.1.0",
+        "stylis": "4.3.2",
+        "tslib": "2.6.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">= 16"
       },
       "funding": {
         "type": "opencollective",
@@ -4798,28 +4299,13 @@
       },
       "peerDependencies": {
         "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0",
-        "react-is": ">= 16.8.0"
+        "react-dom": ">= 16.8.0"
       }
     },
-    "node_modules/styled-components/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/styled-components/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
+    "node_modules/styled-components/node_modules/stylis": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
+      "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg=="
     },
     "node_modules/styled-system": {
       "version": "5.1.5",
@@ -4840,6 +4326,11 @@
         "@styled-system/variant": "^5.1.5",
         "object-assign": "^4.1.1"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ=="
     },
     "node_modules/supports-color": {
       "version": "8.1.1",
@@ -4941,14 +4432,6 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4999,10 +4482,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -5043,6 +4525,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
       "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/integration/app/test-demo/package.json
+++ b/integration/app/test-demo/package.json
@@ -5,14 +5,14 @@
     "amazon-chime-sdk-component-library-react": "file:../../..",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "styled-components": "^5.3.3",
-    "styled-system": "^5.1.5"
+    "styled-components": "^6.1.15",
+    "styled-system": "^5.1.5",
+    "stylis": "^4.3.6"
   },
   "devDependencies": {
     "@types/react": "^18.2.79",
     "@types/react-dom": "^18.2.4",
     "@types/react-router-dom": "^5.3.0",
-    "@types/styled-components": "^5.1.15",
     "aws-sdk": "^2.1354.0",
     "compression": "^1.7.4",
     "concurrently": "^6.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
         "@types/react-dom": "^18.0.11",
         "@types/react-test-renderer": "^18.0.0",
         "@types/resize-observer-browser": "^0.1.3",
-        "@types/styled-components": "^5.1.26",
         "@types/styled-system": "^5.1.16",
         "@types/testing-library__react": "^10.2.0",
         "@types/throttle-debounce": "^2.1.0",
@@ -85,8 +84,9 @@
         "start-server-and-test": "^2.0.8",
         "storybook": "^7.0.2",
         "style-loader": "^0.23.1",
-        "styled-components": "^5.3.9",
+        "styled-components": "^6.1.15",
         "styled-system": "^5.1.5",
+        "stylis": "^4.3.6",
         "ts-jest": "^26.5.2",
         "ts-loader": "^6.0.2",
         "typescript": "^4.2.1",
@@ -101,7 +101,7 @@
         "amazon-chime-sdk-js": "^3.23.0",
         "react": "^17.0.1 || ^18.0.0",
         "react-dom": "^17.0.1 || ^18.0.0",
-        "styled-components": "^5.0.0",
+        "styled-components": "^5.0.0 || ^6.0.0",
         "styled-system": "^5.1.5"
       }
     },
@@ -3076,16 +3076,10 @@
       "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
       "dev": true
     },
-    "node_modules/@emotion/stylis": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
-      "dev": true
-    },
     "node_modules/@emotion/unitless": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
       "dev": true
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
@@ -11978,16 +11972,6 @@
         "@types/unist": "^2"
       }
     },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
-      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
-      "dev": true,
-      "dependencies": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -12345,17 +12329,6 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
     },
-    "node_modules/@types/styled-components": {
-      "version": "5.1.34",
-      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.34.tgz",
-      "integrity": "sha512-mmiVvwpYklFIv9E8qfxuPyIt/OuyIrn6gMOAMOFUO3WJfSrSE+sGUoa4PiZj77Ut7bKZpaa6o1fBKS/4TOEvnA==",
-      "dev": true,
-      "dependencies": {
-        "@types/hoist-non-react-statics": "*",
-        "@types/react": "*",
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/@types/styled-system": {
       "version": "5.1.22",
       "resolved": "https://registry.npmjs.org/@types/styled-system/-/styled-system-5.1.22.tgz",
@@ -12364,6 +12337,12 @@
       "dependencies": {
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/@types/stylis": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
+      "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
+      "dev": true
     },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.9",
@@ -14338,22 +14317,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/babel-plugin-styled-components": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
-      "integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-module-imports": "^7.22.5",
-        "@babel/plugin-syntax-jsx": "^7.22.5",
-        "lodash": "^4.17.21",
-        "picomatch": "^2.3.1"
-      },
-      "peerDependencies": {
-        "styled-components": ">= 2"
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
@@ -20058,21 +20021,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dev": true,
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
     },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
@@ -33011,24 +32959,23 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
-      "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.15.tgz",
+      "integrity": "sha512-PpOTEztW87Ua2xbmLa7yssjNyUF9vE7wdldRfn1I2E6RTkqknkBYpj771OxM/xrvRGinLy2oysa7GOd7NcZZIA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/traverse": "^7.4.5",
-        "@emotion/is-prop-valid": "^1.1.0",
-        "@emotion/stylis": "^0.8.4",
-        "@emotion/unitless": "^0.7.4",
-        "babel-plugin-styled-components": ">= 1.12.0",
-        "css-to-react-native": "^3.0.0",
-        "hoist-non-react-statics": "^3.0.0",
-        "shallowequal": "^1.1.0",
-        "supports-color": "^5.5.0"
+        "@emotion/is-prop-valid": "1.2.2",
+        "@emotion/unitless": "0.8.1",
+        "@types/stylis": "4.2.5",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.1.3",
+        "postcss": "8.4.49",
+        "shallowequal": "1.1.0",
+        "stylis": "4.3.2",
+        "tslib": "2.6.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">= 16"
       },
       "funding": {
         "type": "opencollective",
@@ -33036,9 +32983,14 @@
       },
       "peerDependencies": {
         "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0",
-        "react-is": ">= 16.8.0"
+        "react-dom": ">= 16.8.0"
       }
+    },
+    "node_modules/styled-components/node_modules/stylis": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
+      "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==",
+      "dev": true
     },
     "node_modules/styled-system": {
       "version": "5.1.5",
@@ -33060,6 +33012,12 @@
         "@styled-system/variant": "^5.1.5",
         "object-assign": "^4.1.1"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "dev": true
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -38077,16 +38035,10 @@
       "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
       "dev": true
     },
-    "@emotion/stylis": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
-      "dev": true
-    },
     "@emotion/unitless": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
       "dev": true
     },
     "@emotion/use-insertion-effect-with-fallbacks": {
@@ -44413,16 +44365,6 @@
         "@types/unist": "^2"
       }
     },
-    "@types/hoist-non-react-statics": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
-      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
     "@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -44761,17 +44703,6 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
     },
-    "@types/styled-components": {
-      "version": "5.1.34",
-      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.34.tgz",
-      "integrity": "sha512-mmiVvwpYklFIv9E8qfxuPyIt/OuyIrn6gMOAMOFUO3WJfSrSE+sGUoa4PiZj77Ut7bKZpaa6o1fBKS/4TOEvnA==",
-      "dev": true,
-      "requires": {
-        "@types/hoist-non-react-statics": "*",
-        "@types/react": "*",
-        "csstype": "^3.0.2"
-      }
-    },
     "@types/styled-system": {
       "version": "5.1.22",
       "resolved": "https://registry.npmjs.org/@types/styled-system/-/styled-system-5.1.22.tgz",
@@ -44780,6 +44711,12 @@
       "requires": {
         "csstype": "^3.0.2"
       }
+    },
+    "@types/stylis": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
+      "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
+      "dev": true
     },
     "@types/testing-library__jest-dom": {
       "version": "5.14.9",
@@ -46331,19 +46268,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.5.0"
-      }
-    },
-    "babel-plugin-styled-components": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
-      "integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-module-imports": "^7.22.5",
-        "@babel/plugin-syntax-jsx": "^7.22.5",
-        "lodash": "^4.17.21",
-        "picomatch": "^2.3.1"
       }
     },
     "babel-preset-current-node-syntax": {
@@ -50797,23 +50721,6 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dev": true,
-      "requires": {
-        "react-is": "^16.7.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-          "dev": true
-        }
       }
     },
     "homedir-polyfill": {
@@ -60771,21 +60678,28 @@
       }
     },
     "styled-components": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
-      "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.15.tgz",
+      "integrity": "sha512-PpOTEztW87Ua2xbmLa7yssjNyUF9vE7wdldRfn1I2E6RTkqknkBYpj771OxM/xrvRGinLy2oysa7GOd7NcZZIA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/traverse": "^7.4.5",
-        "@emotion/is-prop-valid": "^1.1.0",
-        "@emotion/stylis": "^0.8.4",
-        "@emotion/unitless": "^0.7.4",
-        "babel-plugin-styled-components": ">= 1.12.0",
-        "css-to-react-native": "^3.0.0",
-        "hoist-non-react-statics": "^3.0.0",
-        "shallowequal": "^1.1.0",
-        "supports-color": "^5.5.0"
+        "@emotion/is-prop-valid": "1.2.2",
+        "@emotion/unitless": "0.8.1",
+        "@types/stylis": "4.2.5",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.1.3",
+        "postcss": "8.4.49",
+        "shallowequal": "1.1.0",
+        "stylis": "4.3.2",
+        "tslib": "2.6.2"
+      },
+      "dependencies": {
+        "stylis": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
+          "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==",
+          "dev": true
+        }
       }
     },
     "styled-system": {
@@ -60808,6 +60722,12 @@
         "@styled-system/variant": "^5.1.5",
         "object-assign": "^4.1.1"
       }
+    },
+    "stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "dev": true
     },
     "supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@types/react-dom": "^18.0.11",
     "@types/react-test-renderer": "^18.0.0",
     "@types/resize-observer-browser": "^0.1.3",
-    "@types/styled-components": "^5.1.26",
     "@types/styled-system": "^5.1.16",
     "@types/testing-library__react": "^10.2.0",
     "@types/throttle-debounce": "^2.1.0",
@@ -117,8 +116,9 @@
     "start-server-and-test": "^2.0.8",
     "storybook": "^7.0.2",
     "style-loader": "^0.23.1",
-    "styled-components": "^5.3.9",
+    "styled-components": "^6.1.15",
     "styled-system": "^5.1.5",
+    "stylis": "^4.3.6",
     "ts-jest": "^26.5.2",
     "ts-loader": "^6.0.2",
     "typescript": "^4.2.1",
@@ -129,7 +129,7 @@
     "amazon-chime-sdk-js": "^3.23.0",
     "react": "^17.0.1 || ^18.0.0",
     "react-dom": "^17.0.1 || ^18.0.0",
-    "styled-components": "^5.0.0",
+    "styled-components": "^5.0.0 || ^6.0.0",
     "styled-system": "^5.1.5"
   },
   "prettier": {

--- a/src/components/sdk/LocalVideo/index.tsx
+++ b/src/components/sdk/LocalVideo/index.tsx
@@ -7,7 +7,6 @@ import styled from 'styled-components';
 import { useApplyVideoObjectFit } from '../../../hooks/useApplyVideoObjectFit';
 import { useAudioVideo } from '../../../providers/AudioVideoProvider';
 import { useLocalVideo } from '../../../providers/LocalVideoProvider';
-import { defaultStyledConfig } from '../../../utils/style';
 import VideoTile from '../../ui/VideoTile';
 import { BaseSdkProps } from '../Base';
 
@@ -16,7 +15,7 @@ interface Props extends BaseSdkProps {
   nameplate?: string;
 }
 
-const StyledLocalVideo = styled<any>(VideoTile).withConfig(defaultStyledConfig)`
+const StyledLocalVideo = styled<any>(VideoTile)`
   ${(props) => (!props.active ? 'display: none' : '')};
 `;
 

--- a/src/components/sdk/LocalVideo/index.tsx
+++ b/src/components/sdk/LocalVideo/index.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import { useApplyVideoObjectFit } from '../../../hooks/useApplyVideoObjectFit';
 import { useAudioVideo } from '../../../providers/AudioVideoProvider';
 import { useLocalVideo } from '../../../providers/LocalVideoProvider';
+import { defaultStyledConfig } from '../../../utils/style';
 import VideoTile from '../../ui/VideoTile';
 import { BaseSdkProps } from '../Base';
 
@@ -15,7 +16,7 @@ interface Props extends BaseSdkProps {
   nameplate?: string;
 }
 
-const StyledLocalVideo = styled<any>(VideoTile)`
+const StyledLocalVideo = styled<any>(VideoTile).withConfig(defaultStyledConfig)`
   ${(props) => (!props.active ? 'display: none' : '')};
 `;
 

--- a/src/components/sdk/PreviewVideo/index.tsx
+++ b/src/components/sdk/PreviewVideo/index.tsx
@@ -9,10 +9,11 @@ import { useVideoInputs } from '../../../providers/DevicesProvider';
 import { useLocalVideo } from '../../../providers/LocalVideoProvider';
 import { useLogger } from '../../../providers/LoggerProvider';
 import { useMeetingManager } from '../../../providers/MeetingProvider';
+import { defaultStyledConfig } from '../../../utils/style';
 import VideoTile from '../../ui/VideoTile';
 import { BaseSdkProps } from '../Base';
 
-const StyledPreview = styled(VideoTile)`
+const StyledPreview = styled(VideoTile).withConfig(defaultStyledConfig)`
   height: auto;
   background: unset;
 

--- a/src/components/sdk/PreviewVideo/index.tsx
+++ b/src/components/sdk/PreviewVideo/index.tsx
@@ -9,11 +9,10 @@ import { useVideoInputs } from '../../../providers/DevicesProvider';
 import { useLocalVideo } from '../../../providers/LocalVideoProvider';
 import { useLogger } from '../../../providers/LoggerProvider';
 import { useMeetingManager } from '../../../providers/MeetingProvider';
-import { defaultStyledConfig } from '../../../utils/style';
 import VideoTile from '../../ui/VideoTile';
 import { BaseSdkProps } from '../Base';
 
-const StyledPreview = styled(VideoTile).withConfig(defaultStyledConfig)`
+const StyledPreview = styled(VideoTile)`
   height: auto;
   background: unset;
 

--- a/src/components/ui/Badge/Styled.tsx
+++ b/src/components/ui/Badge/Styled.tsx
@@ -3,10 +3,13 @@
 
 import styled from 'styled-components';
 
+import { defaultStyledConfig } from '../../../utils/style';
 import { baseSpacing, baseStyles } from '../Base';
 import { BadgeProps } from './';
 
-export const StyledBadge = styled.span<Partial<BadgeProps>>`
+export const StyledBadge = styled.span.withConfig(defaultStyledConfig)<
+  Partial<BadgeProps>
+>`
   ${(props) => {
     if (typeof props.value === 'object') {
       const element: JSX.Element = props.value as JSX.Element;

--- a/src/components/ui/Button/Styled.tsx
+++ b/src/components/ui/Button/Styled.tsx
@@ -3,11 +3,13 @@
 
 import styled, { css } from 'styled-components';
 
-import { visuallyHidden } from '../../../utils/style';
+import { defaultStyledConfig, visuallyHidden } from '../../../utils/style';
 import { baseSpacing, baseStyles } from '../Base';
 import { ButtonProps } from './';
 
-export const StyledButton = styled.button<ButtonProps>`
+export const StyledButton = styled.button.withConfig(
+  defaultStyledConfig
+)<ButtonProps>`
   border-radius: ${(props) => props.theme.radii.default};
   font-size: ${(props) => props.theme.fontSizes.text.fontSize};
   padding: 0.5rem 1rem;
@@ -219,7 +221,9 @@ export const StyledIconButton = css<ButtonProps>`
   }
 `;
 
-export const StyledIconButtonWrapper = styled.span`
+export const StyledIconButtonWrapper = styled.span.withConfig(
+  defaultStyledConfig
+)`
   display: inline-block;
   position: relative;
 `;

--- a/src/components/ui/Chat/ChannelList/Styled.tsx
+++ b/src/components/ui/Chat/ChannelList/Styled.tsx
@@ -3,11 +3,14 @@
 
 import styled from 'styled-components';
 
+import { defaultStyledConfig } from '../../../../utils/style';
 import { baseSpacing, baseStyles } from '../../Base';
 import { ChannelListProps } from '.';
 import { ChannelItemProps } from './ChannelItem';
 
-export const StyledChannelList = styled.ul<ChannelListProps>`
+export const StyledChannelList = styled.ul.withConfig(
+  defaultStyledConfig
+)<ChannelListProps>`
   display: flex;
   flex-direction: column;
   width: 20rem;
@@ -16,7 +19,9 @@ export const StyledChannelList = styled.ul<ChannelListProps>`
   ${baseSpacing}
 `;
 
-export const StyledChannelItem = styled.li<ChannelItemProps>`
+export const StyledChannelItem = styled.li.withConfig(
+  defaultStyledConfig
+)<ChannelItemProps>`
   position: relative;
 
   ${baseStyles};

--- a/src/components/ui/Chat/ChatBubble/EditableChatBubble.stories.tsx
+++ b/src/components/ui/Chat/ChatBubble/EditableChatBubble.stories.tsx
@@ -42,7 +42,7 @@ export const _EditableChatBubble = (args) => {
         senderName={args.senderName}
         content="This messsage has typos that ned to be fixxed."
         showTail={args.showTail}
-        showName={args.boolean}
+        showName={args.showName}
         saveLabel={args.saveLabel}
         cancelLabel={args.cancelLabel}
         css={bubbleStyles}

--- a/src/components/ui/Chat/ChatBubble/Styled.tsx
+++ b/src/components/ui/Chat/ChatBubble/Styled.tsx
@@ -3,6 +3,7 @@
 
 import styled from 'styled-components';
 
+import { defaultStyledConfig } from '../../../../utils/style';
 import { BaseProps, baseSpacing, baseStyles } from '../../Base';
 import { MessageVariant } from './ChatBubbleContainer';
 
@@ -15,7 +16,9 @@ interface StyledChatBubbleProps extends BaseProps {
   editable?: boolean;
 }
 
-export const StyledChatBubbleContainer = styled.div<StyledChatBubbleContainerProps>`
+export const StyledChatBubbleContainer = styled.div.withConfig(
+  defaultStyledConfig
+)<StyledChatBubbleContainerProps>`
   display: flex;
   flex-direction: row;
   font-size: 0.65rem;
@@ -32,7 +35,9 @@ export const StyledChatBubbleContainer = styled.div<StyledChatBubbleContainerPro
   ${baseStyles}
 `;
 
-export const StyledChatBubble = styled.div<StyledChatBubbleProps>`
+export const StyledChatBubble = styled.div.withConfig(
+  defaultStyledConfig
+)<StyledChatBubbleProps>`
   background-color: ${(props) => props.theme.chatBubble[props.variant].bgd};
   padding: 0.625rem 1rem;
   border-radius: 4px;
@@ -94,7 +99,7 @@ export const StyledChatBubble = styled.div<StyledChatBubbleProps>`
   ${baseStyles};
 `;
 
-export const StyledChatBubbleInfo = styled.div`
+export const StyledChatBubbleInfo = styled.div.withConfig(defaultStyledConfig)`
   display: flex;
   margin-right: 0.5rem;
   margin-left: auto;

--- a/src/components/ui/Chat/InfiniteList/Styled.tsx
+++ b/src/components/ui/Chat/InfiniteList/Styled.tsx
@@ -3,6 +3,7 @@
 
 import styled, { keyframes } from 'styled-components';
 
+import { defaultStyledConfig } from '../../../../utils/style';
 import { baseSpacing, baseStyles } from '../../Base';
 import { InfiniteListProps } from './';
 
@@ -18,7 +19,9 @@ const rotate = keyframes`
 
 interface StyledInfiniteListProps extends InfiniteListProps {}
 
-export const StyledInfiniteList = styled.ul<StyledInfiniteListProps>`
+export const StyledInfiniteList = styled.ul.withConfig(
+  defaultStyledConfig
+)<StyledInfiniteListProps>`
   background-color: ${(props) => props.theme.chatBubble.container.bgd};
   overflow-y: scroll;
   display: flex;

--- a/src/components/ui/Chat/MessageAttachment/Styled.tsx
+++ b/src/components/ui/Chat/MessageAttachment/Styled.tsx
@@ -3,13 +3,16 @@
 
 import styled from 'styled-components';
 
+import { defaultStyledConfig } from '../../../../utils/style';
 import { BaseProps, baseSpacing, baseStyles } from '../../Base';
 
 interface StyledMessageAttachmentProps extends BaseProps {
   imgStyles?: string;
 }
 
-export const StyledMessageAttachmentContent = styled.div`
+export const StyledMessageAttachmentContent = styled.div.withConfig(
+  defaultStyledConfig
+)`
   display: flex;
   flex-direction: row;
   padding: 10px;
@@ -30,9 +33,9 @@ export const StyledMessageAttachmentContent = styled.div`
     margin-left: 1rem;
 
     & a:link,
-    a:visited,
-    a:hover,
-    a:active {
+    & a:visited,
+    & a:hover,
+    & a:active {
       color: ${(props) => props.theme.messageAttachment.name.fontColor};
       text-decoration: none;
     }
@@ -45,7 +48,9 @@ export const StyledMessageAttachmentContent = styled.div`
   }
 `;
 
-export const StyledMessageAttachment = styled.div<StyledMessageAttachmentProps>`
+export const StyledMessageAttachment = styled.div.withConfig(
+  defaultStyledConfig
+)<StyledMessageAttachmentProps>`
   color: ${(props) => props.theme.messageAttachment.content.fontColor};
   display: flex;
   flex-direction: column;

--- a/src/components/ui/Checkbox/Styled.tsx
+++ b/src/components/ui/Checkbox/Styled.tsx
@@ -3,10 +3,10 @@
 
 import styled from 'styled-components';
 
-import { visuallyHidden } from '../../../utils/style';
+import { defaultStyledConfig, visuallyHidden } from '../../../utils/style';
 import { StyledCheckboxProps } from './';
 
-export const HiddenCheckbox = styled.input`
+export const HiddenCheckbox = styled.input.withConfig(defaultStyledConfig)`
   ${visuallyHidden};
 
   &[aria-invalid='true'] + .ch-checkbox {
@@ -15,7 +15,9 @@ export const HiddenCheckbox = styled.input`
   }
 `;
 
-export const StyledCheckbox = styled.div<StyledCheckboxProps>`
+export const StyledCheckbox = styled.div.withConfig(
+  defaultStyledConfig
+)<StyledCheckboxProps>`
   background-color: ${(props) => props.theme.inputs.bgd};
   border: ${(props) => props.theme.inputs.border};
   border-radius: ${(props) => props.theme.radii.default};

--- a/src/components/ui/ContentTile/index.tsx
+++ b/src/components/ui/ContentTile/index.tsx
@@ -3,9 +3,12 @@
 
 import styled from 'styled-components';
 
+import { createStyledConfig } from '../../../utils/style';
 import { VideoTile } from '../../ui/VideoTile';
 
-export const ContentTile = styled(VideoTile)`
+export const ContentTile = styled(VideoTile).withConfig(
+  createStyledConfig(['nameplate'])
+)`
   background-color: ${({ theme }) => theme.colors.greys.grey80};
 `;
 

--- a/src/components/ui/ContentTile/index.tsx
+++ b/src/components/ui/ContentTile/index.tsx
@@ -3,12 +3,9 @@
 
 import styled from 'styled-components';
 
-import { createStyledConfig } from '../../../utils/style';
 import { VideoTile } from '../../ui/VideoTile';
 
-export const ContentTile = styled(VideoTile).withConfig(
-  createStyledConfig(['nameplate'])
-)`
+export const ContentTile = styled(VideoTile)`
   background-color: ${({ theme }) => theme.colors.greys.grey80};
 `;
 

--- a/src/components/ui/ControlBar/Styled.tsx
+++ b/src/components/ui/ControlBar/Styled.tsx
@@ -5,6 +5,7 @@ import styled, { css } from 'styled-components';
 
 import { darkTheme } from '../../../theme/dark';
 import { lightTheme } from '../../../theme/light';
+import { defaultStyledConfig } from '../../../utils/style';
 import { baseSpacing, baseStyles } from '../Base';
 import { PopOverItemProps } from '../PopOver/PopOverItem';
 import { ControlBarLayout, ControlBarProps } from '.';
@@ -47,30 +48,26 @@ export const responsiveStyles = (props: StyledControlBarProps) => {
   return css`
     ${({ theme }) => theme.mediaQueries.max.sm} {
       ${unsetPosition}
-      ${(props: StyledControlBarProps) =>
-        isVertical(props.layout) ? layoutMap['left'] : layoutMap['bottom']};
-      box-shadow: ${(props: StyledControlBarProps) =>
-        props.theme.controlBar.shadow};
+      ${isVertical(props.layout) ? layoutMap['left'] : layoutMap['bottom']};
+      box-shadow: ${props.theme.controlBar.shadow};
       border: none;
-      height: ${(props: StyledControlBarProps) =>
-        isVertical(props.layout) && '100%'};
-      width: ${(props: StyledControlBarProps) =>
-        !isVertical(props.layout) && '100%'};
+      height: ${isVertical(props.layout) && '100%'};
+      width: ${!isVertical(props.layout) && '100%'};
     }
 
     ${({ theme }) => theme.mediaQueries.max.xs} {
-      justify-content: ${(props: StyledControlBarProps) =>
-        isVertical(props.layout) ? 'center' : 'space-around'};
+      justify-content: ${isVertical(props.layout) ? 'center' : 'space-around'};
       ${unsetPosition}
-      ${(props: StyledControlBarProps) =>
-        isVertical(props.layout) ? layoutMap['left'] : layoutMap['bottom']};
+      ${isVertical(props.layout) ? layoutMap['left'] : layoutMap['bottom']};
       box-shadow: ${({ theme }) => theme.controlBar.shadow};
       border: none;
     }
   `;
 };
 
-export const StyledControlBar = styled.div<StyledControlBarProps>`
+export const StyledControlBar = styled.div.withConfig(
+  defaultStyledConfig
+)<StyledControlBarProps>`
   display: inline-flex;
   justify-content: center;
   align-items: center;
@@ -98,7 +95,9 @@ interface StyledControlBarItemProps extends StyledControlBarProps {
   isSelected: boolean;
 }
 
-export const StyledControlBarItem = styled.div<StyledControlBarItemProps>`
+export const StyledControlBarItem = styled.div.withConfig(
+  defaultStyledConfig
+)<StyledControlBarItemProps>`
   margin: ${({ layout }) => (isVertical(layout) ? '0.625rem 0' : '0 0.625rem')};
   display: grid;
   grid-template-rows: ${({ showLabels }) =>

--- a/src/components/ui/Flex/Styled.tsx
+++ b/src/components/ui/Flex/Styled.tsx
@@ -3,6 +3,7 @@
 
 import styled, { css } from 'styled-components';
 
+import { defaultStyledConfig } from '../../../utils/style';
 import { baseSpacing, baseStyles } from '../Base';
 import { FlexProps } from './';
 
@@ -47,7 +48,7 @@ const layoutMap = {
   stack,
 };
 
-export const StyledFlex = styled.div<FlexProps>`
+export const StyledFlex = styled.div.withConfig(defaultStyledConfig)<FlexProps>`
   align-items: ${(props) => props.alignItems};
   display: ${(props) => (props.container ? 'flex' : 'block')};
   flex: ${(props) => props.flex || ''};

--- a/src/components/ui/Flex/docs/common.tsx
+++ b/src/components/ui/Flex/docs/common.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import { defaultStyledConfig } from '../../../../utils/style';
 import Flex from '..';
 
-export const Child = styled(Flex).withConfig(defaultStyledConfig)`
+export const Child = styled(Flex)`
   background-color: ${(props) => props.theme.colors.primary.lightest};
   color: ${(props) => props.theme.colors.primary.darkest};
   margin: 1vh;
@@ -15,14 +15,14 @@ export const Child = styled(Flex).withConfig(defaultStyledConfig)`
   width: 20vw;
 `;
 
-export const Block = styled(Flex).withConfig(defaultStyledConfig)`
+export const Block = styled(Flex)`
   background-color: ${(props) => props.theme.colors.primary.lightest};
   height: 5vh;
   margin: 1rem;
   border-radius: 4px;
 `;
 
-export const Stack = styled(Flex).withConfig(defaultStyledConfig)`
+export const Stack = styled(Flex)`
   padding: 1rem 20vw;
 `;
 

--- a/src/components/ui/Flex/docs/common.tsx
+++ b/src/components/ui/Flex/docs/common.tsx
@@ -3,9 +3,10 @@
 
 import styled from 'styled-components';
 
+import { defaultStyledConfig } from '../../../../utils/style';
 import Flex from '..';
 
-export const Child = styled(Flex)`
+export const Child = styled(Flex).withConfig(defaultStyledConfig)`
   background-color: ${(props) => props.theme.colors.primary.lightest};
   color: ${(props) => props.theme.colors.primary.darkest};
   margin: 1vh;
@@ -14,25 +15,25 @@ export const Child = styled(Flex)`
   width: 20vw;
 `;
 
-export const Block = styled(Flex)`
+export const Block = styled(Flex).withConfig(defaultStyledConfig)`
   background-color: ${(props) => props.theme.colors.primary.lightest};
   height: 5vh;
   margin: 1rem;
   border-radius: 4px;
 `;
 
-export const Stack = styled(Flex)`
+export const Stack = styled(Flex).withConfig(defaultStyledConfig)`
   padding: 1rem 20vw;
 `;
 
-export const StackChild = styled.div`
+export const StackChild = styled.div.withConfig(defaultStyledConfig)`
   height: 20vh;
   width: 20vw;
   margin: 1vh;
   background-color: ${(props) => props.theme.colors.primary.lightest};
 `;
 
-export const Title = styled.h1`
+export const Title = styled.h1.withConfig(defaultStyledConfig)`
   background-color: ${(props) => props.theme.colors.primary.lightest};
   color: ${(props) => props.theme.colors.primary.darkest};
   padding: 2rem;

--- a/src/components/ui/FormField/Styled.tsx
+++ b/src/components/ui/FormField/Styled.tsx
@@ -3,6 +3,7 @@
 
 import styled, { css } from 'styled-components';
 
+import { defaultStyledConfig } from '../../../utils/style';
 import { baseSpacing, baseStyles } from '../Base';
 import { FieldWrapperProps } from './';
 
@@ -180,7 +181,9 @@ const layoutMap = {
   'input-only': inputOnly,
 };
 
-export const StyledFormField = styled.div<FieldWrapperProps>`
+export const StyledFormField = styled.div.withConfig(
+  defaultStyledConfig
+)<FieldWrapperProps>`
   display: flex;
   margin-bottom: 1rem;
   position: relative;

--- a/src/components/ui/Grid/Styled.tsx
+++ b/src/components/ui/Grid/Styled.tsx
@@ -4,11 +4,12 @@
 import styled from 'styled-components';
 import { grid } from 'styled-system';
 
+import { defaultStyledConfig } from '../../../utils/style';
 import { baseSpacing, baseStyles } from '../Base';
 import { GridProps } from './';
 import { CellProps } from './Cell';
 
-export const StyledGrid = styled.div<GridProps>`
+export const StyledGrid = styled.div.withConfig(defaultStyledConfig)<GridProps>`
   display: grid;
   width: 100%;
   height: 100%;
@@ -33,7 +34,7 @@ export const StyledGrid = styled.div<GridProps>`
   ${(props) => props.css || ''}
 `;
 
-export const StyledCell = styled.div<CellProps>`
+export const StyledCell = styled.div.withConfig(defaultStyledConfig)<CellProps>`
   ${baseSpacing}
   ${grid}
 

--- a/src/components/ui/Heading/Heading.mdx
+++ b/src/components/ui/Heading/Heading.mdx
@@ -25,14 +25,14 @@ Heading rendered as a paragraph with color `blue`, `level = 3`.
 <ThemeProvider theme={lightTheme}>
   <GlobalStyles />
   <Canvas>
-    <Heading style={{ color: 'blue' }} level={3} tag="p">
+    <Heading style={{ color: 'blue' }} level={3} tag="span">
       Change my level or as prop
     </Heading>
   </Canvas>
 </ThemeProvider>
 
 ```jsx
-<Heading style={{ color: 'blue' }} level={3} tag="p">
+<Heading style={{ color: 'blue' }} level={3} tag="span">
   Change my level or as prop
 </Heading>
 ```

--- a/src/components/ui/Heading/Styled.tsx
+++ b/src/components/ui/Heading/Styled.tsx
@@ -3,10 +3,13 @@
 
 import styled from 'styled-components';
 
+import { defaultStyledConfig } from '../../../utils/style';
 import { baseSpacing, baseStyles } from '../Base';
 import { HeadingProps } from './';
 
-export const StyledHeading = styled.h1<HeadingProps>`
+export const StyledHeading = styled.h1.withConfig(
+  defaultStyledConfig
+)<HeadingProps>`
   display: block;
   margin: 0;
 

--- a/src/components/ui/Input/Styled.tsx
+++ b/src/components/ui/Input/Styled.tsx
@@ -3,6 +3,7 @@
 
 import styled from 'styled-components';
 
+import { defaultStyledConfig } from '../../../utils/style';
 import { baseSpacing, baseStyles } from '../Base';
 import { InputWrapperProps } from './InputWrapper';
 
@@ -13,7 +14,9 @@ const getPadding = (props: InputWrapperProps) => {
     : `0.34375rem 1.75rem 0.34375rem ${leadingIcon ? '1.3125rem' : '0.5rem'}`;
 };
 
-export const StyledInputWrapper = styled.span<InputWrapperProps>`
+export const StyledInputWrapper = styled.span.withConfig(
+  defaultStyledConfig
+)<InputWrapperProps>`
   position: relative;
 
   > .ch-icon {
@@ -30,7 +33,7 @@ export const StyledInputWrapper = styled.span<InputWrapperProps>`
   }
 `;
 
-export const StyledInput = styled.input`
+export const StyledInput = styled.input.withConfig(defaultStyledConfig)`
   align-items: center;
   display: flex;
   letter-spacing: -0.005625rem;
@@ -61,9 +64,9 @@ export const StyledInput = styled.input`
 
   // Hides native clear button
   &::-webkit-search-decoration,
-  ::-webkit-search-cancel-button,
-  ::-webkit-search-results-button,
-  ::-webkit-search-results-decoration {
+  &::-webkit-search-cancel-button,
+  &::-webkit-search-results-button,
+  &::-webkit-search-results-decoration {
     display: none;
   }
 
@@ -82,7 +85,9 @@ interface ClearProps {
   active: boolean;
 }
 
-export const StyledClear = styled.button<ClearProps>`
+export const StyledClear = styled.button.withConfig(
+  defaultStyledConfig
+)<ClearProps>`
   position: absolute;
   top: 50%;
   right: 0.125rem;

--- a/src/components/ui/Label/Styled.tsx
+++ b/src/components/ui/Label/Styled.tsx
@@ -3,9 +3,10 @@
 
 import styled from 'styled-components';
 
+import { defaultStyledConfig } from '../../../utils/style';
 import { baseSpacing, baseStyles } from '../Base';
 
-export const StyledLabel = styled.label`
+export const StyledLabel = styled.label.withConfig(defaultStyledConfig)`
   color: ${(props) => props.theme.inputs.fontColor};
   font-size: ${(props) => props.theme.fontSizes.label.fontSize};
   line-height: ${(props) => props.theme.fontSizes.label.lineHeight};

--- a/src/components/ui/MicVolumeIndicator/Styled.tsx
+++ b/src/components/ui/MicVolumeIndicator/Styled.tsx
@@ -3,10 +3,13 @@
 
 import styled from 'styled-components';
 
+import { defaultStyledConfig } from '../../../utils/style';
 import { baseSpacing, baseStyles } from '../Base';
 import { MicVolumeIndicatorProps } from '.';
 
-export const StyledMicVolumeIndicator = styled.div<MicVolumeIndicatorProps>`
+export const StyledMicVolumeIndicator = styled.div.withConfig(
+  defaultStyledConfig
+)<MicVolumeIndicatorProps>`
   position: relative;
   height: inherit;
   line-height: 0;

--- a/src/components/ui/Modal/Styled.ts
+++ b/src/components/ui/Modal/Styled.ts
@@ -4,10 +4,13 @@
 import styled from 'styled-components';
 
 import { fadeAnimation, slideDownAndScaleUp } from '../../../utils/animations';
+import { defaultStyledConfig } from '../../../utils/style';
 import { baseSpacing, baseStyles } from '../Base';
 import { ModalProps } from './';
 
-export const StyledModal = styled.div<ModalProps>`
+export const StyledModal = styled.div.withConfig(
+  defaultStyledConfig
+)<ModalProps>`
   position: fixed;
   top: 0;
   left: 0;
@@ -56,7 +59,7 @@ export const StyledModal = styled.div<ModalProps>`
   ${baseStyles}
 `;
 
-export const StyledModalHeader = styled.header`
+export const StyledModalHeader = styled.header.withConfig(defaultStyledConfig)`
   padding: 1rem 1.5rem;
 
   .ch-close-button {
@@ -76,7 +79,7 @@ export const StyledModalHeader = styled.header`
   ${baseStyles}
 `;
 
-export const StyledModalBody = styled.div`
+export const StyledModalBody = styled.div.withConfig(defaultStyledConfig)`
   font-size: ${(props) => props.theme.fontSizes.text.fontSize};
   line-height: ${(props) => props.theme.fontSizes.text.lineHeight};
   padding: 0 1.5rem;
@@ -87,7 +90,9 @@ export const StyledModalBody = styled.div`
   ${baseStyles}
 `;
 
-export const StyledModalButtonGroup = styled.footer`
+export const StyledModalButtonGroup = styled.footer.withConfig(
+  defaultStyledConfig
+)`
   padding: 1.5rem;
   border-top: 1px solid ${(props) => props.theme.modal.border};
   display: flex;

--- a/src/components/ui/Navbar/Styled.tsx
+++ b/src/components/ui/Navbar/Styled.tsx
@@ -3,12 +3,13 @@
 
 import styled from 'styled-components';
 
+import { defaultStyledConfig } from '../../../utils/style';
 import { baseSpacing, baseStyles } from '../Base';
 import Flex from '../Flex';
 import { NavbarProps } from '.';
 import { NavbarItemProps } from './NavbarItem';
 
-export const StyledHeader = styled.div`
+export const StyledHeader = styled.div.withConfig(defaultStyledConfig)`
   display: flex;
   height: 3rem;
   align-items: center;
@@ -30,7 +31,9 @@ export const StyledHeader = styled.div`
   }
 `;
 
-export const StyledNavbarItem = styled.div<Partial<NavbarItemProps>>`
+export const StyledNavbarItem = styled.div.withConfig(defaultStyledConfig)<
+  Partial<NavbarItemProps>
+>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -49,7 +52,9 @@ export const StyledNavbarItem = styled.div<Partial<NavbarItemProps>>`
   }
 `;
 
-export const StyledNavbar = styled(Flex)<NavbarProps>`
+export const StyledNavbar = styled(Flex).withConfig(
+  defaultStyledConfig
+)<NavbarProps>`
   display: flex;
   flex-direction: column;
   height: 100%;

--- a/src/components/ui/Navbar/Styled.tsx
+++ b/src/components/ui/Navbar/Styled.tsx
@@ -52,9 +52,7 @@ export const StyledNavbarItem = styled.div.withConfig(defaultStyledConfig)<
   }
 `;
 
-export const StyledNavbar = styled(Flex).withConfig(
-  defaultStyledConfig
-)<NavbarProps>`
+export const StyledNavbar = styled(Flex)<NavbarProps>`
   display: flex;
   flex-direction: column;
   height: 100%;

--- a/src/components/ui/Notification/Styled.tsx
+++ b/src/components/ui/Notification/Styled.tsx
@@ -14,12 +14,8 @@ interface StyledNotificationProps extends NotificationProps {
   severity: Severity;
 }
 
-export const StyledCloseIconButton = styled(IconButton).withConfig(
-  defaultStyledConfig
-)``;
-export const StyledNotificationButton = styled(SecondaryButton).withConfig(
-  defaultStyledConfig
-)``;
+export const StyledCloseIconButton = styled(IconButton)``;
+export const StyledNotificationButton = styled(SecondaryButton)``;
 
 export const StyledNotification = styled.div.withConfig(
   defaultStyledConfig

--- a/src/components/ui/Notification/Styled.tsx
+++ b/src/components/ui/Notification/Styled.tsx
@@ -4,6 +4,7 @@
 import styled from 'styled-components';
 
 import { Severity } from '../../../providers/NotificationProvider';
+import { defaultStyledConfig } from '../../../utils/style';
 import { baseSpacing, baseStyles } from '../Base';
 import IconButton from '../Button/IconButton';
 import SecondaryButton from '../Button/SecondaryButton';
@@ -13,10 +14,16 @@ interface StyledNotificationProps extends NotificationProps {
   severity: Severity;
 }
 
-export const StyledCloseIconButton = styled(IconButton)``;
-export const StyledNotificationButton = styled(SecondaryButton)``;
+export const StyledCloseIconButton = styled(IconButton).withConfig(
+  defaultStyledConfig
+)``;
+export const StyledNotificationButton = styled(SecondaryButton).withConfig(
+  defaultStyledConfig
+)``;
 
-export const StyledNotification = styled.div<StyledNotificationProps>`
+export const StyledNotification = styled.div.withConfig(
+  defaultStyledConfig
+)<StyledNotificationProps>`
   align-items: center;
   position: relative;
   display: inline-flex;
@@ -58,7 +65,7 @@ export const StyledNotification = styled.div<StyledNotificationProps>`
     background-color: ${({ theme, severity }) =>
       theme.colors[severity].primary};
     color: ${({ theme, severity }) =>
-      theme.notification[severity].closeButton.text}};
+      theme.notification[severity].closeButton.text};
   }
 
   ${StyledCloseIconButton}:hover, ${StyledCloseIconButton}:focus, ${StyledNotificationButton}:hover, ${StyledNotificationButton}:focus {

--- a/src/components/ui/NotificationGroup/NotificationGroup.stories.tsx
+++ b/src/components/ui/NotificationGroup/NotificationGroup.stories.tsx
@@ -54,6 +54,7 @@ const AddNotificationButtonGroup = () => {
     message:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.',
     autoClose: true,
+    autoCloseDelay: 2000,
   };
   return (
     <StyledWrapper>

--- a/src/components/ui/NotificationGroup/Styled.tsx
+++ b/src/components/ui/NotificationGroup/Styled.tsx
@@ -3,7 +3,11 @@
 
 import styled from 'styled-components';
 
-export const StyledNotificationGroup = styled.div`
+import { defaultStyledConfig } from '../../../utils/style';
+
+export const StyledNotificationGroup = styled.div.withConfig(
+  defaultStyledConfig
+)`
   position: fixed;
   top: 2rem;
   left: 0;

--- a/src/components/ui/PopOver/Styled.tsx
+++ b/src/components/ui/PopOver/Styled.tsx
@@ -87,9 +87,7 @@ export const StyledPopOverItem = styled.li.withConfig(defaultStyledConfig)`
   }
 `;
 
-export const StyledSubMenu = styled(StyledPopOverItem).withConfig(
-  defaultStyledConfig
-)`
+export const StyledSubMenu = styled(StyledPopOverItem)`
   > span {
     width: 100%;
     height: 100%;

--- a/src/components/ui/PopOver/Styled.tsx
+++ b/src/components/ui/PopOver/Styled.tsx
@@ -3,9 +3,9 @@
 
 import styled from 'styled-components';
 
-import { ellipsis } from '../../../utils/style';
+import { defaultStyledConfig, ellipsis } from '../../../utils/style';
 
-export const StyledPopOverMenu = styled.ul`
+export const StyledPopOverMenu = styled.ul.withConfig(defaultStyledConfig)`
   width: fit-content;
   max-width: 22rem;
   background-color: ${(props) => props.theme.popOver.menuBgd};
@@ -21,7 +21,9 @@ export const StyledPopOverMenu = styled.ul`
   overflow: inherit;
 `;
 
-export const StyledPopOverToggle = styled.button`
+export const StyledPopOverToggle = styled.button.withConfig(
+  defaultStyledConfig
+)`
   background-color: transparent;
   padding: 0;
   border: none;
@@ -31,7 +33,7 @@ export const StyledPopOverToggle = styled.button`
   }
 `;
 
-export const StyledPopOverItem = styled.li`
+export const StyledPopOverItem = styled.li.withConfig(defaultStyledConfig)`
   height: 2rem;
   position: relative;
 
@@ -85,7 +87,9 @@ export const StyledPopOverItem = styled.li`
   }
 `;
 
-export const StyledSubMenu = styled(StyledPopOverItem)`
+export const StyledSubMenu = styled(StyledPopOverItem).withConfig(
+  defaultStyledConfig
+)`
   > span {
     width: 100%;
     height: 100%;
@@ -107,7 +111,9 @@ export const StyledSubMenu = styled(StyledPopOverItem)`
   }
 `;
 
-export const StyledPopOverHeader = styled.header`
+export const StyledPopOverHeader = styled.header.withConfig(
+  defaultStyledConfig
+)`
   border-bottom: 0.0625rem solid ${(props) => props.theme.popOver.separator};
   margin-bottom: 0.75rem;
   max-width: 22rem;
@@ -144,7 +150,7 @@ export const StyledPopOverHeader = styled.header`
   }
 `;
 
-export const StyledPopOverSeparator = styled.li`
+export const StyledPopOverSeparator = styled.li.withConfig(defaultStyledConfig)`
   margin: 0;
   border-width: 0.0625rem 0 0 0;
   border-style: solid;

--- a/src/components/ui/Radio/Styled.tsx
+++ b/src/components/ui/Radio/Styled.tsx
@@ -43,9 +43,7 @@ export const StyledRadio = styled.div.withConfig(defaultStyledConfig)<any>`
   }
 `;
 
-export const StyledRadioLabel = styled(StyledRadio).withConfig(
-  defaultStyledConfig
-)<any>`
+export const StyledRadioLabel = styled(StyledRadio)<any>`
   display: inline-block;
   height: 1rem;
   position: relative;
@@ -66,9 +64,7 @@ export const StyledRadioLabel = styled(StyledRadio).withConfig(
   }
 `;
 
-export const StyledRadioIcon = styled(StyledRadio).withConfig(
-  defaultStyledConfig
-)<any>`
+export const StyledRadioIcon = styled(StyledRadio)<any>`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/ui/Radio/Styled.tsx
+++ b/src/components/ui/Radio/Styled.tsx
@@ -3,9 +3,13 @@
 
 import styled from 'styled-components';
 
-import { absoluteCenter, visuallyHidden } from '../../../utils/style';
+import {
+  absoluteCenter,
+  defaultStyledConfig,
+  visuallyHidden,
+} from '../../../utils/style';
 
-export const HiddenRadio = styled.input`
+export const HiddenRadio = styled.input.withConfig(defaultStyledConfig)`
   ${visuallyHidden};
 
   &[aria-invalid='true'] + .ch-radio {
@@ -14,12 +18,12 @@ export const HiddenRadio = styled.input`
   }
 `;
 
-export const StyledRadioWrapper = styled.span`
+export const StyledRadioWrapper = styled.span.withConfig(defaultStyledConfig)`
   > label {
     margin-left: 0.5rem;
   }
 `;
-export const StyledRadio = styled.div<any>`
+export const StyledRadio = styled.div.withConfig(defaultStyledConfig)<any>`
   background-color: ${(props) => props.theme.inputs.bgd};
   border: ${(props) => props.theme.inputs.border};
   border-radius: ${(props) => props.theme.radii.circle};
@@ -39,7 +43,9 @@ export const StyledRadio = styled.div<any>`
   }
 `;
 
-export const StyledRadioLabel = styled(StyledRadio)<any>`
+export const StyledRadioLabel = styled(StyledRadio).withConfig(
+  defaultStyledConfig
+)<any>`
   display: inline-block;
   height: 1rem;
   position: relative;
@@ -60,7 +66,9 @@ export const StyledRadioLabel = styled(StyledRadio)<any>`
   }
 `;
 
-export const StyledRadioIcon = styled(StyledRadio)<any>`
+export const StyledRadioIcon = styled(StyledRadio).withConfig(
+  defaultStyledConfig
+)<any>`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/ui/Roster/Roster.stories.tsx
+++ b/src/components/ui/Roster/Roster.stories.tsx
@@ -191,7 +191,7 @@ export const _RosterHeaderWithNavigationIcon = (args) => {
 _RosterHeaderWithNavigationIcon.argTypes = {
   title: { control: 'text', table: { disable: false } },
   badge: { control: 'number' },
-  ...commonHiddenArgTypes
+  ...commonHiddenArgTypes,
 };
 
 _RosterHeaderWithNavigationIcon.args = {
@@ -233,7 +233,7 @@ export const _RosterHeaderWithCustomElements = (args) => {
 _RosterHeaderWithCustomElements.argTypes = {
   title: { control: 'text', table: { disable: false } },
   badge: { control: 'number' },
-  ...commonHiddenArgTypes
+  ...commonHiddenArgTypes,
 };
 
 _RosterHeaderWithCustomElements.args = {
@@ -272,7 +272,7 @@ _RosterCell.argTypes = {
   sharingContent: { control: 'boolean' },
   poorConnection: { control: 'boolean' },
   micPosition: { control: 'select', options: ['grouped', 'leading'] },
-  ...commonHiddenArgTypes
+  ...commonHiddenArgTypes,
 };
 
 _RosterCell.args = {

--- a/src/components/ui/Roster/RosterCell/Styled.tsx
+++ b/src/components/ui/Roster/RosterCell/Styled.tsx
@@ -3,10 +3,13 @@
 
 import styled from 'styled-components';
 
+import { defaultStyledConfig } from '../../../../utils/style';
 import { baseSpacing, baseStyles } from '../../Base';
 import { RosterCellProps } from '.';
 
-export const StyledCell = styled.div<RosterCellProps>`
+export const StyledCell = styled.div.withConfig(
+  defaultStyledConfig
+)<RosterCellProps>`
   display: flex;
   align-items: center;
   padding: 0.625rem 1rem;
@@ -51,7 +54,7 @@ export const StyledCell = styled.div<RosterCellProps>`
   ${baseStyles}
 `;
 
-export const StyledLateMessage = styled.div`
+export const StyledLateMessage = styled.div.withConfig(defaultStyledConfig)`
   display: flex;
   align-items: center;
   white-space: nowrap;

--- a/src/components/ui/Roster/Styled.tsx
+++ b/src/components/ui/Roster/Styled.tsx
@@ -3,10 +3,10 @@
 
 import styled from 'styled-components';
 
-import { ellipsis } from '../../../utils/style';
+import { defaultStyledConfig, ellipsis } from '../../../utils/style';
 import { baseSpacing, baseStyles } from '../Base';
 
-export const StyledRoster = styled.aside`
+export const StyledRoster = styled.aside.withConfig(defaultStyledConfig)`
   width: 100%;
   height: 100%;
   padding-bottom: 1rem;
@@ -24,7 +24,7 @@ export const StyledRoster = styled.aside`
   ${baseStyles}
 `;
 
-export const StyledTitle = styled.span`
+export const StyledTitle = styled.span.withConfig(defaultStyledConfig)`
   display: inline-block;
   margin: 0 0.625rem 0 0;
   font-weight: 600;
@@ -32,7 +32,7 @@ export const StyledTitle = styled.span`
   color: ${(props) => props.theme.roster.secondaryText};
 `;
 
-export const StyledGroupWrapper = styled.div`
+export const StyledGroupWrapper = styled.div.withConfig(defaultStyledConfig)`
   margin: 0 0.5rem;
 
   & + & {
@@ -43,7 +43,7 @@ export const StyledGroupWrapper = styled.div`
   ${baseStyles}
 `;
 
-export const StyledGroup = styled.div`
+export const StyledGroup = styled.div.withConfig(defaultStyledConfig)`
   background-color: ${(props) => props.theme.roster.fgd};
   border-radius: ${(props) => props.theme.radii.default};
 
@@ -51,7 +51,7 @@ export const StyledGroup = styled.div`
   ${baseStyles}
 `;
 
-export const StyledHeader = styled.div<any>`
+export const StyledHeader = styled.div.withConfig(defaultStyledConfig)<any>`
   position: relative;
   display: flex;
   align-items: center;
@@ -114,7 +114,7 @@ export const StyledHeader = styled.div<any>`
   ${baseStyles}
 `;
 
-export const StyledName = styled.div`
+export const StyledName = styled.div.withConfig(defaultStyledConfig)`
   flex-grow: 1;
   min-width: 0;
   line-height: 1.5;

--- a/src/components/ui/Select/Styled.tsx
+++ b/src/components/ui/Select/Styled.tsx
@@ -3,9 +3,10 @@
 
 import styled from 'styled-components';
 
+import { defaultStyledConfig } from '../../../utils/style';
 import { baseSpacing, baseStyles } from '../Base';
 
-export const StyledWrapper = styled.div`
+export const StyledWrapper = styled.div.withConfig(defaultStyledConfig)`
   position: relative;
 
   .ch-select-icon {
@@ -16,7 +17,7 @@ export const StyledWrapper = styled.div`
   ${baseStyles}
 `;
 
-export const StyledSelectInput = styled.select`
+export const StyledSelectInput = styled.select.withConfig(defaultStyledConfig)`
   background-color: ${(props) => props.theme.inputs.bgd};
   border: ${(props) => props.theme.inputs.border};
   border-radius: ${(props) => props.theme.inputs.borderRadius};

--- a/src/components/ui/Textarea/Styled.tsx
+++ b/src/components/ui/Textarea/Styled.tsx
@@ -3,7 +3,9 @@
 
 import styled from 'styled-components';
 
-export const StyledTextarea = styled.textarea`
+import { defaultStyledConfig } from '../../../utils/style';
+
+export const StyledTextarea = styled.textarea.withConfig(defaultStyledConfig)`
   background-color: ${(props) => props.theme.inputs.bgd};
   border: ${(props) => props.theme.inputs.border};
   border-radius: ${(props) => props.theme.inputs.borderRadius};

--- a/src/components/ui/UserActivityManager/Styled.tsx
+++ b/src/components/ui/UserActivityManager/Styled.tsx
@@ -4,9 +4,12 @@
 import styled from 'styled-components';
 
 import { fadeAnimation } from '../../../utils/animations';
+import { defaultStyledConfig } from '../../../utils/style';
 import { Props } from './';
 
-export const StyledUserActivityManager = styled.div<Props>`
+export const StyledUserActivityManager = styled.div.withConfig(
+  defaultStyledConfig
+)<Props>`
   z-index: ${(props) =>
     props.isActive ? props.theme.zIndex.controlBar : '-10'};
   visibility: ${(props) => (props.isActive ? 'visible' : 'hidden')};

--- a/src/components/ui/VideoGrid/Styled.tsx
+++ b/src/components/ui/VideoGrid/Styled.tsx
@@ -4,6 +4,7 @@
 import styled from 'styled-components';
 
 import { AspectRatio } from '../../../hooks/useElementAspectRatio';
+import { defaultStyledConfig } from '../../../utils/style';
 import { VideoGridProps } from './';
 
 interface StyledGridProps extends VideoGridProps {
@@ -431,7 +432,9 @@ const landscapeStyles = `
   }
 `;
 
-export const StyledGrid = styled.div<StyledGridProps>`
+export const StyledGrid = styled.div.withConfig(
+  defaultStyledConfig
+)<StyledGridProps>`
   position: relative;
   display: grid;
   height: 100%;

--- a/src/components/ui/VideoTile/Styled.tsx
+++ b/src/components/ui/VideoTile/Styled.tsx
@@ -3,11 +3,13 @@
 
 import styled from 'styled-components';
 
-import { ellipsis } from '../../../utils/style';
+import { defaultStyledConfig, ellipsis } from '../../../utils/style';
 import { baseSpacing, baseStyles } from '../Base';
 import { VideoTileProps } from './';
 
-export const StyledVideoTile = styled.div<VideoTileProps>`
+export const StyledVideoTile = styled.div.withConfig(
+  defaultStyledConfig
+)<VideoTileProps>`
   height: 100%;
   width: 100%;
   position: relative;
@@ -21,7 +23,7 @@ export const StyledVideoTile = styled.div<VideoTileProps>`
     bottom: 0;
     width: 100%;
     height: 100%;
-    object-fit: ${(props) => props.objectFit || 'cover'}};
+    object-fit: ${(props) => props.objectFit || 'cover'};
   }
 
   .ch-icon {

--- a/src/components/ui/WithTooltip/Styled.tsx
+++ b/src/components/ui/WithTooltip/Styled.tsx
@@ -3,6 +3,7 @@
 
 import styled, { css } from 'styled-components';
 
+import { defaultStyledConfig } from '../../../utils/style';
 import { ToolTipPositionType } from '.';
 
 // All units are in rem
@@ -79,7 +80,9 @@ const RightProps = css<StyledTooltipProps>`
   }
 `;
 
-export const StyledTooltip = styled.span<StyledTooltipProps>`
+export const StyledTooltip = styled.span.withConfig(
+  defaultStyledConfig
+)<StyledTooltipProps>`
   @keyframes fadeIn {
     0% {
       opacity: 0;

--- a/src/components/ui/WithTooltip/WithTooltip.mdx
+++ b/src/components/ui/WithTooltip/WithTooltip.mdx
@@ -1,4 +1,5 @@
 import { WithTooltip } from '.'
+import { Meta } from '@storybook/blocks';
 
 <Meta title="UI Components/WithTooltip" />
 

--- a/src/components/ui/icons/All/All.stories.tsx
+++ b/src/components/ui/icons/All/All.stories.tsx
@@ -130,9 +130,9 @@ const IconWrapper = styled.div`
   border-radius: 2px;
 `;
 
-const getIconAndName = (Icon, args) => {
+const getIconAndName = (Icon, args, index) => {
   return (
-    <IconWrapper>
+    <IconWrapper key={index}>
       <Icon {...args} />
       <p>{Icon.displayName}</p>
     </IconWrapper>
@@ -142,7 +142,7 @@ const getIconAndName = (Icon, args) => {
 export const _All = (args) => {
   return (
     <Flex container flexDirection="row" alignItems="center" flexWrap="wrap">
-      {icons.map((icon) => getIconAndName(icon, args))}
+      {icons.map((icon, index) => getIconAndName(icon, args, index))}
     </Flex>
   );
 };

--- a/src/components/ui/icons/Arrow/index.tsx
+++ b/src/components/ui/icons/Arrow/index.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { Direction } from '../../../../types';
+import { defaultStyledConfig } from '../../../../utils/style';
 import Svg, { SvgProps } from '../Svg';
 
 const dirTransform = {
@@ -19,7 +20,7 @@ interface ArrowProps extends SvgProps {
   direction?: Direction;
 }
 
-const StyledArrow = styled(Svg)<ArrowProps>`
+const StyledArrow = styled(Svg).withConfig(defaultStyledConfig)<ArrowProps>`
   transform: ${({ direction }) =>
     `rotate(${dirTransform[direction || 'up']}deg)`};
 `;

--- a/src/components/ui/icons/Caret/index.tsx
+++ b/src/components/ui/icons/Caret/index.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { Direction } from '../../../../types';
+import { defaultStyledConfig } from '../../../../utils/style';
 import Svg, { SvgProps } from '../Svg';
 
 const dirTransform = {
@@ -20,7 +21,7 @@ interface CaretProps extends SvgProps {
   className?: string;
 }
 
-const StyledCaret = styled(Svg)<CaretProps>`
+const StyledCaret = styled(Svg).withConfig(defaultStyledConfig)<CaretProps>`
   transform: ${({ direction }) =>
     `rotate(${dirTransform[direction || 'up']}deg)`};
 `;

--- a/src/components/ui/icons/Caution/styled.tsx
+++ b/src/components/ui/icons/Caution/styled.tsx
@@ -3,6 +3,7 @@
 
 import styled, { css } from 'styled-components';
 
+import { defaultStyledConfig } from '../../../../utils/style';
 import { CautionProps } from './';
 
 const defaultStyle = css`
@@ -45,6 +46,8 @@ const variantMap = {
   'fill-error': errorStyle,
 };
 
-export const StyledCaution = styled.g<CautionProps>`
+export const StyledCaution = styled.g.withConfig(
+  defaultStyledConfig
+)<CautionProps>`
   ${(props) => variantMap[props.variant || 'default']};
 `;

--- a/src/components/ui/icons/HandRaise/Styled.tsx
+++ b/src/components/ui/icons/HandRaise/Styled.tsx
@@ -3,6 +3,8 @@
 
 import styled from 'styled-components';
 
-export const StyledCircle = styled.circle`
+import { defaultStyledConfig } from '../../../../utils/style';
+
+export const StyledCircle = styled.circle.withConfig(defaultStyledConfig)`
   fill: ${(props) => props.theme.colors.primary.main};
 `;

--- a/src/components/ui/icons/Microphone/Microphone.stories.tsx
+++ b/src/components/ui/icons/Microphone/Microphone.stories.tsx
@@ -15,12 +15,16 @@ _Microphone.argTypes = {
   width: { control: 'text' },
   poorConnection: { control: 'boolean' },
   muted: { control: 'boolean' },
+  mutedTitle: { control: 'text' },
+  unmutedTitle: { control: 'text' },
 };
 
 _Microphone.args = {
   width: '2rem',
   poorConnection: false,
   muted: false,
+  mutedTitle: 'Muted microphone',
+  unmutedTitle: 'Microphone',
 };
 
 _Microphone.story = {

--- a/src/components/ui/icons/Microphone/Styled.tsx
+++ b/src/components/ui/icons/Microphone/Styled.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
+import { defaultStyledConfig } from '../../../../utils/style';
 import Svg from '../Svg';
 import { MicrophoneProps } from './';
 
@@ -13,7 +14,9 @@ const SvgWithoutMicrophoneProps = ({
   ...rest
 }: MicrophoneProps) => <Svg {...rest} />;
 
-export const StyledSvg = styled(SvgWithoutMicrophoneProps)<MicrophoneProps>`
+export const StyledSvg = styled(SvgWithoutMicrophoneProps).withConfig(
+  defaultStyledConfig
+)<MicrophoneProps>`
   ${(props) =>
     props.poorConnection ? `color: ${props.theme.colors.error.light}` : ''}
 `;

--- a/src/utils/style.ts
+++ b/src/utils/style.ts
@@ -26,12 +26,12 @@ export const absoluteCenter = css`
   transform: translate(-50%, -50%);
 `;
 
-export const isValidCSSHex = (hex: string) => {
+export const isValidCSSHex = (hex: string): boolean => {
   // matches 6 digit characters prefixed with a '#'.
   return /^#[0-9A-F]{6}$/i.test(hex);
 };
 
-export const hexTorgba = (hex: string, alpha: number = 1) => {
+export const hexTorgba = (hex: string, alpha: number = 1): string => {
   if (!isValidCSSHex(hex)) {
     return '';
   }
@@ -52,12 +52,13 @@ export const hexTorgba = (hex: string, alpha: number = 1) => {
  */
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const createStyledConfig = (additionalProps: string[] = []) => ({
-  shouldForwardProp: (prop: string) =>
-    // Native HTML props is forwarded
-    isPropValid(prop) ||
-    // Allow additional non-HTML/custom props to be forwarded
-    additionalProps.includes(prop),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  shouldForwardProp: (prop: string) => {
+    // Forward custom props
+    if (additionalProps.includes(prop)) return true;
+
+    return isPropValid(prop);
+  },
 });
 
-// Default styled config with no additional props
 export const defaultStyledConfig = createStyledConfig();

--- a/src/utils/style.ts
+++ b/src/utils/style.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import isPropValid from '@emotion/is-prop-valid';
 import { css } from 'styled-components';
 
 // use for elements that contain text for screen readers, but need no visual representation
@@ -38,3 +39,25 @@ export const hexTorgba = (hex: string, alpha: number = 1) => {
   const [r, g, b]: any = hex.match(/\w\w/g)?.map((h) => parseInt(h, 16));
   return `rgba(${r}, ${g}, ${b}, ${alpha || 1})`;
 };
+
+// There's a breaking change in styled-components v6 - shouldForwardProp is no longer provided by default
+// https://styled-components.com/docs/faqs#shouldforwardprop-is-no-longer-provided-by-default
+// This maintains backwards compatibility with v5 by filtering props using @emotion/is-prop-valid
+// https://styled-components.com/docs/faqs#shouldforwardprop-is-no-longer-provided-by-default
+
+/**
+ * Creates a configuration object for styled-components to control prop forwarding
+ * @param additionalProps - Array of custom prop names that should be forwarded
+ * @returns Configuration object with shouldForwardProp function
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const createStyledConfig = (additionalProps: string[] = []) => ({
+  shouldForwardProp: (prop: string) =>
+    // Native HTML props is forwarded
+    isPropValid(prop) ||
+    // Allow additional non-HTML/custom props to be forwarded
+    additionalProps.includes(prop),
+});
+
+// Default styled config with no additional props
+export const defaultStyledConfig = createStyledConfig();


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
- Migrate styled-components from v5 to v6 in SDK
- Add support for styled-components v6 in peerDependencies


**Testing**
1. Have you successfully run `npm run build:release` locally?
  Yes

2. How did you test these changes?

1. `npm run build:release` passes.

2. I verified the following scenarios when installing styled-components v5 and v6 in the local React Component SDK:
  - Confirmed that the local Storybook appearance matches the production version, with no styled-components-related errors
  - Successfully tested the local meeting demo's end-to-end flow and UI after installing the React Component SDK tarball

When installing v6 in demo, both demo and SDK uses v6
```
❯ npm list styled-components
chime-sdk-meeting-demo@0.1.0 /Users/sichax/Projects/amazon-chime-sdk/apps/meeting
├─┬ amazon-chime-sdk-component-library-react@3.10.0
│ └── styled-components@6.1.15 deduped
└── styled-components@6.1.15
```

When installing v5 in demo, both demo and SDK uses v5
```
❯ npm list styled-components     
chime-sdk-meeting-demo@0.1.0 /Users/sichax/Projects/amazon-chime-sdk/apps/meeting
├─┬ amazon-chime-sdk-component-library-react@3.10.0
│ └── styled-components@5.3.11 deduped
└─┬ styled-components@5.3.11
  └─┬ babel-plugin-styled-components@2.1.4
    └── styled-components@5.3.11 deduped
```

4. If you made changes to the component library, have you provided corresponding documentation changes?
  Yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
