### PR TITLE
Add support for multiple content shares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for multiple content shares in meetings through the `ContentShareProvider`. The provider now accepts a `maxContentShares` prop (default: 1, range 1-2) to specify the maximum number of concurrent content shares allowed.
+  - Added new collections in `ContentShareState` to track multiple content shares: `tiles`, `tileIdToAttendeeId`, and `attendeeIdToTileId`.
+  - Added optional `tileId` prop to the `ContentShare` component to specify which content share to render.
+  - Added `canStartContentShare` state to control when content sharing is allowed based on the current number of shares and configured maximum.
+  - Maintained backward compatibility by keeping `tileId` and `sharingAttendeeId` properties, which now point to the most recently started content share when multiple shares are present.
+
 ### Removed
 
 ### Changed

--- a/src/components/sdk/ContentShare/ContentShare.mdx
+++ b/src/components/sdk/ContentShare/ContentShare.mdx
@@ -5,11 +5,15 @@ import { ContentShare } from './';
 
 # ContentShare
 
-The `ContentShare` component renders a `ContentTile` for the active content share video, remote or local.
+The `ContentShare` component renders a `ContentTile` for a content share video, remote or local.
 
 If used within the `VideoGrid` component, it will automatically place the active tile in the featured grid slot. It takes precedence over the featured video tile.
 
 Once a meeting session has been started, a user can start and stop content sharing by using the `useContentShareControls` hook.
+
+## Multiple Content Shares
+
+With the support for multiple content shares, you can now specify which content share tile to render by providing the `tileId` prop. If no `tileId` is provided, the component will render the default content share tile from (`const { tileId } = useContentShareState()`).
 
 ## Importing
 
@@ -19,12 +23,14 @@ import { ContentShare } from 'amazon-chime-sdk-component-library-react';
 
 ## Usage
 
+### With Single Content Share
+
 ```jsx
 import React from 'react';
 import {
   MeetingProvider,
   ContentShare,
-  useContentShareControls
+  useContentShareControls,
 } from 'amazon-chime-sdk-component-library-react';
 
 const App = () => {
@@ -32,9 +38,66 @@ const App = () => {
 
   return (
     <MeetingProvider>
-      <ContentShare nameplate='Content share' />
+      <ContentShare nameplate="Content share" />
       <button onClick={toggleContentShare}>Toggle content share</button>
     </MeetingProvider>
+  );
+};
+```
+
+### With Multiple Content Shares
+
+```jsx
+import React from 'react';
+import {
+  MeetingProvider,
+  ContentShare,
+  ContentShareProvider,
+  useContentShareState,
+  useContentShareControls,
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => {
+  return (
+    <MeetingProvider>
+      <ContentShareProvider maxContentShares={2}>
+        <ContentShareView />
+        <ContentShareControls />
+      </ContentShareProvider>
+    </MeetingProvider>
+  );
+};
+
+const ContentShareView = () => {
+  const { tiles, tileIdToAttendeeId } = useContentShareState();
+
+  return (
+    <div>
+      {tiles.length === 0 ? (
+        <p>No content is being shared</p>
+      ) : (
+        <div className="content-share-container">
+          {tiles.map((tileId) => (
+            <ContentShare
+              key={tileId}
+              tileId={tileId}
+              nameplate={`Shared by: ${tileIdToAttendeeId[tileId.toString()]}`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const ContentShareControls = () => {
+  const { toggleContentShare } = useContentShareControls();
+  const { canStartContentShare } = useContentShareState();
+
+  return (
+    <button onClick={toggleContentShare} disabled={!canStartContentShare}>
+      Share content
+    </button>
   );
 };
 ```

