### PR TITLE
Update release script to install react 18

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -97,7 +97,7 @@ const checkNPMDepsInstall = () => {
   }
   process.chdir(path.join(__dirname, '../../dependency-check-app'));
   spawnOrFail('npm', ['init -y']);
-  spawnOrFail('npm', ['install react react-dom']);
+  spawnOrFail('npm', ['install react@18 react-dom@18']);
 
   // As of June 5, 2023, running `npm install styled-components` fails due to this issue.
   // https://github.com/styled-components/styled-components/issues/3998


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
- React 19 has been released. The release script is installing latest react version. Now fix it to react 18, because react 19 is not supported yet.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Tested release script.

3. If you made changes to the component library, have you provided corresponding documentation changes?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
