### PR TITLE
Update storybook loader for ESM module on Node 24

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -14,13 +14,13 @@ const config: StorybookConfig = {
   webpackFinal: async (config) => {
     config.module = config.module || {};
     config.module.rules = config.module.rules || [];
-    
+
     // Ensure TypeScript files are handled correctly
     config.module.rules.push({
       test: /\.tsx?$/,
       use: [
         {
-          loader: require.resolve('ts-loader'),
+          loader: 'ts-loader',
           options: {
             transpileOnly: true,
           },
@@ -28,7 +28,7 @@ const config: StorybookConfig = {
       ],
       exclude: /node_modules/,
     });
-    
+
     return config;
   },
   stories: ['../src/**/*.@(stories.tsx|mdx)'],


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Storybook loader failed on node 24 due to usage of `require`. Updated to remove.

**Testing**
1. Have you successfully run `npm run build:release` locally?

2. How did you test these changes?
Tested on both node 22 and 24. 

3. If you made changes to the component library, have you provided corresponding documentation changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