--- a/src/components/sdk/FeaturedRemoteVideos/index.tsx
+++ b/src/components/sdk/FeaturedRemoteVideos/index.tsx
@@ -21,19 +21,20 @@ export const FeaturedRemoteVideos: FC<React.PropsWithChildren<Props>> = (
   const gridData = useGridData();
   const { roster } = useRosterState();
   const { tileId: featuredTileId } = useFeaturedTileState();
-  const { tileId: contentTileId } = useContentShareState();
+  const { tiles: contentTiles } = useContentShareState();
   const { tiles, tileIdToAttendeeId } = useRemoteVideoTileState();
 
   return (
     <>
       {tiles.map((tileId) => {
-        const featured = !contentTileId && featuredTileId === tileId;
+        const hasContentShare = contentTiles.length > 0;
+        const featured = !hasContentShare && featuredTileId === tileId;
         const styles = gridData && featured ? 'grid-area: ft;' : '';
         const classes = `${featured ? 'ch-featured-tile' : ''} ${
           props.className || ''
         }`;
         const attendee = roster[tileIdToAttendeeId[tileId]] || {};
-        const { name }: any = attendee;
+        const { name = undefined }: { name?: string } = attendee;
 
         return (
           <RemoteVideo

--- a/src/components/sdk/VideoTileGrid/VideoTileGrid.mdx
+++ b/src/components/sdk/VideoTileGrid/VideoTileGrid.mdx
@@ -5,7 +5,7 @@ import { VideoTileGrid } from './';
 
 # VideoTileGrid
 
-The `VideoTileGrid` component renders all meeting session video tiles in a responsive grid layout. This includes the local tile, remote tiles, and content share tile. By default a user joins without video, so in order to see the VideoTileGrid there must be at least one video tile being shared. To start sharing a video, see the [LocalVideo](?path=/docs/sdk-components-localvideo--page) component. 
+The `VideoTileGrid` component renders all meeting session video tiles in a responsive grid layout. This includes the local tile, remote tiles, and content share tile. By default a user joins without video, so in order to see the VideoTileGrid there must be at least one video tile being shared. To start sharing a video, see the [LocalVideo](?path=/docs/sdk-components-localvideo--page) component.
 
 ## Importing
 
@@ -19,7 +19,7 @@ import { VideoTileGrid } from 'amazon-chime-sdk-component-library-react';
 import React from 'react';
 import {
   MeetingProvider,
-  VideoTileGrid
+  VideoTileGrid,
 } from 'amazon-chime-sdk-component-library-react';
 
 const App = () => (
@@ -27,6 +27,44 @@ const App = () => (
     <VideoTileGrid />
   </MeetingProvider>
 );
+```
+
+## Content Share Behavior
+
+The `VideoTileGrid` component does not support displaying multiple content shares simultaneously:
+
+- It can display only one content share tile at a time in the featured area
+- When multiple content shares are active, only the most recently started content share is displayed, and earlier shares are ignored
+- The grid size calculation always allocates exactly one tile space for content sharing (when content is present), regardless of how many content share tiles actually exist
+
+This means that even if there are multiple content share tiles available through `useContentShareState()`, the VideoTileGrid will only render one of them.
+
+### Custom Handling of Multiple Content Shares
+
+If you need to support multiple simultaneous content shares, you'll need to implement a custom grid using `useContentShareState` hook and `ContentShare` sdk component.
+
+```jsx
+import React from 'react';
+import {
+  useContentShareState,
+  ContentShare,
+} from 'amazon-chime-sdk-component-library-react';
+
+const CustomMultiContentShareGrid = () => {
+  // Access all content share tiles
+  const { tiles: contentTiles } = useContentShareState();
+
+  return (
+    <div className="custom-grid">
+      {/* Render each content share tile */}
+      {contentTiles.map((tileId) => (
+        <ContentShare key={tileId} tileId={tileId} />
+      ))}
+
+      {/* Other video tiles */}
+    </div>
+  );
+};
 ```
 
 ## Props

--- a/src/components/sdk/VideoTileGrid/index.tsx
+++ b/src/components/sdk/VideoTileGrid/index.tsx
@@ -46,14 +46,20 @@ export const VideoTileGrid: React.FC<React.PropsWithChildren<Props>> = ({
   ...rest
 }) => {
   const { tileId: featureTileId } = useFeaturedTileState();
-  const { tiles } = useRemoteVideoTileState();
-  const { tileId: contentTileId } = useContentShareState();
+  const { tiles: remoteVideoTiles } = useRemoteVideoTileState();
+  const { tiles: contentShareTiles } = useContentShareState();
   const { isVideoEnabled } = useLocalVideo();
-  const featured =
-    (layout === 'featured' && !!featureTileId) || !!contentTileId;
-  const remoteSize = tiles.length + (contentTileId ? 1 : 0);
+
+  const hasContentShare = contentShareTiles.length > 0;
+  // contentShareSize is counted as 1 in the grid size calculation, since only the most
+  // recent content share tile is displayed in the featured area when multiple content shares exist
+  const contentShareSize = hasContentShare ? 1 : 0;
+  const remoteSize = remoteVideoTiles.length + contentShareSize;
   const gridSize =
     remoteSize > 1 && isVideoEnabled ? remoteSize + 1 : remoteSize;
+
+  const featured =
+    (layout === 'featured' && !!featureTileId) || hasContentShare;
 
   return (
     <VideoGrid {...rest} size={gridSize} layout={featured ? 'featured' : null}>

--- a/src/providers/ContentShareProvider/docs/ContentShareProvider.mdx
+++ b/src/providers/ContentShareProvider/docs/ContentShareProvider.mdx
@@ -6,12 +6,26 @@ import { Meta } from '@storybook/blocks';
 
 The `ContentShareProvider` provides state and functionality for content sharing.
 
+### Props
+
+```javascript
+{
+  // Maximum number of concurrent content shares allowed (default: 1, range: 1-2)
+  maxContentShares?: number;
+}
+```
+
 ### State
 
 ```javascript
 {
-  // The tile ID of the active content share
+  // The tile ID of the active content share (deprecated, maintained for backward compatibility)
+  // When multiple content shares are present, this points to the most recently started content share
   tileId: number | null;
+
+  // The chime attendee ID of the user sharing (deprecated, maintained for backward compatibility)
+  // When multiple content shares are present, this points to the attendee of the most recently started content share
+  sharingAttendeeId: string | null;
 
   // Whether the content share is paused
   paused: boolean;
@@ -22,8 +36,17 @@ The `ContentShareProvider` provides state and functionality for content sharing.
   // Whether or not the local user's content share is loading
   isLocalShareLoading: boolean;
 
-  // The chime attendee ID of the user sharing
-  sharingAttendeeId: string | null;
+  // Whether the user can start a content share based on current limits and `isLocalUserSharing`
+  canStartContentShare: boolean;
+
+  // Array of all content share tile IDs
+  tiles: number[];
+
+  // Map of tile IDs to attendee IDs
+  tileIdToAttendeeId: { [key: string]: string };
+
+  // Map of attendee IDs to tile IDs
+  attendeeIdToTileId: { [key: string]: number };
 }
 ```
 
@@ -50,6 +73,49 @@ const MyChild = () => {
   const { isLocalUserSharing } = useContentShareState();
 
   return isLocalUserSharing ? <div>Sharing</div> : <div>Not sharing</div>;
+};
+```
+
+## Multiple Content Shares
+
+You can configure the maximum number of concurrent content shares allowed (up to 2):
+
+```jsx
+import React from 'react';
+import {
+  MeetingProvider,
+  ContentShareProvider,
+  useContentShareState,
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <MeetingProvider>
+    {/* Override the default maxContentShares value (1) in ContentShareProvider */}
+    <ContentShareProvider maxContentShares={2}>
+      <MyComponent />
+    </ContentShareProvider>
+  </MeetingProvider>
+);
+
+const MyComponent = () => {
+  const { tiles, tileIdToAttendeeId, canStartContentShare } =
+    useContentShareState();
+
+  return (
+    <div>
+      <p>Content shares available: {tiles.length}</p>
+      <p>Can start content share: {canStartContentShare ? 'Yes' : 'No'}</p>
+      <div>
+        {tiles.map((tileId) => (
+          <ContentShare
+            key={tileId}
+            tileId={tileId}
+            nameplate={`Shared by: ${tileIdToAttendeeId[tileId.toString()]}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
 };
 ```
 

--- a/src/providers/ContentShareProvider/docs/useContentShareControls.mdx
+++ b/src/providers/ContentShareProvider/docs/useContentShareControls.mdx
@@ -13,6 +13,18 @@ The `useContentShareControls` hook returns the state and functionality around st
   // Whether or not the local content share is paused
   paused: boolean;
 
+  // Whether or not the local user is currently sharing content
+  isLocalUserSharing: boolean;
+
+  // Whether or not the local user's content share is loading
+  isLocalShareLoading: boolean;
+
+  // Determines if the user can start a new content share
+  // Returns false in two cases:
+  // 1. When the ContentShareProvider has reached its `maxContentShares` limit
+  // 2. When the local user is already sharing content
+  canStartContentShare: boolean;
+
   // A function to toggle content share.
   // If the user is sharing, it will stop the content share.
   // If a user is not sharing, it will start the content share workflow.
@@ -36,23 +48,66 @@ import { useContentShareControls } from 'amazon-chime-sdk-component-library-reac
 
 The hook depends on the `ContentShareProvider`. If you are using `MeetingProvider`, it is rendered by default.
 
+### Basic Usage
+
 ```jsx
 import React from 'react';
 import {
   MeetingProvider,
+  ContentShareProvider,
   useContentShareControls,
 } from 'amazon-chime-sdk-component-library-react';
 
 const App = () => (
   <MeetingProvider>
-    <MyChild />
+    <ContentShareProvider maxContentShares={2}>
+      <ContentShareButton />
+    </ContentShareProvider>
   </MeetingProvider>
 );
 
-const MyChild = () => {
-  const { toggleContentShare } = useContentShareControls();
+const ContentShareButton = () => {
+  const {
+    toggleContentShare,
+    togglePauseContentShare,
+    paused,
+    isLocalUserSharing,
+    isLocalShareLoading,
+    canStartContentShare,
+  } = useContentShareControls();
 
-  return <button onClick={toggleContentShare}>Toggle content share</button>;
+  return (
+    <div>
+      {/* Content share toggle button */}
+      <button
+        onClick={toggleContentShare}
+        disabled={isLocalShareLoading || !canStartContentShare}
+      >
+        {isLocalShareLoading
+          ? 'Loading...'
+          : isLocalUserSharing
+          ? 'Stop sharing'
+          : 'Start sharing'}
+      </button>
+
+      {/* Pause/resume button only shown when sharing */}
+      {isLocalUserSharing && (
+        <button onClick={togglePauseContentShare}>
+          {paused ? 'Resume content share' : 'Pause content share'}
+        </button>
+      )}
+
+      {/* Status indicator */}
+      <div className="status">
+        {isLocalUserSharing && (
+          <span>
+            Status: {paused ? 'Paused' : 'Active'}
+            {isLocalShareLoading && ' (Loading...)'}
+          </span>
+        )}
+      </div>
+    </div>
+  );
 };
 ```
 

--- a/src/providers/ContentShareProvider/docs/useContentShareState.mdx
+++ b/src/providers/ContentShareProvider/docs/useContentShareState.mdx
@@ -10,8 +10,13 @@ The `useContentShareState` hook returns the state related to content share statu
 
 ```javascript
 {
-  // The tile ID of the active content share
+  // The tile ID of the active content share (deprecated, maintained for backward compatibility)
+  // When multiple content shares are present, this points to the most recently started content share
   tileId: number | null;
+
+  // The chime attendee ID of the sharing user (deprecated, maintained for backward compatibility)
+  // When multiple content shares are present, this points to the attendee of the most recently started content share
+  sharingAttendeeId: string | null;
 
   // Whether the content share is paused
   paused: boolean;
@@ -22,8 +27,20 @@ The `useContentShareState` hook returns the state related to content share statu
   // Whether or not the local user's content share is loading
   isLocalShareLoading: boolean;
 
-  // The chime attendee ID of the sharing user
-  sharingAttendeeId: string | null;
+  // Determines if the user can start a new content share
+  // Returns false in two cases:
+  // 1. When the ContentShareProvider has reached its `maxContentShares` limit
+  // 2. When the local user is already sharing content
+  canStartContentShare: boolean;
+
+  // Array of all content share tile IDs
+  tiles: number[];
+
+  // Map of tile IDs to attendee IDs
+  tileIdToAttendeeId: { [key: string]: string };
+
+  // Map of attendee IDs to tile IDs
+  attendeeIdToTileId: { [key: string]: number };
 }
 ```
 
@@ -36,6 +53,8 @@ import { useContentShareState } from 'amazon-chime-sdk-component-library-react';
 ## Usage
 
 The hook depends on the `ContentShareProvider`. If you are using `MeetingProvider`, it is rendered by default.
+
+### Basic Usage
 
 ```jsx
 import React from 'react';
@@ -54,6 +73,169 @@ const MyChild = () => {
   const { isLocalUserSharing } = useContentShareState();
 
   return isLocalUserSharing ? <div>Sharing</div> : <div>Not sharing</div>;
+};
+```
+
+### Single Content Share with All Properties
+
+```jsx
+import React from 'react';
+import {
+  MeetingProvider,
+  useContentShareState,
+  ContentShare,
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <MeetingProvider>
+    <ContentShareView />
+  </MeetingProvider>
+);
+
+const ContentShareView = () => {
+  const {
+    // Deprecated properties (maintained for backward compatibility)
+    tileId,
+    sharingAttendeeId,
+
+    // Content share state
+    paused,
+    isLocalUserSharing,
+    isLocalShareLoading,
+    canStartContentShare,
+
+    // Collections for multiple content shares
+    tiles,
+    tileIdToAttendeeId,
+    attendeeIdToTileId,
+  } = useContentShareState();
+
+  // No content is being shared
+  if (tiles.length === 0) {
+    return (
+      <div className="content-share-container">
+        <p>No content is being shared</p>
+        <p>Can start content share: {canStartContentShare ? 'Yes' : 'No'}</p>
+      </div>
+    );
+  }
+
+  // Get the content share tile ID
+  const contentShareTileId = tiles[0]; // Note: Previously known as `tileId` (deprecated)
+
+  // Attendee Id for content sharer
+  const attendeeId = attendeeIdToTileId[contentShareTileId.toString()]; // Note: Previously known as `sharingAttendeeId` (deprecated)
+
+  return (
+    <div className="content-share-container">
+      <div className="content-share-status">
+        <h3>Content Share Status</h3>
+        <ul>
+          <li>Active content shares: {tiles.length}</li>
+          <li>Current content share ID: {contentShareTileId}</li>
+          <li>Shared by: {attendeeId}</li>
+          <li>Paused: {paused ? 'Yes' : 'No'}</li>
+          <li>Local user is sharing: {isLocalUserSharing ? 'Yes' : 'No'}</li>
+          <li>Loading: {isLocalShareLoading ? 'Yes' : 'No'}</li>
+        </ul>
+      </div>
+
+      <div className="content-share-view">
+        <ContentShare nameplate={`Shared by: ${attendeeId}`} />
+      </div>
+    </div>
+  );
+};
+```
+
+### With Multiple Content Shares
+
+```jsx
+import React from 'react';
+import {
+  MeetingProvider,
+  ContentShareProvider,
+  useContentShareState,
+  ContentShare,
+} from 'amazon-chime-sdk-component-library-react';
+
+const App = () => (
+  <MeetingProvider>
+    <ContentShareProvider maxContentShares={2}>
+      <ContentShareList />
+    </ContentShareProvider>
+  </MeetingProvider>
+);
+
+const ContentShareList = () => {
+  const {
+    // Content share state
+    paused,
+    isLocalUserSharing,
+    isLocalShareLoading,
+    canStartContentShare,
+
+    // Collections for multiple content shares
+    tiles,
+    tileIdToAttendeeId,
+    attendeeIdToTileId,
+  } = useContentShareState();
+
+  return (
+    <div>
+      <h2>Content Shares ({tiles.length})</h2>
+
+      {/* Status information */}
+      <div className="content-share-status">
+        <p>
+          {canStartContentShare
+            ? 'You can start a content share (limit not reached)'
+            : "Maximum number of content shares reached or you're already sharing"}
+        </p>
+
+        {isLocalUserSharing && (
+          <div className="local-share-status">
+            <p>You are currently sharing content</p>
+            <p>Status: {paused ? 'Paused' : 'Active'}</p>
+            {isLocalShareLoading && <p>Loading your content share...</p>}
+          </div>
+        )}
+      </div>
+
+      {/* Content share tiles */}
+      <div className="content-shares">
+        {tiles.length === 0 ? (
+          <p>No content is being shared</p>
+        ) : (
+          tiles.map((tileId) => {
+            const attendeeId = tileIdToAttendeeId[tileId.toString()];
+
+            return (
+              <ContentShare
+                key={tileId}
+                tileId={tileId}
+                nameplate={`Shared by: ${attendeeId}`}
+              />
+            );
+          })
+        )}
+      </div>
+
+      {/* Mapping between attendees and tiles */}
+      {tiles.length > 0 && (
+        <div className="content-share-mapping">
+          <h3>Content Share Mappings:</h3>
+          <ul>
+            {Object.entries(attendeeIdToTileId).map(([attendeeId, tileId]) => (
+              <li key={attendeeId}>
+                Attendee {attendeeId} → Tile {tileId}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
 };
 ```
 

--- a/src/providers/MeetingProvider/index.tsx
+++ b/src/providers/MeetingProvider/index.tsx
@@ -26,6 +26,7 @@ interface Props {
    * Check `meetingManager` prop documentation for more information.
    */
   meetingManager?: MeetingManager;
+  maxContentShares?: number;
 }
 
 export const MeetingContext = createContext<MeetingManager | null>(null);
@@ -33,6 +34,7 @@ export const MeetingContext = createContext<MeetingManager | null>(null);
 export const MeetingProvider: React.FC<React.PropsWithChildren<Props>> = ({
   onDeviceReplacement,
   meetingManager: meetingManagerProp,
+  maxContentShares,
   children,
 }) => {
   const logger = useLogger();
@@ -49,7 +51,7 @@ export const MeetingProvider: React.FC<React.PropsWithChildren<Props>> = ({
               <RemoteVideoTileProvider>
                 <LocalVideoProvider>
                   <LocalAudioOutputProvider>
-                    <ContentShareProvider>
+                    <ContentShareProvider maxContentShares={maxContentShares}>
                       <FeaturedVideoTileProvider>
                         {children}
                       </FeaturedVideoTileProvider>

--- a/src/providers/RemoteVideoTileProvider/state.tsx
+++ b/src/providers/RemoteVideoTileProvider/state.tsx
@@ -1,18 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-type tileMap = {
-  [key: string]: string;
-};
-
-type attendeeMap = {
-  [key: string]: number;
-};
+import { AttendeeMap, TileMap } from '../../types';
 
 export type State = {
   tiles: number[];
-  tileIdToAttendeeId: tileMap;
-  attendeeIdToTileId: attendeeMap;
+  tileIdToAttendeeId: TileMap;
+  attendeeIdToTileId: AttendeeMap;
   size: number;
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,8 +41,19 @@ export type LocalVideoContextType = {
 
 export type ContentShareControlContextType = {
   paused: boolean;
+  isLocalUserSharing: boolean;
+  isLocalShareLoading: boolean;
   toggleContentShare: (source?: string | MediaStream) => Promise<void>;
   togglePauseContentShare: () => void;
+  canStartContentShare: boolean;
+};
+
+export type TileMap = {
+  [key: string]: string;
+};
+
+export type AttendeeMap = {
+  [key: string]: number;
 };
 
 export enum MeetingStatus {


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**

- Added support for multiple content shares in meetings through the `ContentShareProvider`. The provider now accepts a `maxContentShares` prop (default: 1, range 1-2) to specify the maximum number of concurrent content shares allowed.
  - Added new collections in `ContentShareState` to track multiple content shares: `tiles`, `tileIdToAttendeeId`, and `attendeeIdToTileId`.
  - Added optional `tileId` prop to the `ContentShare` component to specify which content share to render.
  - Added `canStartContentShare` state to control when content sharing is allowed based on the current number of shares and configured maximum.
  - Maintained backward compatibility by keeping `tileId` and `sharingAttendeeId` properties, which now point to the most recently started content share when multiple shares are present.


**Testing**
1. Have you successfully run `npm run build:release` locally?

Yes

2. How did you test these changes?

Update meeting demo to enable multiple content shares and verify the hook values, ContentTile components are working as expected.

3. If you made changes to the component library, have you provided corresponding documentation changes?

Yes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
